### PR TITLE
Add missing ethereum clients and wrapper role

### DIFF
--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -30,9 +30,16 @@ jobs:
       - name: Run setup
         run: ./setup.sh
 
-      - name: Lint
+      - name: Lint roles
         run: >
-          ansible-lint
+          ansible-lint roles/
+          --nocolor
+          --exclude .github
+          --profile production
+
+      - name: Lint playbooks
+        run: >
+          ansible-lint playbooks/
           --nocolor
           --exclude .github
           --profile production

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 ansible 6.7.0
-ansible-lint 6.10.0
+ansible-lint 6.10.2
 shellcheck 0.9.0

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A collection of reusable ansible components used by the EthPandaOps team.
 - [ethereum_auth_jwt](roles/ethereum_auth_jwt)
 - [dshackle](roles/dshackle)
 
+### Ethereum client pair
+- [ethereum_node](roles/ethereum_node)
 ### Ethereum execution clients
 - [geth](roles/geth)
 - [nethermind](roles/nethermind)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A collection of reusable ansible components used by the EthPandaOps team.
 - [geth](roles/geth)
 - [erigon](roles/erigon)
 - [nethermind](roles/nethermind)
+- [ethereumjs](roles/ethereumjs)
 ### Ethereum consensus clients
 - [teku](roles/teku)
 - [nimbus](roles/nimbus)

--- a/README.md
+++ b/README.md
@@ -11,11 +11,17 @@ A collection of reusable ansible components used by the EthPandaOps team.
 - [ethereum_auth_jwt](roles/ethereum_auth_jwt)
 - [dshackle](roles/dshackle)
 
-### Ethereum clients
+### Ethereum execution clients
 - [geth](roles/geth)
+- [nethermind](roles/nethermind)
+### Ethereum consensus clients
 - [teku](roles/teku)
 - [nimbus](roles/nimbus)
+- [prysm](roles/prysm)
+- [lodestar](roles/lodestar)
 - [lighthouse](roles/lighthouse)
+
+### Ethereum L2 clients
 - [arbitrum_node](roles/arbitrum_node)
 
 ### General purpose tooling

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A collection of reusable ansible components used by the EthPandaOps team.
 ### Ethereum execution clients
 - [besu](roles/besu)
 - [geth](roles/geth)
+- [erigon](roles/erigon)
 - [nethermind](roles/nethermind)
 ### Ethereum consensus clients
 - [teku](roles/teku)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A collection of reusable ansible components used by the EthPandaOps team.
 ### Ethereum client pair
 - [ethereum_node](roles/ethereum_node)
 ### Ethereum execution clients
+- [besu](roles/besu)
 - [geth](roles/geth)
 - [nethermind](roles/nethermind)
 ### Ethereum consensus clients

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A collection of reusable ansible components used by the EthPandaOps team.
 - [geth](roles/geth)
 - [teku](roles/teku)
 - [nimbus](roles/nimbus)
+- [lighthouse](roles/lighthouse)
 - [arbitrum_node](roles/arbitrum_node)
 
 ### General purpose tooling

--- a/roles/besu/README.md
+++ b/roles/besu/README.md
@@ -1,6 +1,6 @@
 # ethpandaops.general.besu
 
-Setup [besu](https://github.com/ethereum/go-ethereum), a ethereum execution layer client.
+Setup [besu](https://github.com/hyperledger/besu), a ethereum execution layer client.
 
 ## Requirements
 

--- a/roles/besu/README.md
+++ b/roles/besu/README.md
@@ -1,0 +1,39 @@
+# ethpandaops.general.besu
+
+Setup [besu](https://github.com/ethereum/go-ethereum), a ethereum execution layer client.
+
+## Requirements
+
+You'll need docker on the target system. Make sure to install it upfront.
+
+## Role Variables
+
+Default variables are defined in [defaults/main.yaml](defaults/main.yaml)
+
+## Dependencies
+
+You'll need docker to run this role. One way of installing docker could be via ansible galaxy with the following dependencies set within `requirements.yaml`:
+
+```yaml
+roles:
+- src: geerlingguy.docker
+  version: latest
+- src: geerlingguy.pip
+  version: latest
+```
+
+## Example Playbook
+
+Your playbook could look like this:
+
+```yaml
+- hosts: localhost
+  become: true
+  roles:
+  - role: geerlingguy.docker
+  - role: geerlingguy.pip
+    pip_install_packages:
+    - name: docker
+  - role: ethpandaops.general.besu
+  - role: ethpandaops.general.teku
+```

--- a/roles/besu/defaults/main.yaml
+++ b/roles/besu/defaults/main.yaml
@@ -10,7 +10,7 @@ besu_ports_engine: 8551
 besu_ports_metrics: 9545
 
 besu_container_name: besu
-besu_container_image: hyperledger/besu:22.10.3
+besu_container_image: hyperledger/besu:latest
 besu_container_env: {}
 besu_container_ports:
   - "127.0.0.1:{{ besu_ports_http_rpc }}:{{ besu_ports_http_rpc }}"

--- a/roles/besu/defaults/main.yaml
+++ b/roles/besu/defaults/main.yaml
@@ -1,0 +1,41 @@
+besu_user: besu
+besu_datadir: /data/besu
+besu_auth_jwt_path: /data/execution-auth.secret
+
+besu_cleanup: false # when set to "true" it will remove the container
+
+besu_ports_p2p: 30303
+besu_ports_http_rpc: 8545
+besu_ports_engine: 8551
+besu_ports_monitoring: 6060
+
+besu_container_name: besu
+besu_container_image: hyperledger/besu:22.10.3
+besu_container_env: {}
+besu_container_ports:
+  - "127.0.0.1:{{ besu_ports_http_rpc }}:{{ besu_ports_http_rpc }}"
+  - "127.0.0.1:{{ besu_ports_engine }}:{{ besu_ports_engine }}"
+  - "{{ besu_ports_p2p }}:{{ besu_ports_p2p }}"
+  - "{{ besu_ports_p2p }}:{{ besu_ports_p2p}}/udp"
+besu_container_volumes:
+  - "{{ besu_datadir }}:/data"
+  - "{{ besu_auth_jwt_path }}:/execution-auth.jwt:ro"
+besu_container_stop_timeout: "300"
+besu_container_networks: []
+besu_container_command:
+  - --data-path=/data
+  - --nat-method=NONE
+  - --p2p-host={{ ansible_host }}
+  - --p2p-port={{ besu_ports_p2p }}
+  - --rpc-http-enabled
+  - --rpc-http-host=0.0.0.0
+  - --rpc-http-port={{ besu_ports_http_rpc }}
+  - --rpc-http-cors-origins=*
+  - --host-allowlist=*
+  - --engine-jwt-secret=/execution-auth.jwt
+  - --engine-rpc-port={{ besu_ports_engine }}
+  - --engine-host-allowlist=*
+  - --metrics-enabled
+  - --metrics-host=0.0.0.0
+  - --metrics-port={{ besu_ports_monitoring }}
+besu_container_command_extra_args: []

--- a/roles/besu/defaults/main.yaml
+++ b/roles/besu/defaults/main.yaml
@@ -7,7 +7,7 @@ besu_cleanup: false # when set to "true" it will remove the container
 besu_ports_p2p: 30303
 besu_ports_http_rpc: 8545
 besu_ports_engine: 8551
-besu_ports_metrics: 6060
+besu_ports_metrics: 9545
 
 besu_container_name: besu
 besu_container_image: hyperledger/besu:22.10.3

--- a/roles/besu/defaults/main.yaml
+++ b/roles/besu/defaults/main.yaml
@@ -16,7 +16,7 @@ besu_container_ports:
   - "127.0.0.1:{{ besu_ports_http_rpc }}:{{ besu_ports_http_rpc }}"
   - "127.0.0.1:{{ besu_ports_engine }}:{{ besu_ports_engine }}"
   - "{{ besu_ports_p2p }}:{{ besu_ports_p2p }}"
-  - "{{ besu_ports_p2p }}:{{ besu_ports_p2p}}/udp"
+  - "{{ besu_ports_p2p }}:{{ besu_ports_p2p }}/udp"
 besu_container_volumes:
   - "{{ besu_datadir }}:/data"
   - "{{ besu_auth_jwt_path }}:/execution-auth.jwt:ro"

--- a/roles/besu/defaults/main.yaml
+++ b/roles/besu/defaults/main.yaml
@@ -7,7 +7,7 @@ besu_cleanup: false # when set to "true" it will remove the container
 besu_ports_p2p: 30303
 besu_ports_http_rpc: 8545
 besu_ports_engine: 8551
-besu_ports_monitoring: 6060
+besu_ports_metrics: 6060
 
 besu_container_name: besu
 besu_container_image: hyperledger/besu:22.10.3
@@ -37,5 +37,5 @@ besu_container_command:
   - --engine-host-allowlist=*
   - --metrics-enabled
   - --metrics-host=0.0.0.0
-  - --metrics-port={{ besu_ports_monitoring }}
+  - --metrics-port={{ besu_ports_metrics }}
 besu_container_command_extra_args: []

--- a/roles/besu/meta/main.yaml
+++ b/roles/besu/meta/main.yaml
@@ -1,0 +1,4 @@
+dependencies:
+  - role: ethpandaops.general.ethereum_auth_jwt
+    vars:
+      ethereum_auth_jwt_path: "{{ besu_auth_jwt_path }}"

--- a/roles/besu/tasks/cleanup.yaml
+++ b/roles/besu/tasks/cleanup.yaml
@@ -1,0 +1,4 @@
+- name: Remove besu container
+  community.docker.docker_container:
+    name: "{{ besu_container_name }}"
+    state: absent

--- a/roles/besu/tasks/main.yaml
+++ b/roles/besu/tasks/main.yaml
@@ -1,0 +1,7 @@
+- name: Setup besu
+  ansible.builtin.import_tasks: setup.yaml
+  when: not besu_cleanup
+
+- name: Cleanup besu
+  ansible.builtin.import_tasks: cleanup.yaml
+  when: besu_cleanup

--- a/roles/besu/tasks/setup.yaml
+++ b/roles/besu/tasks/setup.yaml
@@ -1,0 +1,26 @@
+- name: Add besu user
+  ansible.builtin.user:
+    name: "{{ besu_user }}"
+  register: besu_user_meta
+
+- name: Create data dir
+  ansible.builtin.file:
+    path: "{{ besu_datadir }}"
+    state: directory
+    recurse: true
+    owner: "{{ besu_user }}"
+    group: "{{ besu_user }}"
+
+- name: Run besu container
+  community.docker.docker_container:
+    name: "{{ besu_container_name }}"
+    image: "{{ besu_container_image }}"
+    state: started
+    restart_policy: always
+    stop_timeout: "{{ besu_container_stop_timeout }}"
+    ports: "{{ besu_container_ports }}"
+    volumes: "{{ besu_container_volumes }}"
+    env: "{{ besu_container_env }}"
+    networks: "{{ besu_container_networks }}"
+    command: "{{ besu_container_command + besu_container_command_extra_args }}"
+    user: "{{ besu_user_meta.uid }}"

--- a/roles/bootstrap/tasks/main.yml
+++ b/roles/bootstrap/tasks/main.yml
@@ -1,10 +1,10 @@
 - name: Try connection
   block:
-  - name: Test connection
-    ansible.builtin.wait_for_connection:
-      timeout: "3"
-    register: bootstrap_connect
-    changed_when: false
+    - name: Test connection
+      ansible.builtin.wait_for_connection:
+        timeout: "3"
+      register: bootstrap_connect
+      changed_when: false
   rescue:
     - name: Conenction message
       ansible.builtin.debug:

--- a/roles/docker_nginx_proxy/defaults/main.yaml
+++ b/roles/docker_nginx_proxy/defaults/main.yaml
@@ -1,7 +1,8 @@
 docker_nginx_proxy_user: nginx-proxy
 docker_nginx_proxy_datadir: /opt/nginx-proxy
 docker_nginx_proxy_default_email: "mail@yourdomain.tld"
-docker_nginx_proxy_conf_tmpl: "{{ lookup('ansible.builtin.url', 'https://raw.githubusercontent.com/nginx-proxy/nginx-proxy/main/nginx.tmpl', split_lines=False) }}"
+docker_nginx_proxy_conf_tmpl: >-
+  {{ lookup('ansible.builtin.url', 'https://raw.githubusercontent.com/nginx-proxy/nginx-proxy/main/nginx.tmpl', split_lines=False) }}
 
 ############################################################################
 ## Nginx
@@ -10,7 +11,7 @@ docker_nginx_proxy_container_image: nginx:alpine
 docker_nginx_proxy_container_name: nginx-proxy
 docker_nginx_proxy_container_published_ports: ["80:80", "443:443"]
 docker_nginx_proxy_container_restart_policy: always
-docker_nginx_proxy_container_networks_cli_compatible: yes
+docker_nginx_proxy_container_networks_cli_compatible: true
 docker_nginx_proxy_container_network_mode: default
 docker_nginx_proxy_container_networks: []
 docker_nginx_proxy_container_env: {}
@@ -30,7 +31,7 @@ docker_nginx_proxy_docker_gen_container_command: >-
   -notify-sighup nginx-proxy
   -watch /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
 docker_nginx_proxy_docker_gen_container_restart_policy: always
-docker_nginx_proxy_docker_gen_container_networks_cli_compatible: yes
+docker_nginx_proxy_docker_gen_container_networks_cli_compatible: true
 docker_nginx_proxy_docker_gen_container_network_mode: default
 docker_nginx_proxy_docker_gen_container_networks: []
 docker_nginx_proxy_docker_gen_container_env: {}
@@ -46,7 +47,7 @@ docker_nginx_proxy_docker_gen_container_volumes:
 docker_nginx_proxy_acme_companion_container_image: nginxproxy/acme-companion
 docker_nginx_proxy_acme_companion_container_name: nginx-proxy-acme
 docker_nginx_proxy_acme_companion_container_restart_policy: always
-docker_nginx_proxy_acme_companion_container_networks_cli_compatible: yes
+docker_nginx_proxy_acme_companion_container_networks_cli_compatible: true
 docker_nginx_proxy_acme_companion_container_network_mode: default
 docker_nginx_proxy_acme_companion_container_networks: []
 docker_nginx_proxy_acme_companion_container_volumes_from:

--- a/roles/dshackle/defaults/main.yaml
+++ b/roles/dshackle/defaults/main.yaml
@@ -5,7 +5,7 @@ dshackle_container_image: emeraldpay/dshackle
 dshackle_container_name: dshackle
 dshackle_container_published_ports: []
 dshackle_container_restart_policy: always
-dshackle_container_networks_cli_compatible: yes
+dshackle_container_networks_cli_compatible: true
 dshackle_container_network_mode: default
 dshackle_container_networks: []
 dshackle_container_volumes_from: []

--- a/roles/dshackle/tasks/main.yaml
+++ b/roles/dshackle/tasks/main.yaml
@@ -31,4 +31,4 @@
     network_mode: "{{ dshackle_container_network_mode }}"
     volumes: "{{ dshackle_container_volumes }}"
     env: "{{ dshackle_container_env }}"
-    user: "{{dshackle_user_meta.uid }}"
+    user: "{{ dshackle_user_meta.uid }}"

--- a/roles/erigon/README.md
+++ b/roles/erigon/README.md
@@ -1,0 +1,39 @@
+# ethpandaops.general.erigon
+
+Setup [erigon](https://github.com/ledgerwatch/erigon), a ethereum execution layer client.
+
+## Requirements
+
+You'll need docker on the target system. Make sure to install it upfront.
+
+## Role Variables
+
+Default variables are defined in [defaults/main.yaml](defaults/main.yaml)
+
+## Dependencies
+
+You'll need docker to run this role. One way of installing docker could be via ansible galaxy with the following dependencies set within `requirements.yaml`:
+
+```yaml
+roles:
+- src: geerlingguy.docker
+  version: latest
+- src: geerlingguy.pip
+  version: latest
+```
+
+## Example Playbook
+
+Your playbook could look like this:
+
+```yaml
+- hosts: localhost
+  become: true
+  roles:
+  - role: geerlingguy.docker
+  - role: geerlingguy.pip
+    pip_install_packages:
+    - name: docker
+  - role: ethpandaops.general.erigon
+  - role: ethpandaops.general.teku
+```

--- a/roles/erigon/defaults/main.yaml
+++ b/roles/erigon/defaults/main.yaml
@@ -1,0 +1,45 @@
+erigon_user: erigon
+erigon_datadir: /data/erigon
+erigon_auth_jwt_path: /data/execution-auth.secret
+
+erigon_cleanup: false # when set to "true" it will remove the container
+
+erigon_ports_p2p: 30303
+erigon_ports_http_rpc: 8545
+erigon_ports_engine: 8551
+erigon_ports_metrics: 6060
+
+##
+## Main container
+##
+erigon_container_name: erigon
+erigon_container_image: thorax/erigon:stable
+erigon_container_env: {}
+erigon_container_ports:
+  - "127.0.0.1:{{ erigon_ports_engine }}:{{ erigon_ports_engine }}"
+  - "{{ erigon_ports_p2p }}:{{ erigon_ports_p2p }}"
+  - "{{ erigon_ports_p2p }}:{{ erigon_ports_p2p}}/udp"
+erigon_container_volumes:
+  - "{{ erigon_datadir }}:/data"
+  - "{{ erigon_auth_jwt_path }}:/execution-auth.jwt:ro"
+erigon_container_stop_timeout: "300"
+erigon_container_networks: []
+erigon_container_entrypoint:
+  - erigon
+erigon_container_command:
+  - --datadir=/data
+  - --nat=extip:{{ ansible_host }}
+  - --port={{ erigon_ports_p2p }}
+  - --http
+  - --http.addr=0.0.0.0
+  - --http.port={{ erigon_ports_http_rpc }}
+  - --authrpc.jwtsecret=/execution-auth.jwt
+  - --authrpc.addr=0.0.0.0
+  - --authrpc.port={{ erigon_ports_engine }}
+  - --authrpc.vhosts=*
+  - --externalcl
+  - --metrics
+  - --metrics.addr=0.0.0.0
+  - --metrics.port={{ erigon_ports_metrics }}
+erigon_container_command_extra_args:
+  - --prune=htc

--- a/roles/erigon/defaults/main.yaml
+++ b/roles/erigon/defaults/main.yaml
@@ -41,5 +41,5 @@ erigon_container_command:
   - --metrics
   - --metrics.addr=0.0.0.0
   - --metrics.port={{ erigon_ports_metrics }}
-erigon_container_command_extra_args:
-  - --prune=htc
+erigon_container_command_extra_args: []
+#  - --prune=htc

--- a/roles/erigon/defaults/main.yaml
+++ b/roles/erigon/defaults/main.yaml
@@ -18,7 +18,7 @@ erigon_container_env: {}
 erigon_container_ports:
   - "127.0.0.1:{{ erigon_ports_engine }}:{{ erigon_ports_engine }}"
   - "{{ erigon_ports_p2p }}:{{ erigon_ports_p2p }}"
-  - "{{ erigon_ports_p2p }}:{{ erigon_ports_p2p}}/udp"
+  - "{{ erigon_ports_p2p }}:{{ erigon_ports_p2p }}/udp"
 erigon_container_volumes:
   - "{{ erigon_datadir }}:/data"
   - "{{ erigon_auth_jwt_path }}:/execution-auth.jwt:ro"

--- a/roles/erigon/meta/main.yaml
+++ b/roles/erigon/meta/main.yaml
@@ -1,0 +1,4 @@
+dependencies:
+  - role: ethpandaops.general.ethereum_auth_jwt
+    vars:
+      ethereum_auth_jwt_path: "{{ erigon_auth_jwt_path }}"

--- a/roles/erigon/tasks/cleanup.yaml
+++ b/roles/erigon/tasks/cleanup.yaml
@@ -1,0 +1,4 @@
+- name: Remove erigon container
+  community.docker.docker_container:
+    name: "{{ erigon_container_name }}"
+    state: absent

--- a/roles/erigon/tasks/main.yaml
+++ b/roles/erigon/tasks/main.yaml
@@ -1,0 +1,7 @@
+- name: Setup erigon
+  ansible.builtin.import_tasks: setup.yaml
+  when: not erigon_cleanup
+
+- name: Cleanup erigon
+  ansible.builtin.import_tasks: cleanup.yaml
+  when: erigon_cleanup

--- a/roles/erigon/tasks/setup.yaml
+++ b/roles/erigon/tasks/setup.yaml
@@ -1,0 +1,27 @@
+- name: Add erigon user
+  ansible.builtin.user:
+    name: "{{ erigon_user }}"
+  register: erigon_user_meta
+
+- name: Create data dir
+  ansible.builtin.file:
+    path: "{{ erigon_datadir }}"
+    state: directory
+    recurse: true
+    owner: "{{ erigon_user }}"
+    group: "{{ erigon_user }}"
+
+- name: Run erigon container
+  community.docker.docker_container:
+    name: "{{ erigon_container_name }}"
+    image: "{{ erigon_container_image }}"
+    state: started
+    restart_policy: always
+    stop_timeout: "{{ erigon_container_stop_timeout }}"
+    ports: "{{ erigon_container_ports }}"
+    volumes: "{{ erigon_container_volumes }}"
+    env: "{{ erigon_container_env }}"
+    networks: "{{ erigon_container_networks }}"
+    entrypoint: "{{ erigon_container_entrypoint }}"
+    command: "{{ erigon_container_command + erigon_container_command_extra_args }}"
+    user: "{{ erigon_user_meta.uid }}"

--- a/roles/ethereum_node/README.md
+++ b/roles/ethereum_node/README.md
@@ -23,6 +23,7 @@ It uses the following underyling roles:
 - [ethpandaops.general.geth](../geth)
 - [ethpandaops.general.erigon](../erigon)
 - [ethpandaops.general.nethermind](../nethermind)
+- [ethpandaops.general.ethereumjs](../ethereumjs)
 
 ## Requirements
 

--- a/roles/ethereum_node/README.md
+++ b/roles/ethereum_node/README.md
@@ -19,6 +19,7 @@ It uses the following underyling roles:
 - [ethpandaops.general.lighthouse](../lighthouse)
 
 ### Execution layer clients
+- [ethpandaops.general.besu](../besu)
 - [ethpandaops.general.geth](../geth)
 - [ethpandaops.general.nethermind](../nethermind)
 

--- a/roles/ethereum_node/README.md
+++ b/roles/ethereum_node/README.md
@@ -1,0 +1,65 @@
+# ethpandaops.general.ethereum_node
+
+This role will allow you to run a ethereum execution and consensus layer node.
+
+You can choose and switch between client you want to run by changing the following variables:
+
+```yaml
+ ethereum_node_el: geth
+ ethereum_node_cl: lighthouse
+```
+
+It uses the following underyling roles:
+
+### Consensus layer clients
+- [ethpandaops.general.teku](../teku)
+- [ethpandaops.general.prysm](../prysm)
+- [ethpandaops.general.nimbus](../nimbus)
+- [ethpandaops.general.lodestar](../lodestar)
+- [ethpandaops.general.lighthouse](../lighthouse)
+
+### Execution layer clients
+- [ethpandaops.general.geth](../geth)
+- [ethpandaops.general.nethermind](../nethermind)
+
+## Requirements
+
+You'll need docker on the target system. Make sure to install it upfront.
+
+## Role Variables
+
+Default variables are defined in [defaults/main.yaml](defaults/main.yaml)
+
+You can also overwrite any of the default variables used by the specific EL or CL client roles too.
+
+E.g. For geth that would be [ethpandaops.general.geth/defaults/main.yaml](../geth/defaults/main.yaml).
+
+
+## Dependencies
+
+You'll need docker to run this role. One way of installing docker could be via ansible galaxy with the following dependencies set within `requirements.yaml`:
+
+```yaml
+roles:
+- src: geerlingguy.docker
+  version: latest
+- src: geerlingguy.pip
+  version: latest
+```
+
+## Example Playbook
+
+If you would like to run a geth and lighthouse node, then your playbook could look like this:
+
+```yaml
+- hosts: localhost
+  become: true
+  roles:
+  - role: geerlingguy.docker
+  - role: geerlingguy.pip
+    pip_install_packages:
+    - name: docker
+  - role: ethpandaops.general.ethereum_node
+    ethereum_node_el: geth
+    ethereum_node_cl: lighthouse
+```

--- a/roles/ethereum_node/README.md
+++ b/roles/ethereum_node/README.md
@@ -63,3 +63,17 @@ If you would like to run a geth and lighthouse node, then your playbook could lo
     ethereum_node_el: geth
     ethereum_node_cl: lighthouse
 ```
+
+If you want to set client specific configuration you could do it by overwriting the the client specific default variables. For example, if you want to provide extra arguments to your lighthouse command and run a specific version of geth, then you could do it like this:
+
+```yaml
+  - role: ethpandaops.general.ethereum_node
+    # Define which clients you want to use
+    ethereum_node_el: geth
+    ethereum_node_cl: lighthouse
+    # Overwrite a specific lighthouse variable. Check lighthouse/defaults/main.yaml
+    lighthouse_container_command_extra_args:
+      - --checkpoint-sync-url=http://your-other-node
+    # Overwrite a specific geth variable. Check geth/defaults/main.yaml
+    geth_container_image: ethereum/client-go:latest
+```

--- a/roles/ethereum_node/README.md
+++ b/roles/ethereum_node/README.md
@@ -21,6 +21,7 @@ It uses the following underyling roles:
 ### Execution layer clients
 - [ethpandaops.general.besu](../besu)
 - [ethpandaops.general.geth](../geth)
+- [ethpandaops.general.erigon](../erigon)
 - [ethpandaops.general.nethermind](../nethermind)
 
 ## Requirements

--- a/roles/ethereum_node/defaults/main.yaml
+++ b/roles/ethereum_node/defaults/main.yaml
@@ -1,6 +1,6 @@
 ethereum_node_docker_network_name: shared
 
-ethereum_node_el: geth # Valid options: geth, nethermind
+ethereum_node_el: besu # Valid options: besu, geth, nethermind
 ethereum_node_el_enabled: true
 ethereum_node_el_ports_p2p_tcp: 30303
 ethereum_node_el_ports_p2p_udp: 30303

--- a/roles/ethereum_node/defaults/main.yaml
+++ b/roles/ethereum_node/defaults/main.yaml
@@ -1,6 +1,6 @@
 ethereum_node_docker_network_name: shared
 
-ethereum_node_el: besu # Valid options: besu, geth, nethermind
+ethereum_node_el: geth # Valid options: besu, geth, erigon, nethermind
 ethereum_node_el_enabled: true
 ethereum_node_el_ports_p2p_tcp: 30303
 ethereum_node_el_ports_p2p_udp: 30303
@@ -8,7 +8,7 @@ ethereum_node_el_ports_http_rpc: 8545
 ethereum_node_el_ports_engine: 8551
 ethereum_node_el_ports_metrics: 6060
 
-ethereum_node_cl: nimbus # Valid options: lighthouse, lodestar, teku, prysm
+ethereum_node_cl: lighthouse # Valid options: lighthouse, lodestar, teku, prysm
 ethereum_node_cl_enabled: true
 ethereum_node_cl_ports_p2p_tcp: 9000
 ethereum_node_cl_ports_p2p_udp: 9000

--- a/roles/ethereum_node/defaults/main.yaml
+++ b/roles/ethereum_node/defaults/main.yaml
@@ -1,6 +1,6 @@
 ethereum_node_docker_network_name: shared
 
-ethereum_node_el: geth # Valid options: besu, geth, erigon, nethermind
+ethereum_node_el: ethereumjs # Valid options: besu, geth, erigon, nethermind
 ethereum_node_el_enabled: true
 ethereum_node_el_ports_p2p_tcp: 30303
 ethereum_node_el_ports_p2p_udp: 30303

--- a/roles/ethereum_node/defaults/main.yaml
+++ b/roles/ethereum_node/defaults/main.yaml
@@ -1,0 +1,18 @@
+ethereum_node_docker_network_name: shared
+
+ethereum_node_el: geth # Valid options: geth, nethermind
+ethereum_node_el_enabled: true
+ethereum_node_el_ports_p2p_tcp: 30303
+ethereum_node_el_ports_p2p_udp: 30303
+ethereum_node_el_ports_http_rpc: 8545
+ethereum_node_el_ports_engine: 8551
+ethereum_node_el_ports_metrics: 6060
+
+ethereum_node_cl: nimbus # Valid options: lighthouse, lodestar, teku, prysm
+ethereum_node_cl_enabled: true
+ethereum_node_cl_ports_p2p_tcp: 9000
+ethereum_node_cl_ports_p2p_udp: 9000
+ethereum_node_cl_ports_http_beacon: 5052
+ethereum_node_cl_ports_metrics: 5054
+
+ethereum_node_execution_endpoint: "http://{{ ethereum_node_el }}:{{ ethereum_node_el_ports_engine }}"

--- a/roles/ethereum_node/tasks/cleanup.yaml
+++ b/roles/ethereum_node/tasks/cleanup.yaml
@@ -12,6 +12,13 @@
   vars:
     geth_cleanup: true
 
+- name: "Cleanup execution client: erigon"
+  when: (ethereum_node_el != "erigon") or (not ethereum_node_el_enabled)
+  ansible.builtin.include_role:
+    name: ethpandaops.general.erigon
+  vars:
+    erigon_cleanup: true
+
 - name: "Cleanup execution client: nethermind"
   when: (ethereum_node_el != "nethermind") or (not ethereum_node_el_enabled)
   ansible.builtin.include_role:

--- a/roles/ethereum_node/tasks/cleanup.yaml
+++ b/roles/ethereum_node/tasks/cleanup.yaml
@@ -26,6 +26,13 @@
   vars:
     nethermind_cleanup: true
 
+- name: "Cleanup execution client: ethereumjs"
+  when: (ethereum_node_el != "ethereumjs") or (not ethereum_node_el_enabled)
+  ansible.builtin.include_role:
+    name: ethpandaops.general.ethereumjs
+  vars:
+    ethereumjs_cleanup: true
+
 - name: "Cleanup consensus client: lighthouse"
   when: (ethereum_node_cl != "lighthouse") or (not ethereum_node_cl_enabled)
   ansible.builtin.include_role:
@@ -59,4 +66,4 @@
   ansible.builtin.include_role:
     name: ethpandaops.general.nimbus
   vars:
-    lodestar_cleanup: true
+    nimbus_cleanup: true

--- a/roles/ethereum_node/tasks/cleanup.yaml
+++ b/roles/ethereum_node/tasks/cleanup.yaml
@@ -1,0 +1,48 @@
+- name: "Cleanup execution client: geth"
+  when: (ethereum_node_el != "geth") or (not ethereum_node_el_enabled)
+  ansible.builtin.include_role:
+    name: ethpandaops.general.geth
+  vars:
+    geth_cleanup: true
+
+- name: "Cleanup execution client: nethermind"
+  when: (ethereum_node_el != "nethermind") or (not ethereum_node_el_enabled)
+  ansible.builtin.include_role:
+    name: ethpandaops.general.nethermind
+  vars:
+    nethermind_cleanup: true
+
+- name: "Cleanup consensus client: lighthouse"
+  when: (ethereum_node_cl != "lighthouse") or (not ethereum_node_cl_enabled)
+  ansible.builtin.include_role:
+    name: ethpandaops.general.lighthouse
+  vars:
+    lighthouse_cleanup: true
+
+- name: "Cleanup consensus client: teku"
+  when: (ethereum_node_cl != "teku") or (not ethereum_node_cl_enabled)
+  ansible.builtin.include_role:
+    name: ethpandaops.general.teku
+  vars:
+    teku_cleanup: true
+
+- name: "Cleanup consensus client: prysm"
+  when: (ethereum_node_cl != "prysm") or (not ethereum_node_cl_enabled)
+  ansible.builtin.include_role:
+    name: ethpandaops.general.prysm
+  vars:
+    prysm_cleanup: true
+
+- name: "Cleanup consensus client: lodestar"
+  when: (ethereum_node_cl != "lodestar") or (not ethereum_node_cl_enabled)
+  ansible.builtin.include_role:
+    name: ethpandaops.general.lodestar
+  vars:
+    lodestar_cleanup: true
+
+- name: "Cleanup consensus client: nimbus"
+  when: (ethereum_node_cl != "nimbus") or (not ethereum_node_cl_enabled)
+  ansible.builtin.include_role:
+    name: ethpandaops.general.nimbus
+  vars:
+    lodestar_cleanup: true

--- a/roles/ethereum_node/tasks/cleanup.yaml
+++ b/roles/ethereum_node/tasks/cleanup.yaml
@@ -1,3 +1,10 @@
+- name: "Cleanup execution client: besu"
+  when: (ethereum_node_el != "besu") or (not ethereum_node_el_enabled)
+  ansible.builtin.include_role:
+    name: ethpandaops.general.besu
+  vars:
+    besu_cleanup: true
+
 - name: "Cleanup execution client: geth"
   when: (ethereum_node_el != "geth") or (not ethereum_node_el_enabled)
   ansible.builtin.include_role:

--- a/roles/ethereum_node/tasks/main.yaml
+++ b/roles/ethereum_node/tasks/main.yaml
@@ -1,0 +1,19 @@
+- name: Validate inputs
+  ansible.builtin.import_tasks: validations.yaml
+
+- name: Setup docker network
+  ansible.builtin.include_role:
+    name: ethpandaops.general.docker_network
+  vars:
+    docker_network_name: "{{ ethereum_node_docker_network_name}}"
+
+- name: Cleanup clients that shouldn't be running
+  ansible.builtin.import_tasks: cleanup.yaml
+
+- name: Setup execution client
+  ansible.builtin.import_tasks: setup_el.yaml
+  when: ethereum_node_el_enabled
+
+- name: Setup consensus client
+  ansible.builtin.import_tasks: setup_cl.yaml
+  when: ethereum_node_cl_enabled

--- a/roles/ethereum_node/tasks/main.yaml
+++ b/roles/ethereum_node/tasks/main.yaml
@@ -5,7 +5,7 @@
   ansible.builtin.include_role:
     name: ethpandaops.general.docker_network
   vars:
-    docker_network_name: "{{ ethereum_node_docker_network_name}}"
+    docker_network_name: "{{ ethereum_node_docker_network_name }}"
 
 - name: Cleanup clients that shouldn't be running
   ansible.builtin.import_tasks: cleanup.yaml

--- a/roles/ethereum_node/tasks/setup_cl.yaml
+++ b/roles/ethereum_node/tasks/setup_cl.yaml
@@ -1,0 +1,59 @@
+- name: "Consensus client: lighthouse"
+  when: ethereum_node_cl == "lighthouse"
+  ansible.builtin.include_role:
+    name: ethpandaops.general.lighthouse
+  vars:
+    lighthouse_ports_p2p_tcp: "{{ ethereum_node_cl_ports_p2p_tcp }}"
+    lighthouse_ports_p2p_udp: "{{ ethereum_node_cl_ports_p2p_udp }}"
+    lighthouse_ports_http_beacon: "{{ ethereum_node_cl_ports_http_beacon }}"
+    lighthouse_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
+    lighthouse_container_networks : "{{ ethereum_node_docker_networks }}"
+    lighthouse_execution_engine_endpoint: "{{ ethereum_node_execution_endpoint }}"
+
+- name: "Consensus client: teku"
+  when: ethereum_node_cl == "teku"
+  ansible.builtin.include_role:
+    name: ethpandaops.general.teku
+  vars:
+    teku_ports_p2p_tcp: "{{ ethereum_node_cl_ports_p2p_tcp }}"
+    teku_ports_p2p_udp: "{{ ethereum_node_cl_ports_p2p_udp }}"
+    teku_ports_http_beacon: "{{ ethereum_node_cl_ports_http_beacon }}"
+    teku_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
+    teku_container_networks : "{{ ethereum_node_docker_networks }}"
+    teku_execution_engine_endpoint: "{{ ethereum_node_execution_endpoint }}"
+
+- name: "Consensus client: prysm"
+  when: ethereum_node_cl == "prysm"
+  ansible.builtin.include_role:
+    name: ethpandaops.general.prysm
+  vars:
+    prysm_ports_p2p_tcp: "{{ ethereum_node_cl_ports_p2p_tcp }}"
+    prysm_ports_p2p_udp: "{{ ethereum_node_cl_ports_p2p_udp }}"
+    prysm_ports_http_beacon: "{{ ethereum_node_cl_ports_http_beacon }}"
+    prysm_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
+    prysm_container_networks : "{{ ethereum_node_docker_networks }}"
+    prysm_execution_engine_endpoint: "{{ ethereum_node_execution_endpoint }}"
+
+- name: "Consensus client: lodestar"
+  when: ethereum_node_cl == "lodestar"
+  ansible.builtin.include_role:
+    name: ethpandaops.general.lodestar
+  vars:
+    lodestar_ports_p2p_tcp: "{{ ethereum_node_cl_ports_p2p_tcp }}"
+    lodestar_ports_p2p_udp: "{{ ethereum_node_cl_ports_p2p_udp }}"
+    lodestar_ports_http_beacon: "{{ ethereum_node_cl_ports_http_beacon }}"
+    lodestar_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
+    lodestar_container_networks : "{{ ethereum_node_docker_networks }}"
+    lodestar_execution_engine_endpoint: "{{ ethereum_node_execution_endpoint }}"
+
+- name: "Consensus client: nimbus"
+  when: ethereum_node_cl == "nimbus"
+  ansible.builtin.include_role:
+    name: ethpandaops.general.nimbus
+  vars:
+    nimbus_ports_p2p_tcp: "{{ ethereum_node_cl_ports_p2p_tcp }}"
+    nimbus_ports_p2p_udp: "{{ ethereum_node_cl_ports_p2p_udp }}"
+    nimbus_ports_http_beacon: "{{ ethereum_node_cl_ports_http_beacon }}"
+    nimbus_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
+    nimbus_container_networks : "{{ ethereum_node_docker_networks }}"
+    nimbus_execution_engine_endpoint: "{{ ethereum_node_execution_endpoint }}"

--- a/roles/ethereum_node/tasks/setup_cl.yaml
+++ b/roles/ethereum_node/tasks/setup_cl.yaml
@@ -7,7 +7,7 @@
     lighthouse_ports_p2p_udp: "{{ ethereum_node_cl_ports_p2p_udp }}"
     lighthouse_ports_http_beacon: "{{ ethereum_node_cl_ports_http_beacon }}"
     lighthouse_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
-    lighthouse_container_networks : "{{ ethereum_node_docker_networks }}"
+    lighthouse_container_networks: "{{ ethereum_node_docker_networks }}"
     lighthouse_execution_engine_endpoint: "{{ ethereum_node_execution_endpoint }}"
 
 - name: "Consensus client: teku"
@@ -19,7 +19,7 @@
     teku_ports_p2p_udp: "{{ ethereum_node_cl_ports_p2p_udp }}"
     teku_ports_http_beacon: "{{ ethereum_node_cl_ports_http_beacon }}"
     teku_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
-    teku_container_networks : "{{ ethereum_node_docker_networks }}"
+    teku_container_networks: "{{ ethereum_node_docker_networks }}"
     teku_execution_engine_endpoint: "{{ ethereum_node_execution_endpoint }}"
 
 - name: "Consensus client: prysm"
@@ -31,7 +31,7 @@
     prysm_ports_p2p_udp: "{{ ethereum_node_cl_ports_p2p_udp }}"
     prysm_ports_http_beacon: "{{ ethereum_node_cl_ports_http_beacon }}"
     prysm_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
-    prysm_container_networks : "{{ ethereum_node_docker_networks }}"
+    prysm_container_networks: "{{ ethereum_node_docker_networks }}"
     prysm_execution_engine_endpoint: "{{ ethereum_node_execution_endpoint }}"
 
 - name: "Consensus client: lodestar"
@@ -43,7 +43,7 @@
     lodestar_ports_p2p_udp: "{{ ethereum_node_cl_ports_p2p_udp }}"
     lodestar_ports_http_beacon: "{{ ethereum_node_cl_ports_http_beacon }}"
     lodestar_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
-    lodestar_container_networks : "{{ ethereum_node_docker_networks }}"
+    lodestar_container_networks: "{{ ethereum_node_docker_networks }}"
     lodestar_execution_engine_endpoint: "{{ ethereum_node_execution_endpoint }}"
 
 - name: "Consensus client: nimbus"
@@ -55,5 +55,5 @@
     nimbus_ports_p2p_udp: "{{ ethereum_node_cl_ports_p2p_udp }}"
     nimbus_ports_http_beacon: "{{ ethereum_node_cl_ports_http_beacon }}"
     nimbus_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
-    nimbus_container_networks : "{{ ethereum_node_docker_networks }}"
+    nimbus_container_networks: "{{ ethereum_node_docker_networks }}"
     nimbus_execution_engine_endpoint: "{{ ethereum_node_execution_endpoint }}"

--- a/roles/ethereum_node/tasks/setup_el.yaml
+++ b/roles/ethereum_node/tasks/setup_el.yaml
@@ -1,0 +1,21 @@
+- name: "Execution client: geth"
+  when: ethereum_node_el == "geth"
+  ansible.builtin.include_role:
+    name: ethpandaops.general.geth
+  vars:
+    geth_ports_p2p: "{{ ethereum_node_el_ports_p2p_tcp }}"
+    geth_ports_http_rpc: "{{ ethereum_node_el_ports_http_rpc }}"
+    geth_ports_engine: "{{ ethereum_node_el_ports_engine }}"
+    geth_ports_monitoring: "{{ ethereum_node_el_ports_metrics }}"
+    geth_container_networks : "{{ ethereum_node_docker_networks }}"
+
+- name: "Execution client: nethermind"
+  when: ethereum_node_el == "nethermind"
+  ansible.builtin.include_role:
+    name: ethpandaops.general.nethermind
+  vars:
+    nethermind_ports_p2p: "{{ ethereum_node_el_ports_p2p_tcp }}"
+    nethermind_ports_http_rpc: "{{ ethereum_node_el_ports_http_rpc }}"
+    nethermind_ports_engine: "{{ ethereum_node_el_ports_engine }}"
+    nethermind_ports_monitoring: "{{ ethereum_node_el_ports_metrics }}"
+    nethermind_container_networks : "{{ ethereum_node_docker_networks }}"

--- a/roles/ethereum_node/tasks/setup_el.yaml
+++ b/roles/ethereum_node/tasks/setup_el.yaml
@@ -6,7 +6,7 @@
     besu_ports_p2p: "{{ ethereum_node_el_ports_p2p_tcp }}"
     besu_ports_http_rpc: "{{ ethereum_node_el_ports_http_rpc }}"
     besu_ports_engine: "{{ ethereum_node_el_ports_engine }}"
-    besu_ports_monitoring: "{{ ethereum_node_el_ports_metrics }}"
+    besu_ports_metrics: "{{ ethereum_node_el_ports_metrics }}"
     besu_container_networks: "{{ ethereum_node_docker_networks }}"
 
 - name: "Execution client: geth"
@@ -17,7 +17,7 @@
     geth_ports_p2p: "{{ ethereum_node_el_ports_p2p_tcp }}"
     geth_ports_http_rpc: "{{ ethereum_node_el_ports_http_rpc }}"
     geth_ports_engine: "{{ ethereum_node_el_ports_engine }}"
-    geth_ports_monitoring: "{{ ethereum_node_el_ports_metrics }}"
+    geth_ports_metrics: "{{ ethereum_node_el_ports_metrics }}"
     geth_container_networks: "{{ ethereum_node_docker_networks }}"
 
 - name: "Execution client: nethermind"
@@ -28,5 +28,5 @@
     nethermind_ports_p2p: "{{ ethereum_node_el_ports_p2p_tcp }}"
     nethermind_ports_http_rpc: "{{ ethereum_node_el_ports_http_rpc }}"
     nethermind_ports_engine: "{{ ethereum_node_el_ports_engine }}"
-    nethermind_ports_monitoring: "{{ ethereum_node_el_ports_metrics }}"
+    nethermind_ports_metrics: "{{ ethereum_node_el_ports_metrics }}"
     nethermind_container_networks: "{{ ethereum_node_docker_networks }}"

--- a/roles/ethereum_node/tasks/setup_el.yaml
+++ b/roles/ethereum_node/tasks/setup_el.yaml
@@ -7,7 +7,7 @@
     geth_ports_http_rpc: "{{ ethereum_node_el_ports_http_rpc }}"
     geth_ports_engine: "{{ ethereum_node_el_ports_engine }}"
     geth_ports_monitoring: "{{ ethereum_node_el_ports_metrics }}"
-    geth_container_networks : "{{ ethereum_node_docker_networks }}"
+    geth_container_networks: "{{ ethereum_node_docker_networks }}"
 
 - name: "Execution client: nethermind"
   when: ethereum_node_el == "nethermind"
@@ -18,4 +18,4 @@
     nethermind_ports_http_rpc: "{{ ethereum_node_el_ports_http_rpc }}"
     nethermind_ports_engine: "{{ ethereum_node_el_ports_engine }}"
     nethermind_ports_monitoring: "{{ ethereum_node_el_ports_metrics }}"
-    nethermind_container_networks : "{{ ethereum_node_docker_networks }}"
+    nethermind_container_networks: "{{ ethereum_node_docker_networks }}"

--- a/roles/ethereum_node/tasks/setup_el.yaml
+++ b/roles/ethereum_node/tasks/setup_el.yaml
@@ -20,6 +20,17 @@
     geth_ports_metrics: "{{ ethereum_node_el_ports_metrics }}"
     geth_container_networks: "{{ ethereum_node_docker_networks }}"
 
+- name: "Execution client: erigon"
+  when: ethereum_node_el == "erigon"
+  ansible.builtin.include_role:
+    name: ethpandaops.general.erigon
+  vars:
+    erigon_ports_p2p: "{{ ethereum_node_el_ports_p2p_tcp }}"
+    erigon_ports_http_rpc: "{{ ethereum_node_el_ports_http_rpc }}"
+    erigon_ports_engine: "{{ ethereum_node_el_ports_engine }}"
+    erigon_ports_metrics: "{{ ethereum_node_el_ports_metrics }}"
+    erigon_container_networks: "{{ ethereum_node_docker_networks }}"
+
 - name: "Execution client: nethermind"
   when: ethereum_node_el == "nethermind"
   ansible.builtin.include_role:

--- a/roles/ethereum_node/tasks/setup_el.yaml
+++ b/roles/ethereum_node/tasks/setup_el.yaml
@@ -1,3 +1,14 @@
+- name: "Execution client: besu"
+  when: ethereum_node_el == "besu"
+  ansible.builtin.include_role:
+    name: ethpandaops.general.besu
+  vars:
+    besu_ports_p2p: "{{ ethereum_node_el_ports_p2p_tcp }}"
+    besu_ports_http_rpc: "{{ ethereum_node_el_ports_http_rpc }}"
+    besu_ports_engine: "{{ ethereum_node_el_ports_engine }}"
+    besu_ports_monitoring: "{{ ethereum_node_el_ports_metrics }}"
+    besu_container_networks: "{{ ethereum_node_docker_networks }}"
+
 - name: "Execution client: geth"
   when: ethereum_node_el == "geth"
   ansible.builtin.include_role:

--- a/roles/ethereum_node/tasks/setup_el.yaml
+++ b/roles/ethereum_node/tasks/setup_el.yaml
@@ -41,3 +41,13 @@
     nethermind_ports_engine: "{{ ethereum_node_el_ports_engine }}"
     nethermind_ports_metrics: "{{ ethereum_node_el_ports_metrics }}"
     nethermind_container_networks: "{{ ethereum_node_docker_networks }}"
+
+- name: "Execution client: ethereumjs"
+  when: ethereum_node_el == "ethereumjs"
+  ansible.builtin.include_role:
+    name: ethpandaops.general.ethereumjs
+  vars:
+    ethereumjs_ports_p2p: "{{ ethereum_node_el_ports_p2p_tcp }}"
+    ethereumjs_ports_http_rpc: "{{ ethereum_node_el_ports_http_rpc }}"
+    ethereumjs_ports_engine: "{{ ethereum_node_el_ports_engine }}"
+    ethereumjs_container_networks: "{{ ethereum_node_docker_networks }}"

--- a/roles/ethereum_node/tasks/validations.yaml
+++ b/roles/ethereum_node/tasks/validations.yaml
@@ -1,0 +1,15 @@
+- name: Check defined execution client
+  ansible.builtin.assert:
+    that:
+      - ethereum_node_el in ethereum_node_supported_el
+    success_msg: "'ethereum_node_el' is a supported client"
+    fail_msg: >
+      ethereum_node_el = '{{ ethereum_node_el }}' is invalid. You can choose between: '{{ ethereum_node_supported_el }}'
+
+- name: Check defined consensus client
+  ansible.builtin.assert:
+    that:
+      - ethereum_node_cl in ethereum_node_supported_cl
+    success_msg: "'ethereum_node_cl' is a supported client"
+    fail_msg: >
+      ethereum_node_el = '{{ ethereum_node_cl }}' is invalid. You can choose between: '{{ ethereum_node_supported_cl }}'

--- a/roles/ethereum_node/vars/main.yaml
+++ b/roles/ethereum_node/vars/main.yaml
@@ -1,0 +1,13 @@
+ethereum_node_supported_el:
+  - geth
+  - nethermind
+
+ethereum_node_supported_cl:
+  - lighthouse
+  - teku
+  - prysm
+  - lodestar
+  - nimbus
+
+ethereum_node_docker_networks:
+  - name: "{{ ethereum_node_docker_network_name }}"

--- a/roles/ethereum_node/vars/main.yaml
+++ b/roles/ethereum_node/vars/main.yaml
@@ -1,4 +1,5 @@
 ethereum_node_supported_el:
+  - besu
   - geth
   - nethermind
 

--- a/roles/ethereum_node/vars/main.yaml
+++ b/roles/ethereum_node/vars/main.yaml
@@ -1,6 +1,7 @@
 ethereum_node_supported_el:
   - besu
   - geth
+  - erigon
   - nethermind
 
 ethereum_node_supported_cl:

--- a/roles/ethereum_node/vars/main.yaml
+++ b/roles/ethereum_node/vars/main.yaml
@@ -3,6 +3,7 @@ ethereum_node_supported_el:
   - geth
   - erigon
   - nethermind
+  - ethereumjs
 
 ethereum_node_supported_cl:
   - lighthouse

--- a/roles/ethereumjs/README.md
+++ b/roles/ethereumjs/README.md
@@ -1,0 +1,39 @@
+# ethpandaops.general.ethereumjs
+
+Setup [ethereumjs](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/client), a ethereum execution layer client.
+
+## Requirements
+
+You'll need docker on the target system. Make sure to install it upfront.
+
+## Role Variables
+
+Default variables are defined in [defaults/main.yaml](defaults/main.yaml)
+
+## Dependencies
+
+You'll need docker to run this role. One way of installing docker could be via ansible galaxy with the following dependencies set within `requirements.yaml`:
+
+```yaml
+roles:
+- src: geerlingguy.docker
+  version: latest
+- src: geerlingguy.pip
+  version: latest
+```
+
+## Example Playbook
+
+Your playbook could look like this:
+
+```yaml
+- hosts: localhost
+  become: true
+  roles:
+  - role: geerlingguy.docker
+  - role: geerlingguy.pip
+    pip_install_packages:
+    - name: docker
+  - role: ethpandaops.general.ethereumjs
+  - role: ethpandaops.general.teku
+```

--- a/roles/ethereumjs/defaults/main.yaml
+++ b/roles/ethereumjs/defaults/main.yaml
@@ -15,7 +15,7 @@ ethereumjs_container_ports:
   - "127.0.0.1:{{ ethereumjs_ports_http_rpc }}:{{ ethereumjs_ports_http_rpc }}"
   - "127.0.0.1:{{ ethereumjs_ports_engine }}:{{ ethereumjs_ports_engine }}"
   - "{{ ethereumjs_ports_p2p }}:{{ ethereumjs_ports_p2p }}"
-  - "{{ ethereumjs_ports_p2p }}:{{ ethereumjs_ports_p2p}}/udp"
+  - "{{ ethereumjs_ports_p2p }}:{{ ethereumjs_ports_p2p }}/udp"
 ethereumjs_container_volumes:
   - "{{ ethereumjs_datadir }}:/data"
   - "{{ ethereumjs_auth_jwt_path }}:/execution-auth.jwt:ro"

--- a/roles/ethereumjs/defaults/main.yaml
+++ b/roles/ethereumjs/defaults/main.yaml
@@ -1,0 +1,36 @@
+ethereumjs_user: ethereumjs
+ethereumjs_datadir: /data/ethereumjs
+ethereumjs_auth_jwt_path: /data/execution-auth.secret
+
+ethereumjs_cleanup: false # when set to "true" it will remove the container
+
+ethereumjs_ports_p2p: 30303
+ethereumjs_ports_http_rpc: 8545
+ethereumjs_ports_engine: 8551
+
+ethereumjs_container_name: ethereumjs
+ethereumjs_container_image: g11tech/ethereumjs:latest
+ethereumjs_container_env: {}
+ethereumjs_container_ports:
+  - "127.0.0.1:{{ ethereumjs_ports_http_rpc }}:{{ ethereumjs_ports_http_rpc }}"
+  - "127.0.0.1:{{ ethereumjs_ports_engine }}:{{ ethereumjs_ports_engine }}"
+  - "{{ ethereumjs_ports_p2p }}:{{ ethereumjs_ports_p2p }}"
+  - "{{ ethereumjs_ports_p2p }}:{{ ethereumjs_ports_p2p}}/udp"
+ethereumjs_container_volumes:
+  - "{{ ethereumjs_datadir }}:/data"
+  - "{{ ethereumjs_auth_jwt_path }}:/execution-auth.jwt:ro"
+ethereumjs_container_stop_timeout: "300"
+ethereumjs_container_networks: []
+ethereumjs_container_command:
+  - --datadir=/data
+  - --port={{ ethereumjs_ports_p2p }}
+  - --rpc
+  - --rpcaddr=0.0.0.0
+  - --rpcport={{ ethereumjs_ports_http_rpc }}
+  - --rpcCors=*
+  - --rpcEngine
+  - --rpcEngineAddr=0.0.0.0
+  - --rpcEnginePort={{ ethereumjs_ports_engine }}
+  - --jwt-secret=/execution-auth.jwt
+  - --extIP={{ ansible_host }}
+ethereumjs_container_command_extra_args: []

--- a/roles/ethereumjs/meta/main.yaml
+++ b/roles/ethereumjs/meta/main.yaml
@@ -1,0 +1,4 @@
+dependencies:
+  - role: ethpandaops.general.ethereum_auth_jwt
+    vars:
+      ethereum_auth_jwt_path: "{{ ethereumjs_auth_jwt_path }}"

--- a/roles/ethereumjs/tasks/cleanup.yaml
+++ b/roles/ethereumjs/tasks/cleanup.yaml
@@ -1,0 +1,4 @@
+- name: Remove ethereumjs container
+  community.docker.docker_container:
+    name: "{{ ethereumjs_container_name }}"
+    state: absent

--- a/roles/ethereumjs/tasks/main.yaml
+++ b/roles/ethereumjs/tasks/main.yaml
@@ -1,0 +1,7 @@
+- name: Setup ethereumjs
+  ansible.builtin.import_tasks: setup.yaml
+  when: not ethereumjs_cleanup
+
+- name: Cleanup ethereumjs
+  ansible.builtin.import_tasks: cleanup.yaml
+  when: ethereumjs_cleanup

--- a/roles/ethereumjs/tasks/setup.yaml
+++ b/roles/ethereumjs/tasks/setup.yaml
@@ -1,0 +1,26 @@
+- name: Add ethereumjs user
+  ansible.builtin.user:
+    name: "{{ ethereumjs_user }}"
+  register: ethereumjs_user_meta
+
+- name: Create data dir
+  ansible.builtin.file:
+    path: "{{ ethereumjs_datadir }}"
+    state: directory
+    recurse: true
+    owner: "{{ ethereumjs_user }}"
+    group: "{{ ethereumjs_user }}"
+
+- name: Run ethereumjs container
+  community.docker.docker_container:
+    name: "{{ ethereumjs_container_name }}"
+    image: "{{ ethereumjs_container_image }}"
+    state: started
+    restart_policy: always
+    stop_timeout: "{{ ethereumjs_container_stop_timeout }}"
+    ports: "{{ ethereumjs_container_ports }}"
+    volumes: "{{ ethereumjs_container_volumes }}"
+    env: "{{ ethereumjs_container_env }}"
+    networks: "{{ ethereumjs_container_networks }}"
+    command: "{{ ethereumjs_container_command + ethereumjs_container_command_extra_args }}"
+    user: "{{ ethereumjs_user_meta.uid }}"

--- a/roles/geth/defaults/main.yaml
+++ b/roles/geth/defaults/main.yaml
@@ -38,3 +38,4 @@ geth_container_command:
   - --metrics
   - --metrics.port={{ geth_ports_monitoring }}
   - --metrics.addr=0.0.0.0
+geth_container_command_extra_args: []

--- a/roles/geth/defaults/main.yaml
+++ b/roles/geth/defaults/main.yaml
@@ -7,7 +7,7 @@ geth_cleanup: false # when set to "true" it will remove the container
 geth_ports_p2p: 30303
 geth_ports_http_rpc: 8545
 geth_ports_engine: 8551
-geth_ports_monitoring: 6060
+geth_ports_metrics: 6060
 
 geth_container_name: geth
 geth_container_image: ethereum/client-go:v1.10.26
@@ -36,6 +36,6 @@ geth_container_command:
   - --authrpc.jwtsecret=/execution-auth.jwt
   - --nat=extip:{{ ansible_host }}
   - --metrics
-  - --metrics.port={{ geth_ports_monitoring }}
+  - --metrics.port={{ geth_ports_metrics }}
   - --metrics.addr=0.0.0.0
 geth_container_command_extra_args: []

--- a/roles/geth/defaults/main.yaml
+++ b/roles/geth/defaults/main.yaml
@@ -2,13 +2,21 @@ geth_user: geth
 geth_datadir: /data/geth
 geth_auth_jwt_path: /data/execution-auth.secret
 
+geth_cleanup: false # when set to "true" it will remove the container
+
+geth_ports_p2p: 30303
+geth_ports_http_rpc: 8545
+geth_ports_engine: 8551
+geth_ports_monitoring: 6060
+
 geth_container_name: geth
 geth_container_image: ethereum/client-go:v1.10.26
 geth_container_env: {}
 geth_container_ports:
-  - "127.0.0.1:8545:8545"
-  - "127.0.0.1:8551:8551"
-  - "30303:30303"
+  - "127.0.0.1:{{ geth_ports_http_rpc }}:{{ geth_ports_http_rpc }}"
+  - "127.0.0.1:{{ geth_ports_engine }}:{{ geth_ports_engine }}"
+  - "{{ geth_ports_p2p }}:{{ geth_ports_p2p }}"
+  - "{{ geth_ports_p2p }}:{{ geth_ports_p2p}}/udp"
 geth_container_volumes:
   - "{{ geth_datadir }}:/data"
   - "{{ geth_auth_jwt_path }}:/execution-auth.jwt:ro"
@@ -16,14 +24,17 @@ geth_container_stop_timeout: "300"
 geth_container_networks: []
 geth_container_command:
   - --datadir=/data
+  - --port={{ geth_ports_p2p }}
   - --http
   - --http.addr=0.0.0.0
+  - --http.port={{ geth_ports_http_rpc }}
   - --http.api=eth,net,web3
   - --http.vhosts=*
   - --authrpc.addr=0.0.0.0
+  - --authrpc.port={{ geth_ports_engine }}
   - --authrpc.vhosts=*
   - --authrpc.jwtsecret=/execution-auth.jwt
   - --nat=extip:{{ ansible_host }}
   - --metrics
-  - --metrics.port=6060
+  - --metrics.port={{ geth_ports_monitoring }}
   - --metrics.addr=0.0.0.0

--- a/roles/geth/defaults/main.yaml
+++ b/roles/geth/defaults/main.yaml
@@ -16,7 +16,7 @@ geth_container_ports:
   - "127.0.0.1:{{ geth_ports_http_rpc }}:{{ geth_ports_http_rpc }}"
   - "127.0.0.1:{{ geth_ports_engine }}:{{ geth_ports_engine }}"
   - "{{ geth_ports_p2p }}:{{ geth_ports_p2p }}"
-  - "{{ geth_ports_p2p }}:{{ geth_ports_p2p}}/udp"
+  - "{{ geth_ports_p2p }}:{{ geth_ports_p2p }}/udp"
 geth_container_volumes:
   - "{{ geth_datadir }}:/data"
   - "{{ geth_auth_jwt_path }}:/execution-auth.jwt:ro"

--- a/roles/geth/defaults/main.yaml
+++ b/roles/geth/defaults/main.yaml
@@ -10,7 +10,7 @@ geth_ports_engine: 8551
 geth_ports_metrics: 6060
 
 geth_container_name: geth
-geth_container_image: ethereum/client-go:v1.10.26
+geth_container_image: ethereum/client-go:stable
 geth_container_env: {}
 geth_container_ports:
   - "127.0.0.1:{{ geth_ports_http_rpc }}:{{ geth_ports_http_rpc }}"

--- a/roles/geth/tasks/cleanup.yaml
+++ b/roles/geth/tasks/cleanup.yaml
@@ -1,0 +1,4 @@
+- name: Remove geth container
+  community.docker.docker_container:
+    name: "{{ geth_container_name }}"
+    state: absent

--- a/roles/geth/tasks/main.yaml
+++ b/roles/geth/tasks/main.yaml
@@ -1,26 +1,7 @@
-- name: Add geth user
-  ansible.builtin.user:
-    name: "{{ geth_user }}"
-  register: geth_user_meta
+- name: Setup geth
+  ansible.builtin.import_tasks: setup.yaml
+  when: not geth_cleanup
 
-- name: Create data dir
-  ansible.builtin.file:
-    path: "{{ geth_datadir }}"
-    state: directory
-    recurse: true
-    owner: "{{ geth_user }}"
-    group: "{{ geth_user }}"
-
-- name: Run geth container
-  community.docker.docker_container:
-    name: "{{ geth_container_name }}"
-    image: "{{ geth_container_image }}"
-    state: started
-    restart_policy: always
-    stop_timeout: "{{ geth_container_stop_timeout }}"
-    ports: "{{ geth_container_ports }}"
-    volumes: "{{ geth_container_volumes }}"
-    env: "{{ geth_container_env }}"
-    networks: "{{ geth_container_networks }}"
-    command: "{{ geth_container_command }} "
-    user: "{{ geth_user_meta.uid }}"
+- name: Cleanup geth
+  ansible.builtin.import_tasks: cleanup.yaml
+  when: geth_cleanup

--- a/roles/geth/tasks/setup.yaml
+++ b/roles/geth/tasks/setup.yaml
@@ -1,0 +1,26 @@
+- name: Add geth user
+  ansible.builtin.user:
+    name: "{{ geth_user }}"
+  register: geth_user_meta
+
+- name: Create data dir
+  ansible.builtin.file:
+    path: "{{ geth_datadir }}"
+    state: directory
+    recurse: true
+    owner: "{{ geth_user }}"
+    group: "{{ geth_user }}"
+
+- name: Run geth container
+  community.docker.docker_container:
+    name: "{{ geth_container_name }}"
+    image: "{{ geth_container_image }}"
+    state: started
+    restart_policy: always
+    stop_timeout: "{{ geth_container_stop_timeout }}"
+    ports: "{{ geth_container_ports }}"
+    volumes: "{{ geth_container_volumes }}"
+    env: "{{ geth_container_env }}"
+    networks: "{{ geth_container_networks }}"
+    command: "{{ geth_container_command }} "
+    user: "{{ geth_user_meta.uid }}"

--- a/roles/geth/tasks/setup.yaml
+++ b/roles/geth/tasks/setup.yaml
@@ -22,5 +22,5 @@
     volumes: "{{ geth_container_volumes }}"
     env: "{{ geth_container_env }}"
     networks: "{{ geth_container_networks }}"
-    command: "{{ geth_container_command }} "
+    command: "{{ geth_container_command + geth_container_command_extra_args }}"
     user: "{{ geth_user_meta.uid }}"

--- a/roles/lighthouse/README.md
+++ b/roles/lighthouse/README.md
@@ -1,0 +1,39 @@
+# ethpandaops.general.lighthouse
+
+Setup [lighthouse](https://github.com/sigp/lighthouse), a ethereum consensus layer client.
+
+## Requirements
+
+You'll need docker on the target system. Make sure to install it upfront.
+
+## Role Variables
+
+Default variables are defined in [defaults/main.yaml](defaults/main.yaml)
+
+## Dependencies
+
+You'll need docker to run this role. One way of installing docker could be via ansible galaxy with the following dependencies set within `requirements.yaml`:
+
+```yaml
+roles:
+- src: geerlingguy.docker
+  version: latest
+- src: geerlingguy.pip
+  version: latest
+```
+
+## Example Playbook
+
+Your playbook could look like this:
+
+```yaml
+- hosts: localhost
+  become: true
+  roles:
+  - role: geerlingguy.docker
+  - role: geerlingguy.pip
+    pip_install_packages:
+    - name: docker
+  - role: ethpandaops.general.geth
+  - role: ethpandaops.general.lighthouse
+```

--- a/roles/lighthouse/defaults/main.yaml
+++ b/roles/lighthouse/defaults/main.yaml
@@ -11,7 +11,7 @@ lighthouse_ports_http_beacon: 5052
 lighthouse_ports_metrics: 5054
 
 lighthouse_container_name: lighthouse
-lighthouse_container_image: sigp/lighthouse:v3.4.0
+lighthouse_container_image: sigp/lighthouse:latest
 lighthouse_container_env: {}
 lighthouse_container_ports:
   - "127.0.0.1:{{ lighthouse_ports_http_beacon }}:{{ lighthouse_ports_http_beacon }}"

--- a/roles/lighthouse/defaults/main.yaml
+++ b/roles/lighthouse/defaults/main.yaml
@@ -3,35 +3,44 @@ lighthouse_datadir: /data/lighthouse
 lighthouse_auth_jwt_path: /data/execution-auth.secret
 lighthouse_execution_engine_endpoint: http://geth:8551
 
+lighthouse_cleanup: false # when set to "true" it will remove the container
+
+lighthouse_ports_p2p_tcp: 9000
+lighthouse_ports_p2p_udp: 9000
+lighthouse_ports_http_beacon: 5052
+lighthouse_ports_metrics: 5054
+
 lighthouse_container_name: lighthouse
 lighthouse_container_image: sigp/lighthouse:v3.4.0
 lighthouse_container_env: {}
 lighthouse_container_ports:
-  - "127.0.0.1:5052:5052"
-  - "9000:9000"
-  - "9000:9000/udp"
+  - "127.0.0.1:{{ lighthouse_ports_http_beacon }}:{{ lighthouse_ports_http_beacon }}"
+  - "{{ lighthouse_ports_p2p_tcp }}:{{ lighthouse_ports_p2p_tcp }}"
+  - "{{ lighthouse_ports_p2p_udp }}:{{ lighthouse_ports_p2p_udp }}/udp"
 lighthouse_container_volumes:
   - "{{ lighthouse_datadir }}:/data"
   - "{{ lighthouse_auth_jwt_path }}:/execution-auth.jwt:ro"
 lighthouse_container_stop_timeout: "300"
 lighthouse_container_networks: []
 lighthouse_container_command:
+  - lighthouse
+  - beacon_node
   - --datadir=/data
   - --disable-upnp
   - --disable-enr-auto-update
   - --enr-address={{ ansible_host }}
-  - --enr-tcp-port=9000
-  - --enr-udp-port=9000
+  - --enr-tcp-port={{ lighthouse_ports_p2p_tcp }}
+  - --enr-udp-port={{ lighthouse_ports_p2p_udp }}
   - --listen-address=0.0.0.0
-  - --port=9000
-  - --discovery-port=9000
+  - --port={{ lighthouse_ports_p2p_tcp }}
+  - --discovery-port={{ lighthouse_ports_p2p_udp }}
   - --http
   - --http-address=0.0.0.0
-  - --http-port=5052
+  - --http-port={{ lighthouse_ports_http_beacon}}
   - --execution-jwt=/execution-auth.jwt
   - --execution-endpoint={{ lighthouse_execution_engine_endpoint }}
   - --metrics
   - --metrics-address=0.0.0.0
   - --metrics-allow-origin=*
-  - --metrics-port=5054
+  - --metrics-port={{ lighthouse_ports_metrics}}
   # - --checkpoint-sync-url=http://your-other-node

--- a/roles/lighthouse/defaults/main.yaml
+++ b/roles/lighthouse/defaults/main.yaml
@@ -29,6 +29,7 @@ lighthouse_container_command:
   - --http-address=0.0.0.0
   - --http-port=5052
   - --execution-jwt=/execution-auth.jwt
+  - --execution-endpoint={{ lighthouse_execution_engine_endpoint }}
   - --metrics
   - --metrics-address=0.0.0.0
   - --metrics-allow-origin=*

--- a/roles/lighthouse/defaults/main.yaml
+++ b/roles/lighthouse/defaults/main.yaml
@@ -43,4 +43,5 @@ lighthouse_container_command:
   - --metrics-address=0.0.0.0
   - --metrics-allow-origin=*
   - --metrics-port={{ lighthouse_ports_metrics}}
+lighthouse_container_command_extra_args: []
   # - --checkpoint-sync-url=http://your-other-node

--- a/roles/lighthouse/defaults/main.yaml
+++ b/roles/lighthouse/defaults/main.yaml
@@ -1,0 +1,36 @@
+lighthouse_user: lighthouse
+lighthouse_datadir: /data/lighthouse
+lighthouse_auth_jwt_path: /data/execution-auth.secret
+lighthouse_execution_engine_endpoint: http://geth:8551
+
+lighthouse_container_name: lighthouse
+lighthouse_container_image: sigp/lighthouse:v3.4.0
+lighthouse_container_env: {}
+lighthouse_container_ports:
+  - "127.0.0.1:5052:5052"
+  - "9000:9000"
+  - "9000:9000/udp"
+lighthouse_container_volumes:
+  - "{{ lighthouse_datadir }}:/data"
+  - "{{ lighthouse_auth_jwt_path }}:/execution-auth.jwt:ro"
+lighthouse_container_stop_timeout: "300"
+lighthouse_container_networks: []
+lighthouse_container_command:
+  - --datadir=/data
+  - --disable-upnp
+  - --disable-enr-auto-update
+  - --enr-address={{ ansible_host }}
+  - --enr-tcp-port=9000
+  - --enr-udp-port=9000
+  - --listen-address=0.0.0.0
+  - --port=9000
+  - --discovery-port=9000
+  - --http
+  - --http-address=0.0.0.0
+  - --http-port=5052
+  - --execution-jwt=/execution-auth.jwt
+  - --metrics
+  - --metrics-address=0.0.0.0
+  - --metrics-allow-origin=*
+  - --metrics-port=5054
+  # - --checkpoint-sync-url=http://your-other-node

--- a/roles/lighthouse/defaults/main.yaml
+++ b/roles/lighthouse/defaults/main.yaml
@@ -36,12 +36,12 @@ lighthouse_container_command:
   - --discovery-port={{ lighthouse_ports_p2p_udp }}
   - --http
   - --http-address=0.0.0.0
-  - --http-port={{ lighthouse_ports_http_beacon}}
+  - --http-port={{ lighthouse_ports_http_beacon }}
   - --execution-jwt=/execution-auth.jwt
   - --execution-endpoint={{ lighthouse_execution_engine_endpoint }}
   - --metrics
   - --metrics-address=0.0.0.0
   - --metrics-allow-origin=*
-  - --metrics-port={{ lighthouse_ports_metrics}}
+  - --metrics-port={{ lighthouse_ports_metrics }}
 lighthouse_container_command_extra_args: []
   # - --checkpoint-sync-url=http://your-other-node

--- a/roles/lighthouse/meta/main.yaml
+++ b/roles/lighthouse/meta/main.yaml
@@ -1,0 +1,4 @@
+dependencies:
+  - role: ethpandaops.general.ethereum_auth_jwt
+    vars:
+      ethereum_auth_jwt_path: "{{ lighthouse_auth_jwt_path }}"

--- a/roles/lighthouse/tasks/cleanup.yaml
+++ b/roles/lighthouse/tasks/cleanup.yaml
@@ -1,0 +1,5 @@
+- name: Remove lighthouse container
+  community.docker.docker_container:
+    name: "{{ lighthouse_container_name }}"
+    state: absent
+  when: lighthouse_cleanup

--- a/roles/lighthouse/tasks/main.yaml
+++ b/roles/lighthouse/tasks/main.yaml
@@ -1,26 +1,7 @@
-- name: Add lighthouse user
-  ansible.builtin.user:
-    name: "{{ lighthouse_user }}"
-  register: lighthouse_user_meta
+- name: Setup lighthouse
+  ansible.builtin.import_tasks: setup.yaml
+  when: not lighthouse_cleanup
 
-- name: Create data dir
-  ansible.builtin.file:
-    path: "{{ lighthouse_datadir }}"
-    state: directory
-    recurse: true
-    owner: "{{ lighthouse_user }}"
-    group: "{{ lighthouse_user }}"
-
-- name: Run lighthouse container
-  community.docker.docker_container:
-    name: "{{ lighthouse_container_name }}"
-    image: "{{ lighthouse_container_image }}"
-    state: started
-    restart_policy: always
-    stop_timeout: "{{ lighthouse_container_stop_timeout }}"
-    ports: "{{ lighthouse_container_ports }}"
-    volumes: "{{ lighthouse_container_volumes }}"
-    env: "{{ lighthouse_container_env }}"
-    networks: "{{ lighthouse_container_networks }}"
-    command: "{{ lighthouse_container_command }} "
-    user: "{{ lighthouse_user_meta.uid }}"
+- name: Cleanup lighthouse
+  ansible.builtin.import_tasks: cleanup.yaml
+  when: lighthouse_cleanup

--- a/roles/lighthouse/tasks/main.yaml
+++ b/roles/lighthouse/tasks/main.yaml
@@ -1,0 +1,26 @@
+- name: Add lighthouse user
+  ansible.builtin.user:
+    name: "{{ lighthouse_user }}"
+  register: lighthouse_user_meta
+
+- name: Create data dir
+  ansible.builtin.file:
+    path: "{{ lighthouse_datadir }}"
+    state: directory
+    recurse: true
+    owner: "{{ lighthouse_user }}"
+    group: "{{ lighthouse_user }}"
+
+- name: Run lighthouse container
+  community.docker.docker_container:
+    name: "{{ lighthouse_container_name }}"
+    image: "{{ lighthouse_container_image }}"
+    state: started
+    restart_policy: always
+    stop_timeout: "{{ lighthouse_container_stop_timeout }}"
+    ports: "{{ lighthouse_container_ports }}"
+    volumes: "{{ lighthouse_container_volumes }}"
+    env: "{{ lighthouse_container_env }}"
+    networks: "{{ lighthouse_container_networks }}"
+    command: "{{ lighthouse_container_command }} "
+    user: "{{ lighthouse_user_meta.uid }}"

--- a/roles/lighthouse/tasks/setup.yaml
+++ b/roles/lighthouse/tasks/setup.yaml
@@ -22,5 +22,5 @@
     volumes: "{{ lighthouse_container_volumes }}"
     env: "{{ lighthouse_container_env }}"
     networks: "{{ lighthouse_container_networks }}"
-    command: "{{ lighthouse_container_command }} "
+    command: "{{ lighthouse_container_command + lighthouse_container_command_extra_args }} "
     user: "{{ lighthouse_user_meta.uid }}"

--- a/roles/lighthouse/tasks/setup.yaml
+++ b/roles/lighthouse/tasks/setup.yaml
@@ -1,0 +1,26 @@
+- name: Add lighthouse user
+  ansible.builtin.user:
+    name: "{{ lighthouse_user }}"
+  register: lighthouse_user_meta
+
+- name: Create data dir
+  ansible.builtin.file:
+    path: "{{ lighthouse_datadir }}"
+    state: directory
+    recurse: true
+    owner: "{{ lighthouse_user }}"
+    group: "{{ lighthouse_user }}"
+
+- name: Run lighthouse container
+  community.docker.docker_container:
+    name: "{{ lighthouse_container_name }}"
+    image: "{{ lighthouse_container_image }}"
+    state: started
+    restart_policy: always
+    stop_timeout: "{{ lighthouse_container_stop_timeout }}"
+    ports: "{{ lighthouse_container_ports }}"
+    volumes: "{{ lighthouse_container_volumes }}"
+    env: "{{ lighthouse_container_env }}"
+    networks: "{{ lighthouse_container_networks }}"
+    command: "{{ lighthouse_container_command }} "
+    user: "{{ lighthouse_user_meta.uid }}"

--- a/roles/lodestar/README.md
+++ b/roles/lodestar/README.md
@@ -1,0 +1,39 @@
+# ethpandaops.general.lodestar
+
+Setup [lodestar](https://github.com/ChainSafe/lodestar), a ethereum consensus layer client.
+
+## Requirements
+
+You'll need docker on the target system. Make sure to install it upfront.
+
+## Role Variables
+
+Default variables are defined in [defaults/main.yaml](defaults/main.yaml)
+
+## Dependencies
+
+You'll need docker to run this role. One way of installing docker could be via ansible galaxy with the following dependencies set within `requirements.yaml`:
+
+```yaml
+roles:
+- src: geerlingguy.docker
+  version: latest
+- src: geerlingguy.pip
+  version: latest
+```
+
+## Example Playbook
+
+Your playbook could look like this:
+
+```yaml
+- hosts: localhost
+  become: true
+  roles:
+  - role: geerlingguy.docker
+  - role: geerlingguy.pip
+    pip_install_packages:
+    - name: docker
+  - role: ethpandaops.general.geth
+  - role: ethpandaops.general.lodestar
+```

--- a/roles/lodestar/defaults/main.yaml
+++ b/roles/lodestar/defaults/main.yaml
@@ -23,20 +23,20 @@ lodestar_container_volumes:
 lodestar_container_stop_timeout: "300"
 lodestar_container_networks: []
 lodestar_container_command:
-  -  beacon
-  -  --dataDir=/data
-  -  --discv5
-  -  --listenAddress=0.0.0.0
-  -  --port={{ lodestar_ports_p2p_tcp }}
-  -  --enr.ip={{ ansible_host }}
-  -  --enr.tcp={{ lodestar_ports_p2p_tcp }}
-  -  --enr.udp={{ lodestar_ports_p2p_udp }}
-  -  --rest
-  -  --rest.address=0.0.0.0
-  -  --rest.port={{ lodestar_ports_http_beacon }}
-  -  --jwt-secret=/execution-auth.jwt
-  -  --execution.urls={{ lodestar_execution_engine_endpoint }}
-  -  --metrics
-  -  --metrics.address=0.0.0.0
-  -  --metrics.port={{ lodestar_ports_metrics }}
+  - beacon
+  - --dataDir=/data
+  - --discv5
+  - --listenAddress=0.0.0.0
+  - --port={{ lodestar_ports_p2p_tcp }}
+  - --enr.ip={{ ansible_host }}
+  - --enr.tcp={{ lodestar_ports_p2p_tcp }}
+  - --enr.udp={{ lodestar_ports_p2p_udp }}
+  - --rest
+  - --rest.address=0.0.0.0
+  - --rest.port={{ lodestar_ports_http_beacon }}
+  - --jwt-secret=/execution-auth.jwt
+  - --execution.urls={{ lodestar_execution_engine_endpoint }}
+  - --metrics
+  - --metrics.address=0.0.0.0
+  - --metrics.port={{ lodestar_ports_metrics }}
 # - --checkpointSyncUrl=http://your-other-node

--- a/roles/lodestar/defaults/main.yaml
+++ b/roles/lodestar/defaults/main.yaml
@@ -1,0 +1,34 @@
+lodestar_user: lodestar
+lodestar_datadir: /data/lodestar
+lodestar_auth_jwt_path: /data/execution-auth.secret
+lodestar_execution_engine_endpoint: http://geth:8551
+
+lodestar_container_name: lodestar
+lodestar_container_image: chainsafe/lodestar:v1.3.0
+lodestar_container_env: {}
+lodestar_container_ports:
+  - "127.0.0.1:9596:9596"
+  - "9000:9000"
+  - "9000:9000/udp"
+lodestar_container_volumes:
+  - "{{ lodestar_datadir }}:/data"
+  - "{{ lodestar_auth_jwt_path }}:/execution-auth.jwt:ro"
+lodestar_container_stop_timeout: "300"
+lodestar_container_networks: []
+lodestar_container_command:
+  -  beacon
+  -  --dataDir=/data
+  -  --discv5
+  -  --listenAddress=0.0.0.0
+  -  --port=9000
+  -  --enr.ip={{ ansible_host }}
+  -  --enr.tcp=9000
+  -  --enr.udp=9000
+  -  --rest
+  -  --rest.address=0.0.0.0
+  -  --rest.port=9596
+  -  --jwt-secret=/execution-auth.jwt
+  -  --metrics
+  -  --metrics.address=0.0.0.0
+  -  --metrics.port=8008
+# - --checkpointSyncUrl=http://your-other-node

--- a/roles/lodestar/defaults/main.yaml
+++ b/roles/lodestar/defaults/main.yaml
@@ -3,13 +3,20 @@ lodestar_datadir: /data/lodestar
 lodestar_auth_jwt_path: /data/execution-auth.secret
 lodestar_execution_engine_endpoint: http://geth:8551
 
+lodestar_cleanup: false # when set to "true" it will remove the container
+
+lodestar_ports_p2p_tcp: 9000
+lodestar_ports_p2p_udp: 9000
+lodestar_ports_http_beacon: 9596
+lodestar_ports_metrics: 8008
+
 lodestar_container_name: lodestar
 lodestar_container_image: chainsafe/lodestar:v1.3.0
 lodestar_container_env: {}
 lodestar_container_ports:
-  - "127.0.0.1:9596:9596"
-  - "9000:9000"
-  - "9000:9000/udp"
+  - "127.0.0.1:{{ lodestar_ports_http_beacon }}:{{ lodestar_ports_http_beacon }}"
+  - "{{ lodestar_ports_p2p_tcp }}:{{ lodestar_ports_p2p_tcp }}"
+  - "{{ lodestar_ports_p2p_udp }}:{{ lodestar_ports_p2p_udp }}/udp"
 lodestar_container_volumes:
   - "{{ lodestar_datadir }}:/data"
   - "{{ lodestar_auth_jwt_path }}:/execution-auth.jwt:ro"
@@ -20,15 +27,16 @@ lodestar_container_command:
   -  --dataDir=/data
   -  --discv5
   -  --listenAddress=0.0.0.0
-  -  --port=9000
+  -  --port={{ lodestar_ports_p2p_tcp }}
   -  --enr.ip={{ ansible_host }}
-  -  --enr.tcp=9000
-  -  --enr.udp=9000
+  -  --enr.tcp={{ lodestar_ports_p2p_tcp }}
+  -  --enr.udp={{ lodestar_ports_p2p_udp }}
   -  --rest
   -  --rest.address=0.0.0.0
-  -  --rest.port=9596
+  -  --rest.port={{ lodestar_ports_http_beacon }}
   -  --jwt-secret=/execution-auth.jwt
+  -  --execution.urls={{ lodestar_execution_engine_endpoint }}
   -  --metrics
   -  --metrics.address=0.0.0.0
-  -  --metrics.port=8008
+  -  --metrics.port={{ lodestar_ports_metrics }}
 # - --checkpointSyncUrl=http://your-other-node

--- a/roles/lodestar/defaults/main.yaml
+++ b/roles/lodestar/defaults/main.yaml
@@ -11,7 +11,7 @@ lodestar_ports_http_beacon: 9596
 lodestar_ports_metrics: 8008
 
 lodestar_container_name: lodestar
-lodestar_container_image: chainsafe/lodestar:v1.3.0
+lodestar_container_image: chainsafe/lodestar:latest
 lodestar_container_env: {}
 lodestar_container_ports:
   - "127.0.0.1:{{ lodestar_ports_http_beacon }}:{{ lodestar_ports_http_beacon }}"

--- a/roles/lodestar/defaults/main.yaml
+++ b/roles/lodestar/defaults/main.yaml
@@ -39,4 +39,5 @@ lodestar_container_command:
   - --metrics
   - --metrics.address=0.0.0.0
   - --metrics.port={{ lodestar_ports_metrics }}
+lodestar_container_command_extra_args: []
 # - --checkpointSyncUrl=http://your-other-node

--- a/roles/lodestar/meta/main.yaml
+++ b/roles/lodestar/meta/main.yaml
@@ -1,0 +1,4 @@
+dependencies:
+  - role: ethpandaops.general.ethereum_auth_jwt
+    vars:
+      ethereum_auth_jwt_path: "{{ lodestar_auth_jwt_path }}"

--- a/roles/lodestar/tasks/cleanup.yaml
+++ b/roles/lodestar/tasks/cleanup.yaml
@@ -1,0 +1,5 @@
+- name: Remove lodestar container
+  community.docker.docker_container:
+    name: "{{ lodestar_container_name }}"
+    state: absent
+  when: lodestar_cleanup

--- a/roles/lodestar/tasks/main.yaml
+++ b/roles/lodestar/tasks/main.yaml
@@ -1,26 +1,7 @@
-- name: Add lodestar user
-  ansible.builtin.user:
-    name: "{{ lodestar_user }}"
-  register: lodestar_user_meta
+- name: Setup lodestar
+  ansible.builtin.import_tasks: setup.yaml
+  when: not lodestar_cleanup
 
-- name: Create data dir
-  ansible.builtin.file:
-    path: "{{ lodestar_datadir }}"
-    state: directory
-    recurse: true
-    owner: "{{ lodestar_user }}"
-    group: "{{ lodestar_user }}"
-
-- name: Run lodestar container
-  community.docker.docker_container:
-    name: "{{ lodestar_container_name }}"
-    image: "{{ lodestar_container_image }}"
-    state: started
-    restart_policy: always
-    stop_timeout: "{{ lodestar_container_stop_timeout }}"
-    ports: "{{ lodestar_container_ports }}"
-    volumes: "{{ lodestar_container_volumes }}"
-    env: "{{ lodestar_container_env }}"
-    networks: "{{ lodestar_container_networks }}"
-    command: "{{ lodestar_container_command }} "
-    user: "{{ lodestar_user_meta.uid }}"
+- name: Cleanup lodestar
+  ansible.builtin.import_tasks: cleanup.yaml
+  when: lodestar_cleanup

--- a/roles/lodestar/tasks/main.yaml
+++ b/roles/lodestar/tasks/main.yaml
@@ -1,0 +1,26 @@
+- name: Add lodestar user
+  ansible.builtin.user:
+    name: "{{ lodestar_user }}"
+  register: lodestar_user_meta
+
+- name: Create data dir
+  ansible.builtin.file:
+    path: "{{ lodestar_datadir }}"
+    state: directory
+    recurse: true
+    owner: "{{ lodestar_user }}"
+    group: "{{ lodestar_user }}"
+
+- name: Run lodestar container
+  community.docker.docker_container:
+    name: "{{ lodestar_container_name }}"
+    image: "{{ lodestar_container_image }}"
+    state: started
+    restart_policy: always
+    stop_timeout: "{{ lodestar_container_stop_timeout }}"
+    ports: "{{ lodestar_container_ports }}"
+    volumes: "{{ lodestar_container_volumes }}"
+    env: "{{ lodestar_container_env }}"
+    networks: "{{ lodestar_container_networks }}"
+    command: "{{ lodestar_container_command }} "
+    user: "{{ lodestar_user_meta.uid }}"

--- a/roles/lodestar/tasks/setup.yaml
+++ b/roles/lodestar/tasks/setup.yaml
@@ -1,0 +1,26 @@
+- name: Add lodestar user
+  ansible.builtin.user:
+    name: "{{ lodestar_user }}"
+  register: lodestar_user_meta
+
+- name: Create data dir
+  ansible.builtin.file:
+    path: "{{ lodestar_datadir }}"
+    state: directory
+    recurse: true
+    owner: "{{ lodestar_user }}"
+    group: "{{ lodestar_user }}"
+
+- name: Run lodestar container
+  community.docker.docker_container:
+    name: "{{ lodestar_container_name }}"
+    image: "{{ lodestar_container_image }}"
+    state: started
+    restart_policy: always
+    stop_timeout: "{{ lodestar_container_stop_timeout }}"
+    ports: "{{ lodestar_container_ports }}"
+    volumes: "{{ lodestar_container_volumes }}"
+    env: "{{ lodestar_container_env }}"
+    networks: "{{ lodestar_container_networks }}"
+    command: "{{ lodestar_container_command }} "
+    user: "{{ lodestar_user_meta.uid }}"

--- a/roles/nethermind/README.md
+++ b/roles/nethermind/README.md
@@ -1,0 +1,39 @@
+# ethpandaops.general.nethermind
+
+Setup [nethermind](https://github.com/NethermindEth/nethermind), a ethereum execution layer client.
+
+## Requirements
+
+You'll need docker on the target system. Make sure to install it upfront.
+
+## Role Variables
+
+Default variables are defined in [defaults/main.yaml](defaults/main.yaml)
+
+## Dependencies
+
+You'll need docker to run this role. One way of installing docker could be via ansible galaxy with the following dependencies set within `requirements.yaml`:
+
+```yaml
+roles:
+- src: geerlingguy.docker
+  version: latest
+- src: geerlingguy.pip
+  version: latest
+```
+
+## Example Playbook
+
+Your playbook could look like this:
+
+```yaml
+- hosts: localhost
+  become: true
+  roles:
+  - role: geerlingguy.docker
+  - role: geerlingguy.pip
+    pip_install_packages:
+    - name: docker
+  - role: ethpandaops.general.nethermind
+  - role: ethpandaops.general.teku
+```

--- a/roles/nethermind/defaults/main.yaml
+++ b/roles/nethermind/defaults/main.yaml
@@ -2,32 +2,42 @@ nethermind_user: nethermind
 nethermind_datadir: /data/nethermind
 nethermind_auth_jwt_path: /data/execution-auth.secret
 
+nethermind_cleanup: false # when set to "true" it will remove the container
+
+nethermind_ports_p2p: 30303
+nethermind_ports_http_rpc: 8545
+nethermind_ports_engine: 8551
+nethermind_ports_monitoring: 6060
+
 nethermind_container_name: nethermind
 nethermind_container_image: nethermind/nethermind:1.15.0
 nethermind_container_env: {}
 nethermind_container_ports:
-  - "127.0.0.1:8545:8545"
-  - "127.0.0.1:8551:8551"
-  - "30303:30303"
+  - "127.0.0.1:{{ nethermind_ports_http_rpc }}:{{ nethermind_ports_http_rpc }}"
+  - "127.0.0.1:{{ nethermind_ports_engine }}:{{ nethermind_ports_engine }}"
+  - "{{ nethermind_ports_p2p }}:{{ nethermind_ports_p2p }}"
+  - "{{ nethermind_ports_p2p }}:{{ nethermind_ports_p2p }}/udp"
 nethermind_container_volumes:
   - "{{ nethermind_datadir }}:/data"
   - "{{ nethermind_auth_jwt_path }}:/execution-auth.jwt:ro"
 nethermind_container_stop_timeout: "300"
 nethermind_container_networks: []
+nethermind_container_entrypoint:
+  - /nethermind/Nethermind.Runner
 nethermind_container_command:
-  --datadir=/data
-  --KeyStore.KeyStoreDirectory=/data/keystore
-  --Network.ExternalIp={{ ansible_host }}
-  --Network.P2PPort=30303
-  --Network.DiscoveryPort=30303
-  --JsonRpc.Enabled=true
-  --JsonRpc.Host=0.0.0.0
-  --JsonRpc.Port=8545
-  --Init.WebSocketsEnabled=true
-  --JsonRpc.WebSocketsPort=8545
-  --JsonRpc.JwtSecretFile=/execution-auth.jwt
-  --JsonRpc.EngineHost=0.0.0.0
-  --JsonRpc.EnginePort=8551
-  --Metrics.Enabled=true
-  --Metrics.NodeName={{ inventory_hostname_short }}
-  --Metrics.ExposePort=6060
+  - --datadir=/data
+  - --KeyStore.KeyStoreDirectory=/data/keystore
+  - --Network.ExternalIp={{ ansible_host }}
+  - --Network.P2PPort={{ nethermind_ports_p2p }}
+  - --Network.DiscoveryPort={{ nethermind_ports_p2p }}
+  - --JsonRpc.Enabled=true
+  - --JsonRpc.Host=0.0.0.0
+  - --JsonRpc.Port={{ nethermind_ports_http_rpc }}
+  - --Init.WebSocketsEnabled=true
+  - --JsonRpc.WebSocketsPort={{ nethermind_ports_http_rpc }}
+  - --JsonRpc.JwtSecretFile=/execution-auth.jwt
+  - --JsonRpc.EngineHost=0.0.0.0
+  - --JsonRpc.EnginePort={{ nethermind_ports_engine }}
+  - --Metrics.Enabled=true
+  - --Metrics.NodeName={{ inventory_hostname_short }}
+  - --Metrics.ExposePort={{ nethermind_ports_monitoring }}

--- a/roles/nethermind/defaults/main.yaml
+++ b/roles/nethermind/defaults/main.yaml
@@ -1,0 +1,33 @@
+nethermind_user: nethermind
+nethermind_datadir: /data/nethermind
+nethermind_auth_jwt_path: /data/execution-auth.secret
+
+nethermind_container_name: nethermind
+nethermind_container_image: nethermind/nethermind:1.15.0
+nethermind_container_env: {}
+nethermind_container_ports:
+  - "127.0.0.1:8545:8545"
+  - "127.0.0.1:8551:8551"
+  - "30303:30303"
+nethermind_container_volumes:
+  - "{{ nethermind_datadir }}:/data"
+  - "{{ nethermind_auth_jwt_path }}:/execution-auth.jwt:ro"
+nethermind_container_stop_timeout: "300"
+nethermind_container_networks: []
+nethermind_container_command:
+  --datadir=/data
+  --KeyStore.KeyStoreDirectory=/data/keystore
+  --Network.ExternalIp={{ ansible_host }}
+  --Network.P2PPort=30303
+  --Network.DiscoveryPort=30303
+  --JsonRpc.Enabled=true
+  --JsonRpc.Host=0.0.0.0
+  --JsonRpc.Port=8545
+  --Init.WebSocketsEnabled=true
+  --JsonRpc.WebSocketsPort=8545
+  --JsonRpc.JwtSecretFile=/execution-auth.jwt
+  --JsonRpc.EngineHost=0.0.0.0
+  --JsonRpc.EnginePort=8551
+  --Metrics.Enabled=true
+  --Metrics.NodeName={{ inventory_hostname_short }}
+  --Metrics.ExposePort=6060

--- a/roles/nethermind/defaults/main.yaml
+++ b/roles/nethermind/defaults/main.yaml
@@ -7,7 +7,7 @@ nethermind_cleanup: false # when set to "true" it will remove the container
 nethermind_ports_p2p: 30303
 nethermind_ports_http_rpc: 8545
 nethermind_ports_engine: 8551
-nethermind_ports_monitoring: 6060
+nethermind_ports_metrics: 6060
 
 nethermind_container_name: nethermind
 nethermind_container_image: nethermind/nethermind:1.15.0
@@ -40,5 +40,5 @@ nethermind_container_command:
   - --JsonRpc.EnginePort={{ nethermind_ports_engine }}
   - --Metrics.Enabled=true
   - --Metrics.NodeName={{ inventory_hostname_short }}
-  - --Metrics.ExposePort={{ nethermind_ports_monitoring }}
+  - --Metrics.ExposePort={{ nethermind_ports_metrics }}
 nethermind_container_command_extra_args: []

--- a/roles/nethermind/defaults/main.yaml
+++ b/roles/nethermind/defaults/main.yaml
@@ -41,3 +41,4 @@ nethermind_container_command:
   - --Metrics.Enabled=true
   - --Metrics.NodeName={{ inventory_hostname_short }}
   - --Metrics.ExposePort={{ nethermind_ports_monitoring }}
+nethermind_container_command_extra_args: []

--- a/roles/nethermind/defaults/main.yaml
+++ b/roles/nethermind/defaults/main.yaml
@@ -10,7 +10,7 @@ nethermind_ports_engine: 8551
 nethermind_ports_metrics: 6060
 
 nethermind_container_name: nethermind
-nethermind_container_image: nethermind/nethermind:1.15.0
+nethermind_container_image: nethermind/nethermind:latest
 nethermind_container_env: {}
 nethermind_container_ports:
   - "127.0.0.1:{{ nethermind_ports_http_rpc }}:{{ nethermind_ports_http_rpc }}"

--- a/roles/nethermind/meta/main.yaml
+++ b/roles/nethermind/meta/main.yaml
@@ -1,0 +1,4 @@
+dependencies:
+  - role: ethpandaops.general.ethereum_auth_jwt
+    vars:
+      ethereum_auth_jwt_path: "{{ nethermind_auth_jwt_path }}"

--- a/roles/nethermind/tasks/cleanup.yaml
+++ b/roles/nethermind/tasks/cleanup.yaml
@@ -1,0 +1,5 @@
+- name: Remove nethermind container
+  community.docker.docker_container:
+    name: "{{ nethermind_container_name }}"
+    state: absent
+  when: nethermind_cleanup

--- a/roles/nethermind/tasks/main.yaml
+++ b/roles/nethermind/tasks/main.yaml
@@ -1,26 +1,7 @@
-- name: Add nethermind user
-  ansible.builtin.user:
-    name: "{{ nethermind_user }}"
-  register: nethermind_user_meta
+- name: Setup nethermind
+  ansible.builtin.import_tasks: setup.yaml
+  when: not nethermind_cleanup
 
-- name: Create data dir
-  ansible.builtin.file:
-    path: "{{ nethermind_datadir }}"
-    state: directory
-    recurse: true
-    owner: "{{ nethermind_user }}"
-    group: "{{ nethermind_user }}"
-
-- name: Run nethermind container
-  community.docker.docker_container:
-    name: "{{ nethermind_container_name }}"
-    image: "{{ nethermind_container_image }}"
-    state: started
-    restart_policy: always
-    stop_timeout: "{{ nethermind_container_stop_timeout }}"
-    ports: "{{ nethermind_container_ports }}"
-    volumes: "{{ nethermind_container_volumes }}"
-    env: "{{ nethermind_container_env }}"
-    networks: "{{ nethermind_container_networks }}"
-    command: "{{ nethermind_container_command }} "
-    user: "{{ nethermind_user_meta.uid }}"
+- name: Cleanup nethermind
+  ansible.builtin.import_tasks: cleanup.yaml
+  when: nethermind_cleanup

--- a/roles/nethermind/tasks/main.yaml
+++ b/roles/nethermind/tasks/main.yaml
@@ -1,0 +1,26 @@
+- name: Add nethermind user
+  ansible.builtin.user:
+    name: "{{ nethermind_user }}"
+  register: nethermind_user_meta
+
+- name: Create data dir
+  ansible.builtin.file:
+    path: "{{ nethermind_datadir }}"
+    state: directory
+    recurse: true
+    owner: "{{ nethermind_user }}"
+    group: "{{ nethermind_user }}"
+
+- name: Run nethermind container
+  community.docker.docker_container:
+    name: "{{ nethermind_container_name }}"
+    image: "{{ nethermind_container_image }}"
+    state: started
+    restart_policy: always
+    stop_timeout: "{{ nethermind_container_stop_timeout }}"
+    ports: "{{ nethermind_container_ports }}"
+    volumes: "{{ nethermind_container_volumes }}"
+    env: "{{ nethermind_container_env }}"
+    networks: "{{ nethermind_container_networks }}"
+    command: "{{ nethermind_container_command }} "
+    user: "{{ nethermind_user_meta.uid }}"

--- a/roles/nethermind/tasks/setup.yaml
+++ b/roles/nethermind/tasks/setup.yaml
@@ -23,6 +23,6 @@
     env: "{{ nethermind_container_env }}"
     networks: "{{ nethermind_container_networks }}"
     entrypoint: "{{ nethermind_container_entrypoint }} "
-    command: "{{ nethermind_container_command }} "
+    command: "{{ nethermind_container_command + nethermind_container_command_extra_args}} "
     user: "{{ nethermind_user_meta.uid }}"
     working_dir: "{{ nethermind_datadir }}"

--- a/roles/nethermind/tasks/setup.yaml
+++ b/roles/nethermind/tasks/setup.yaml
@@ -23,6 +23,6 @@
     env: "{{ nethermind_container_env }}"
     networks: "{{ nethermind_container_networks }}"
     entrypoint: "{{ nethermind_container_entrypoint }} "
-    command: "{{ nethermind_container_command + nethermind_container_command_extra_args}} "
+    command: "{{ nethermind_container_command + nethermind_container_command_extra_args }} "
     user: "{{ nethermind_user_meta.uid }}"
     working_dir: "{{ nethermind_datadir }}"

--- a/roles/nethermind/tasks/setup.yaml
+++ b/roles/nethermind/tasks/setup.yaml
@@ -1,0 +1,28 @@
+- name: Add nethermind user
+  ansible.builtin.user:
+    name: "{{ nethermind_user }}"
+  register: nethermind_user_meta
+
+- name: Create data dir
+  ansible.builtin.file:
+    path: "{{ nethermind_datadir }}"
+    state: directory
+    recurse: true
+    owner: "{{ nethermind_user }}"
+    group: "{{ nethermind_user }}"
+
+- name: Run nethermind container
+  community.docker.docker_container:
+    name: "{{ nethermind_container_name }}"
+    image: "{{ nethermind_container_image }}"
+    state: started
+    restart_policy: always
+    stop_timeout: "{{ nethermind_container_stop_timeout }}"
+    ports: "{{ nethermind_container_ports }}"
+    volumes: "{{ nethermind_container_volumes }}"
+    env: "{{ nethermind_container_env }}"
+    networks: "{{ nethermind_container_networks }}"
+    entrypoint: "{{ nethermind_container_entrypoint }} "
+    command: "{{ nethermind_container_command }} "
+    user: "{{ nethermind_user_meta.uid }}"
+    working_dir: "{{ nethermind_datadir }}"

--- a/roles/nimbus/defaults/main.yaml
+++ b/roles/nimbus/defaults/main.yaml
@@ -11,7 +11,7 @@ nimbus_ports_http_beacon: 5051
 nimbus_ports_metrics: 8008
 
 nimbus_container_name: nimbus
-nimbus_container_image: statusim/nimbus-eth2:amd64-v22.11.1
+nimbus_container_image: statusim/nimbus-eth2:amd64-latest
 nimbus_container_env: {}
 nimbus_container_ports:
   - "127.0.0.1:{{ nimbus_ports_http_beacon }}:{{ nimbus_ports_http_beacon }}"

--- a/roles/nimbus/defaults/main.yaml
+++ b/roles/nimbus/defaults/main.yaml
@@ -3,13 +3,20 @@ nimbus_datadir: /data/nimbus
 nimbus_auth_jwt_path: /data/execution-auth.secret
 nimbus_execution_engine_endpoint: http://geth:8551
 
+nimbus_cleanup: false # when set to "true" it will remove the container
+
+nimbus_ports_p2p_tcp: 9000
+nimbus_ports_p2p_udp: 9000
+nimbus_ports_http_beacon: 5051
+nimbus_ports_metrics: 8008
+
 nimbus_container_name: nimbus
 nimbus_container_image: statusim/nimbus-eth2:amd64-v22.11.1
 nimbus_container_env: {}
 nimbus_container_ports:
-  - "127.0.0.1:5051:5051"
-  - "9000:9000"
-  - "9000:9000/udp"
+  - "127.0.0.1:{{ nimbus_ports_http_beacon }}:{{ nimbus_ports_http_beacon }}"
+  - "{{ nimbus_ports_p2p_tcp }}:{{ nimbus_ports_p2p_tcp }}"
+  - "{{ nimbus_ports_p2p_udp }}:{{ nimbus_ports_p2p_udp }}/udp"
 nimbus_container_volumes:
   - "{{ nimbus_datadir }}:/data"
   - "{{ nimbus_auth_jwt_path }}:/execution-auth.jwt:ro"
@@ -20,16 +27,16 @@ nimbus_container_command:
   - --data-dir=/data
   - --log-level=INFO
   - --listen-address=0.0.0.0
-  - --udp-port=9000
-  - --tcp-port=9000
-  - --nat="extip:{{ ansible_host }}"
+  - --udp-port={{ nimbus_ports_p2p_udp }}
+  - --tcp-port={{ nimbus_ports_p2p_tcp }}
+  - --nat=extip:{{ ansible_host }}
   - --enr-auto-update=false
   - --rest
-  - --rest-port=5051
+  - --rest-port={{ nimbus_ports_http_beacon }}
   - --rest-address=0.0.0.0
   - --rest-allow-origin="*"
   - --web3-url={{ nimbus_execution_engine_endpoint }}
   - --jwt-secret=/execution-auth.jwt
   - --metrics
-  - --metrics-port=8008
+  - --metrics-port={{ nimbus_ports_metrics }}
   - --metrics-address=0.0.0.0

--- a/roles/nimbus/defaults/main.yaml
+++ b/roles/nimbus/defaults/main.yaml
@@ -40,3 +40,4 @@ nimbus_container_command:
   - --metrics
   - --metrics-port={{ nimbus_ports_metrics }}
   - --metrics-address=0.0.0.0
+nimbus_container_command_extra_args: []

--- a/roles/nimbus/tasks/cleanup.yaml
+++ b/roles/nimbus/tasks/cleanup.yaml
@@ -1,0 +1,5 @@
+- name: Remove nimbus container
+  community.docker.docker_container:
+    name: "{{ nimbus_container_name }}"
+    state: absent
+  when: nimbus_cleanup

--- a/roles/nimbus/tasks/main.yaml
+++ b/roles/nimbus/tasks/main.yaml
@@ -1,27 +1,7 @@
-- name: Add nimbus user
-  ansible.builtin.user:
-    name: "{{ nimbus_user }}"
-  register: nimbus_user_meta
+- name: Setup nimbus
+  ansible.builtin.import_tasks: setup.yaml
+  when: not nimbus_cleanup
 
-- name: Create data dir
-  ansible.builtin.file:
-    path: "{{ nimbus_datadir }}"
-    state: directory
-    mode: '0700'
-    recurse: true
-    owner: "{{ nimbus_user }}"
-    group: "{{ nimbus_user }}"
-
-- name: Run nimbus container
-  community.docker.docker_container:
-    name: "{{ nimbus_container_name }}"
-    image: "{{ nimbus_container_image }}"
-    state: started
-    restart_policy: always
-    stop_timeout: "{{ nimbus_container_stop_timeout }}"
-    ports: "{{ nimbus_container_ports }}"
-    volumes: "{{ nimbus_container_volumes }}"
-    env: "{{ nimbus_container_env }}"
-    networks: "{{ nimbus_container_networks }}"
-    command: "{{ nimbus_container_command }} "
-    user: "{{ nimbus_user_meta.uid }}"
+- name: Cleanup nimbus
+  ansible.builtin.import_tasks: cleanup.yaml
+  when: nimbus_cleanup

--- a/roles/nimbus/tasks/setup.yaml
+++ b/roles/nimbus/tasks/setup.yaml
@@ -1,0 +1,27 @@
+- name: Add nimbus user
+  ansible.builtin.user:
+    name: "{{ nimbus_user }}"
+  register: nimbus_user_meta
+
+- name: Create data dir
+  ansible.builtin.file:
+    path: "{{ nimbus_datadir }}"
+    state: directory
+    mode: '0700'
+    recurse: true
+    owner: "{{ nimbus_user }}"
+    group: "{{ nimbus_user }}"
+
+- name: Run nimbus container
+  community.docker.docker_container:
+    name: "{{ nimbus_container_name }}"
+    image: "{{ nimbus_container_image }}"
+    state: started
+    restart_policy: always
+    stop_timeout: "{{ nimbus_container_stop_timeout }}"
+    ports: "{{ nimbus_container_ports }}"
+    volumes: "{{ nimbus_container_volumes }}"
+    env: "{{ nimbus_container_env }}"
+    networks: "{{ nimbus_container_networks }}"
+    command: "{{ nimbus_container_command }} "
+    user: "{{ nimbus_user_meta.uid }}"

--- a/roles/nimbus/tasks/setup.yaml
+++ b/roles/nimbus/tasks/setup.yaml
@@ -23,5 +23,5 @@
     volumes: "{{ nimbus_container_volumes }}"
     env: "{{ nimbus_container_env }}"
     networks: "{{ nimbus_container_networks }}"
-    command: "{{ nimbus_container_command }} "
+    command: "{{ nimbus_container_command + nimbus_container_command_extra_args }} "
     user: "{{ nimbus_user_meta.uid }}"

--- a/roles/prysm/README.md
+++ b/roles/prysm/README.md
@@ -1,0 +1,39 @@
+# ethpandaops.general.prysm
+
+Setup [prysm](https://github.com/prysmaticlabs/prysm), a ethereum consensus layer client.
+
+## Requirements
+
+You'll need docker on the target system. Make sure to install it upfront.
+
+## Role Variables
+
+Default variables are defined in [defaults/main.yaml](defaults/main.yaml)
+
+## Dependencies
+
+You'll need docker to run this role. One way of installing docker could be via ansible galaxy with the following dependencies set within `requirements.yaml`:
+
+```yaml
+roles:
+- src: geerlingguy.docker
+  version: latest
+- src: geerlingguy.pip
+  version: latest
+```
+
+## Example Playbook
+
+Your playbook could look like this:
+
+```yaml
+- hosts: localhost
+  become: true
+  roles:
+  - role: geerlingguy.docker
+  - role: geerlingguy.pip
+    pip_install_packages:
+    - name: docker
+  - role: ethpandaops.general.geth
+  - role: ethpandaops.general.prysm
+```

--- a/roles/prysm/defaults/main.yaml
+++ b/roles/prysm/defaults/main.yaml
@@ -1,0 +1,33 @@
+prysm_user: prysm
+prysm_datadir: /data/prysm
+prysm_auth_jwt_path: /data/execution-auth.secret
+prysm_execution_engine_endpoint: http://geth:8551
+
+prysm_container_name: prysm
+prysm_container_image: gcr.io/prysmaticlabs/prysm/beacon-chain:v3.2.0
+prysm_container_env: {}
+prysm_container_ports:
+  - "127.0.0.1:4000:4000"
+  - "13000:13000"
+  - "12000:12000/udp"
+prysm_container_volumes:
+  - "{{ prysm_datadir }}:/data"
+  - "{{ prysm_auth_jwt_path }}:/execution-auth.jwt:ro"
+prysm_container_stop_timeout: "300"
+prysm_container_networks: []
+prysm_container_command:
+  --accept-terms-of-use=true
+  --datadir=/data
+  --p2p-host-ip=$(POD_IP)
+  --p2p-tcp-port=13000
+  --p2p-udp-port=12000
+  --rpc-host=0.0.0.0
+  --rpc-port=4000
+  --jwt-secret=/execution-auth.jwt
+  --execution-endpoint={{ prysm_execution_engine_endpoint }}
+  --grpc-gateway-host=0.0.0.0
+  --grpc-gateway-port=3500
+  --monitoring-host=0.0.0.0
+  --monitoring-port=8080
+# - --checkpoint-sync-url=http://your-other-node
+# - --genesis-beacon-api-url=http://your-other-node

--- a/roles/prysm/defaults/main.yaml
+++ b/roles/prysm/defaults/main.yaml
@@ -12,7 +12,7 @@ prysm_ports_metrics: 8080
 prysm_ports_grpc: 3500
 
 prysm_container_name: prysm
-prysm_container_image: gcr.io/prysmaticlabs/prysm/beacon-chain:v3.2.0
+prysm_container_image: gcr.io/prysmaticlabs/prysm/beacon-chain:stable
 prysm_container_env: {}
 prysm_container_ports:
   - "127.0.0.1:{{ prysm_ports_http_beacon }}:{{ prysm_ports_http_beacon }}"

--- a/roles/prysm/defaults/main.yaml
+++ b/roles/prysm/defaults/main.yaml
@@ -37,5 +37,6 @@ prysm_container_command:
   - --grpc-gateway-port={{ prysm_ports_grpc }}
   - --monitoring-host=0.0.0.0
   - --monitoring-port={{ prysm_ports_metrics }}
+prysm_container_command_extra_args: []
 # - --checkpoint-sync-url=http://your-other-node
 # - --genesis-beacon-api-url=http://your-other-node

--- a/roles/prysm/defaults/main.yaml
+++ b/roles/prysm/defaults/main.yaml
@@ -16,18 +16,18 @@ prysm_container_volumes:
 prysm_container_stop_timeout: "300"
 prysm_container_networks: []
 prysm_container_command:
-  --accept-terms-of-use=true
-  --datadir=/data
-  --p2p-host-ip=$(POD_IP)
-  --p2p-tcp-port=13000
-  --p2p-udp-port=12000
-  --rpc-host=0.0.0.0
-  --rpc-port=4000
-  --jwt-secret=/execution-auth.jwt
-  --execution-endpoint={{ prysm_execution_engine_endpoint }}
-  --grpc-gateway-host=0.0.0.0
-  --grpc-gateway-port=3500
-  --monitoring-host=0.0.0.0
-  --monitoring-port=8080
+  - --accept-terms-of-use=true
+  - --datadir=/data
+  - --p2p-host-ip=$(POD_IP)
+  - --p2p-tcp-port=13000
+  - --p2p-udp-port=12000
+  - --rpc-host=0.0.0.0
+  - --rpc-port=4000
+  - --jwt-secret=/execution-auth.jwt
+  - --execution-endpoint={{ prysm_execution_engine_endpoint }}
+  - --grpc-gateway-host=0.0.0.0
+  - --grpc-gateway-port=3500
+  - --monitoring-host=0.0.0.0
+  - --monitoring-port=8080
 # - --checkpoint-sync-url=http://your-other-node
 # - --genesis-beacon-api-url=http://your-other-node

--- a/roles/prysm/defaults/main.yaml
+++ b/roles/prysm/defaults/main.yaml
@@ -18,7 +18,7 @@ prysm_container_networks: []
 prysm_container_command:
   - --accept-terms-of-use=true
   - --datadir=/data
-  - --p2p-host-ip=$(POD_IP)
+  - --p2p-host-ip={{ ansible_host }}
   - --p2p-tcp-port=13000
   - --p2p-udp-port=12000
   - --rpc-host=0.0.0.0

--- a/roles/prysm/defaults/main.yaml
+++ b/roles/prysm/defaults/main.yaml
@@ -3,13 +3,21 @@ prysm_datadir: /data/prysm
 prysm_auth_jwt_path: /data/execution-auth.secret
 prysm_execution_engine_endpoint: http://geth:8551
 
+prysm_cleanup: false # when set to "true" it will remove the container
+
+prysm_ports_p2p_tcp: 13000
+prysm_ports_p2p_udp: 12000
+prysm_ports_http_beacon: 4000
+prysm_ports_metrics: 8080
+prysm_ports_grpc: 3500
+
 prysm_container_name: prysm
 prysm_container_image: gcr.io/prysmaticlabs/prysm/beacon-chain:v3.2.0
 prysm_container_env: {}
 prysm_container_ports:
-  - "127.0.0.1:4000:4000"
-  - "13000:13000"
-  - "12000:12000/udp"
+  - "127.0.0.1:{{ prysm_ports_http_beacon }}:{{ prysm_ports_http_beacon }}"
+  - "{{ prysm_ports_p2p_tcp }}:{{ prysm_ports_p2p_tcp }}"
+  - "{{ prysm_ports_p2p_udp }}:{{ prysm_ports_p2p_udp }}/udp"
 prysm_container_volumes:
   - "{{ prysm_datadir }}:/data"
   - "{{ prysm_auth_jwt_path }}:/execution-auth.jwt:ro"
@@ -19,15 +27,15 @@ prysm_container_command:
   - --accept-terms-of-use=true
   - --datadir=/data
   - --p2p-host-ip={{ ansible_host }}
-  - --p2p-tcp-port=13000
-  - --p2p-udp-port=12000
+  - --p2p-tcp-port={{ prysm_ports_p2p_tcp }}
+  - --p2p-udp-port={{ prysm_ports_p2p_udp }}
   - --rpc-host=0.0.0.0
-  - --rpc-port=4000
+  - --rpc-port={{ prysm_ports_http_beacon }}
   - --jwt-secret=/execution-auth.jwt
   - --execution-endpoint={{ prysm_execution_engine_endpoint }}
   - --grpc-gateway-host=0.0.0.0
-  - --grpc-gateway-port=3500
+  - --grpc-gateway-port={{ prysm_ports_grpc }}
   - --monitoring-host=0.0.0.0
-  - --monitoring-port=8080
+  - --monitoring-port={{ prysm_ports_metrics }}
 # - --checkpoint-sync-url=http://your-other-node
 # - --genesis-beacon-api-url=http://your-other-node

--- a/roles/prysm/meta/main.yaml
+++ b/roles/prysm/meta/main.yaml
@@ -1,0 +1,4 @@
+dependencies:
+  - role: ethpandaops.general.ethereum_auth_jwt
+    vars:
+      ethereum_auth_jwt_path: "{{ prysm_auth_jwt_path }}"

--- a/roles/prysm/tasks/cleanup.yaml
+++ b/roles/prysm/tasks/cleanup.yaml
@@ -1,0 +1,5 @@
+- name: Remove prysm container
+  community.docker.docker_container:
+    name: "{{ prysm_container_name }}"
+    state: absent
+  when: prysm_cleanup

--- a/roles/prysm/tasks/main.yaml
+++ b/roles/prysm/tasks/main.yaml
@@ -1,26 +1,7 @@
-- name: Add prysm user
-  ansible.builtin.user:
-    name: "{{ prysm_user }}"
-  register: prysm_user_meta
+- name: Setup prysm
+  ansible.builtin.import_tasks: setup.yaml
+  when: not prysm_cleanup
 
-- name: Create data dir
-  ansible.builtin.file:
-    path: "{{ prysm_datadir }}"
-    state: directory
-    recurse: true
-    owner: "{{ prysm_user }}"
-    group: "{{ prysm_user }}"
-
-- name: Run prysm container
-  community.docker.docker_container:
-    name: "{{ prysm_container_name }}"
-    image: "{{ prysm_container_image }}"
-    state: started
-    restart_policy: always
-    stop_timeout: "{{ prysm_container_stop_timeout }}"
-    ports: "{{ prysm_container_ports }}"
-    volumes: "{{ prysm_container_volumes }}"
-    env: "{{ prysm_container_env }}"
-    networks: "{{ prysm_container_networks }}"
-    command: "{{ prysm_container_command }} "
-    user: "{{ prysm_user_meta.uid }}"
+- name: Cleanup prysm
+  ansible.builtin.import_tasks: cleanup.yaml
+  when: prysm_cleanup

--- a/roles/prysm/tasks/main.yaml
+++ b/roles/prysm/tasks/main.yaml
@@ -1,0 +1,26 @@
+- name: Add prysm user
+  ansible.builtin.user:
+    name: "{{ prysm_user }}"
+  register: prysm_user_meta
+
+- name: Create data dir
+  ansible.builtin.file:
+    path: "{{ prysm_datadir }}"
+    state: directory
+    recurse: true
+    owner: "{{ prysm_user }}"
+    group: "{{ prysm_user }}"
+
+- name: Run prysm container
+  community.docker.docker_container:
+    name: "{{ prysm_container_name }}"
+    image: "{{ prysm_container_image }}"
+    state: started
+    restart_policy: always
+    stop_timeout: "{{ prysm_container_stop_timeout }}"
+    ports: "{{ prysm_container_ports }}"
+    volumes: "{{ prysm_container_volumes }}"
+    env: "{{ prysm_container_env }}"
+    networks: "{{ prysm_container_networks }}"
+    command: "{{ prysm_container_command }} "
+    user: "{{ prysm_user_meta.uid }}"

--- a/roles/prysm/tasks/setup.yaml
+++ b/roles/prysm/tasks/setup.yaml
@@ -22,5 +22,5 @@
     volumes: "{{ prysm_container_volumes }}"
     env: "{{ prysm_container_env }}"
     networks: "{{ prysm_container_networks }}"
-    command: "{{ prysm_container_command }} "
+    command: "{{ prysm_container_command + prysm_container_command_extra_args }} "
     user: "{{ prysm_user_meta.uid }}"

--- a/roles/prysm/tasks/setup.yaml
+++ b/roles/prysm/tasks/setup.yaml
@@ -1,0 +1,26 @@
+- name: Add prysm user
+  ansible.builtin.user:
+    name: "{{ prysm_user }}"
+  register: prysm_user_meta
+
+- name: Create data dir
+  ansible.builtin.file:
+    path: "{{ prysm_datadir }}"
+    state: directory
+    recurse: true
+    owner: "{{ prysm_user }}"
+    group: "{{ prysm_user }}"
+
+- name: Run prysm container
+  community.docker.docker_container:
+    name: "{{ prysm_container_name }}"
+    image: "{{ prysm_container_image }}"
+    state: started
+    restart_policy: always
+    stop_timeout: "{{ prysm_container_stop_timeout }}"
+    ports: "{{ prysm_container_ports }}"
+    volumes: "{{ prysm_container_volumes }}"
+    env: "{{ prysm_container_env }}"
+    networks: "{{ prysm_container_networks }}"
+    command: "{{ prysm_container_command }} "
+    user: "{{ prysm_user_meta.uid }}"

--- a/roles/teku/defaults/main.yaml
+++ b/roles/teku/defaults/main.yaml
@@ -3,13 +3,20 @@ teku_datadir: /data/teku
 teku_auth_jwt_path: /data/execution-auth.secret
 teku_execution_engine_endpoint: http://geth:8551
 
+teku_cleanup: false # when set to "true" it will remove the container
+
+teku_ports_p2p_tcp: 9000
+teku_ports_p2p_udp: 9000
+teku_ports_http_beacon: 5051
+teku_ports_metrics: 8008
+
 teku_container_name: teku
 teku_container_image: consensys/teku:22.12.0
 teku_container_env: {}
 teku_container_ports:
-  - "127.0.0.1:5051:5051"
-  - "9000:9000"
-  - "9000:9000/udp"
+  - "127.0.0.1:{{ teku_ports_http_beacon }}:{{ teku_ports_http_beacon }}"
+  - "{{ teku_ports_p2p_tcp }}:{{ teku_ports_p2p_tcp }}"
+  - "{{ teku_ports_p2p_udp }}:{{ teku_ports_p2p_udp }}/udp"
 teku_container_volumes:
   - "{{ teku_datadir }}:/data"
   - "{{ teku_auth_jwt_path }}:/execution-auth.jwt:ro"
@@ -24,16 +31,16 @@ teku_container_command:
   - --p2p-enabled=true
   - --p2p-interface=0.0.0.0
   - --p2p-advertised-ip={{ ansible_host }}
-  - --p2p-port=9000
-  - --p2p-advertised-port=9000
+  - --p2p-port={{ teku_ports_p2p_tcp}}
+  - --p2p-advertised-port={{ teku_ports_p2p_udp }}
   - --rest-api-enabled
   - --rest-api-interface=0.0.0.0
-  - --rest-api-port=5051
+  - --rest-api-port={{ teku_ports_http_beacon }}
   - --rest-api-host-allowlist="*"
   - --ee-endpoint={{ teku_execution_engine_endpoint }}
   - --ee-jwt-secret-file=/execution-auth.jwt
   - --metrics-enabled=true
   - --metrics-interface=0.0.0.0
-  - --metrics-port=8008
+  - --metrics-port={{ teku_ports_metrics }}
   - --metrics-host-allowlist="*"
-  # - --initial-state=https://$USER_ID:$TOKEN@eth2-beacon-mainnet.infura.io/eth/v2/debug/beacon/states/finalized
+  # - --initial-state=http://your-other-node/eth/v2/debug/beacon/states/finalized

--- a/roles/teku/defaults/main.yaml
+++ b/roles/teku/defaults/main.yaml
@@ -28,7 +28,7 @@ teku_container_command:
   - --p2p-enabled=true
   - --p2p-interface=0.0.0.0
   - --p2p-advertised-ip={{ ansible_host }}
-  - --p2p-port={{ teku_ports_p2p_tcp}}
+  - --p2p-port={{ teku_ports_p2p_tcp }}
   - --p2p-advertised-port={{ teku_ports_p2p_udp }}
   - --rest-api-enabled
   - --rest-api-interface=0.0.0.0

--- a/roles/teku/defaults/main.yaml
+++ b/roles/teku/defaults/main.yaml
@@ -24,10 +24,7 @@ teku_container_stop_timeout: "300"
 teku_container_networks: []
 teku_container_command:
   - --data-path=/data
-  - --data-storage-mode=PRUNE
-  - --logging=INFO
   - --log-destination=CONSOLE
-  - --network=mainnet
   - --p2p-enabled=true
   - --p2p-interface=0.0.0.0
   - --p2p-advertised-ip={{ ansible_host }}
@@ -43,4 +40,8 @@ teku_container_command:
   - --metrics-interface=0.0.0.0
   - --metrics-port={{ teku_ports_metrics }}
   - --metrics-host-allowlist="*"
-  # - --initial-state=http://your-other-node/eth/v2/debug/beacon/states/finalized
+teku_container_command_extra_args:
+  - --data-storage-mode=PRUNE
+# - --network=mainnet
+# - --initial-state=http://your-other-node/eth/v2/debug/beacon/states/finalized
+# - --logging=INFO

--- a/roles/teku/defaults/main.yaml
+++ b/roles/teku/defaults/main.yaml
@@ -11,7 +11,7 @@ teku_ports_http_beacon: 5051
 teku_ports_metrics: 8008
 
 teku_container_name: teku
-teku_container_image: consensys/teku:22.12.0
+teku_container_image: consensys/teku:latest
 teku_container_env: {}
 teku_container_ports:
   - "127.0.0.1:{{ teku_ports_http_beacon }}:{{ teku_ports_http_beacon }}"

--- a/roles/teku/tasks/cleanup.yaml
+++ b/roles/teku/tasks/cleanup.yaml
@@ -1,0 +1,5 @@
+- name: Remove teku container
+  community.docker.docker_container:
+    name: "{{ teku_container_name }}"
+    state: absent
+  when: teku_cleanup

--- a/roles/teku/tasks/main.yaml
+++ b/roles/teku/tasks/main.yaml
@@ -1,26 +1,7 @@
-- name: Add teku user
-  ansible.builtin.user:
-    name: "{{ teku_user }}"
-  register: teku_user_meta
+- name: Setup teku
+  ansible.builtin.import_tasks: setup.yaml
+  when: not teku_cleanup
 
-- name: Create data dir
-  ansible.builtin.file:
-    path: "{{ teku_datadir }}"
-    state: directory
-    recurse: true
-    owner: "{{ teku_user }}"
-    group: "{{ teku_user }}"
-
-- name: Run teku container
-  community.docker.docker_container:
-    name: "{{ teku_container_name }}"
-    image: "{{ teku_container_image }}"
-    state: started
-    restart_policy: always
-    stop_timeout: "{{ teku_container_stop_timeout }}"
-    ports: "{{ teku_container_ports }}"
-    volumes: "{{ teku_container_volumes }}"
-    env: "{{ teku_container_env }}"
-    networks: "{{ teku_container_networks }}"
-    command: "{{ teku_container_command }} "
-    user: "{{ teku_user_meta.uid }}"
+- name: Cleanup teku
+  ansible.builtin.import_tasks: cleanup.yaml
+  when: teku_cleanup

--- a/roles/teku/tasks/setup.yaml
+++ b/roles/teku/tasks/setup.yaml
@@ -1,0 +1,26 @@
+- name: Add teku user
+  ansible.builtin.user:
+    name: "{{ teku_user }}"
+  register: teku_user_meta
+
+- name: Create data dir
+  ansible.builtin.file:
+    path: "{{ teku_datadir }}"
+    state: directory
+    recurse: true
+    owner: "{{ teku_user }}"
+    group: "{{ teku_user }}"
+
+- name: Run teku container
+  community.docker.docker_container:
+    name: "{{ teku_container_name }}"
+    image: "{{ teku_container_image }}"
+    state: started
+    restart_policy: always
+    stop_timeout: "{{ teku_container_stop_timeout }}"
+    ports: "{{ teku_container_ports }}"
+    volumes: "{{ teku_container_volumes }}"
+    env: "{{ teku_container_env }}"
+    networks: "{{ teku_container_networks }}"
+    command: "{{ teku_container_command }} "
+    user: "{{ teku_user_meta.uid }}"

--- a/roles/teku/tasks/setup.yaml
+++ b/roles/teku/tasks/setup.yaml
@@ -22,5 +22,5 @@
     volumes: "{{ teku_container_volumes }}"
     env: "{{ teku_container_env }}"
     networks: "{{ teku_container_networks }}"
-    command: "{{ teku_container_command }} "
+    command: "{{ teku_container_command + teku_container_command_extra_args }} "
     user: "{{ teku_user_meta.uid }}"


### PR DESCRIPTION
Added the following new roles:
- lighthouse
- prysm
- lodestar
- nethermind
- besu
- erigon
- ethereumjs

Additionally added a `ethereum_node` role that can be used to setup a client pair. It uses the specific client roles for that. 

Anything validator related hasn't been added yet and I'll do that in a separate PR. 