### PR TITLE
Add validator feature to all CL clients

### DIFF
--- a/roles/ethereum_node/defaults/main.yaml
+++ b/roles/ethereum_node/defaults/main.yaml
@@ -10,6 +10,7 @@ ethereum_node_el_ports_metrics: 6060
 
 ethereum_node_cl: lighthouse # Valid options: lighthouse, lodestar, teku, prysm
 ethereum_node_cl_enabled: true
+ethereum_node_cl_validator_enabled: false
 ethereum_node_cl_ports_p2p_tcp: 9000
 ethereum_node_cl_ports_p2p_udp: 9000
 ethereum_node_cl_ports_http_beacon: 5052

--- a/roles/ethereum_node/defaults/main.yaml
+++ b/roles/ethereum_node/defaults/main.yaml
@@ -10,10 +10,12 @@ ethereum_node_el_ports_metrics: 6060
 
 ethereum_node_cl: lighthouse # Valid options: lighthouse, lodestar, teku, prysm
 ethereum_node_cl_enabled: true
-ethereum_node_cl_validator_enabled: false
 ethereum_node_cl_ports_p2p_tcp: 9000
 ethereum_node_cl_ports_p2p_udp: 9000
 ethereum_node_cl_ports_http_beacon: 5052
 ethereum_node_cl_ports_metrics: 5054
+
+ethereum_node_cl_validator_enabled: false
+ethereum_node_cl_validator_fee_recipient: "0xF29Ff96aaEa6C9A1fBa851f74737f3c069d4f1a9" # theprotocolguild.eth
 
 ethereum_node_execution_endpoint: "http://{{ ethereum_node_el }}:{{ ethereum_node_el_ports_engine }}"

--- a/roles/ethereum_node/tasks/setup_cl.yaml
+++ b/roles/ethereum_node/tasks/setup_cl.yaml
@@ -9,6 +9,8 @@
     lighthouse_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     lighthouse_container_networks: "{{ ethereum_node_docker_networks }}"
     lighthouse_execution_engine_endpoint: "{{ ethereum_node_execution_endpoint }}"
+    lighthouse_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
+    lighthouse_validator_container_networks: "{{ ethereum_node_docker_networks }}"
 
 - name: "Consensus client: teku"
   when: ethereum_node_cl == "teku"
@@ -21,6 +23,8 @@
     teku_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     teku_container_networks: "{{ ethereum_node_docker_networks }}"
     teku_execution_engine_endpoint: "{{ ethereum_node_execution_endpoint }}"
+    teku_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
+    teku_validator_container_networks: "{{ ethereum_node_docker_networks }}"
 
 - name: "Consensus client: prysm"
   when: ethereum_node_cl == "prysm"
@@ -33,6 +37,8 @@
     prysm_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     prysm_container_networks: "{{ ethereum_node_docker_networks }}"
     prysm_execution_engine_endpoint: "{{ ethereum_node_execution_endpoint }}"
+    prysm_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
+    prysm_validator_container_networks: "{{ ethereum_node_docker_networks }}"
 
 - name: "Consensus client: lodestar"
   when: ethereum_node_cl == "lodestar"
@@ -45,6 +51,8 @@
     lodestar_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     lodestar_container_networks: "{{ ethereum_node_docker_networks }}"
     lodestar_execution_engine_endpoint: "{{ ethereum_node_execution_endpoint }}"
+    lodestar_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
+    lodestar_validator_container_networks: "{{ ethereum_node_docker_networks }}"
 
 - name: "Consensus client: nimbus"
   when: ethereum_node_cl == "nimbus"
@@ -57,3 +65,5 @@
     nimbus_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     nimbus_container_networks: "{{ ethereum_node_docker_networks }}"
     nimbus_execution_engine_endpoint: "{{ ethereum_node_execution_endpoint }}"
+    nimbus_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
+    nimbus_validator_container_networks: "{{ ethereum_node_docker_networks }}"

--- a/roles/ethereum_node/tasks/setup_cl.yaml
+++ b/roles/ethereum_node/tasks/setup_cl.yaml
@@ -11,6 +11,7 @@
     lighthouse_execution_engine_endpoint: "{{ ethereum_node_execution_endpoint }}"
     lighthouse_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     lighthouse_validator_container_networks: "{{ ethereum_node_docker_networks }}"
+    lighthouse_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
 
 - name: "Consensus client: teku"
   when: ethereum_node_cl == "teku"
@@ -25,6 +26,7 @@
     teku_execution_engine_endpoint: "{{ ethereum_node_execution_endpoint }}"
     teku_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     teku_validator_container_networks: "{{ ethereum_node_docker_networks }}"
+    teku_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
 
 - name: "Consensus client: prysm"
   when: ethereum_node_cl == "prysm"
@@ -39,6 +41,7 @@
     prysm_execution_engine_endpoint: "{{ ethereum_node_execution_endpoint }}"
     prysm_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     prysm_validator_container_networks: "{{ ethereum_node_docker_networks }}"
+    prysm_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
 
 - name: "Consensus client: lodestar"
   when: ethereum_node_cl == "lodestar"
@@ -53,6 +56,7 @@
     lodestar_execution_engine_endpoint: "{{ ethereum_node_execution_endpoint }}"
     lodestar_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     lodestar_validator_container_networks: "{{ ethereum_node_docker_networks }}"
+    lodestar_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
 
 - name: "Consensus client: nimbus"
   when: ethereum_node_cl == "nimbus"
@@ -67,3 +71,4 @@
     nimbus_execution_engine_endpoint: "{{ ethereum_node_execution_endpoint }}"
     nimbus_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     nimbus_validator_container_networks: "{{ ethereum_node_docker_networks }}"
+    nimbus_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"

--- a/roles/lighthouse/defaults/main.yaml
+++ b/roles/lighthouse/defaults/main.yaml
@@ -71,7 +71,7 @@ lighthouse_validator_container_networks: []
 lighthouse_validator_container_command:
   - lighthouse
   - validator_client
-  - --validators-dir=/validator-data/validators
+  - --validators-dir=/validator-data/keys
   - --secrets-dir=/validator-data/secrets
   - --beacon-nodes=http://{{ lighthouse_container_name }}:{{ lighthouse_ports_http_beacon }}
   - --init-slashing-protection

--- a/roles/lighthouse/defaults/main.yaml
+++ b/roles/lighthouse/defaults/main.yaml
@@ -16,7 +16,7 @@ lighthouse_validator_datadir: /data/lighthouse-validator
 
 ################################################################################
 ##
-## Beacon chain container configuration
+## Beacon node container configuration
 ##
 ################################################################################
 lighthouse_container_name: lighthouse
@@ -83,3 +83,4 @@ lighthouse_validator_container_command:
 lighthouse_validator_container_command_extra_args: []
   # - --http
   # - --http-port=5062
+  # - --graffiti=hello-world

--- a/roles/lighthouse/defaults/main.yaml
+++ b/roles/lighthouse/defaults/main.yaml
@@ -3,13 +3,22 @@ lighthouse_datadir: /data/lighthouse
 lighthouse_auth_jwt_path: /data/execution-auth.secret
 lighthouse_execution_engine_endpoint: http://geth:8551
 
-lighthouse_cleanup: false # when set to "true" it will remove the container
+lighthouse_cleanup: false # when set to "true" it will remove the container(s)
 
 lighthouse_ports_p2p_tcp: 9000
 lighthouse_ports_p2p_udp: 9000
 lighthouse_ports_http_beacon: 5052
 lighthouse_ports_metrics: 5054
 
+lighthouse_validator_enabled: false
+lighthouse_validator_fee_recipient: "0xF29Ff96aaEa6C9A1fBa851f74737f3c069d4f1a9" # theprotocolguild.eth
+lighthouse_validator_datadir: /data/lighthouse-validator
+
+################################################################################
+##
+## Beacon chain container configuration
+##
+################################################################################
 lighthouse_container_name: lighthouse
 lighthouse_container_image: sigp/lighthouse:latest
 lighthouse_container_env: {}
@@ -45,3 +54,32 @@ lighthouse_container_command:
   - --metrics-port={{ lighthouse_ports_metrics }}
 lighthouse_container_command_extra_args: []
   # - --checkpoint-sync-url=http://your-other-node
+
+################################################################################
+##
+## Validator container configuration
+##
+################################################################################
+lighthouse_validator_container_name: "{{ lighthouse_container_name }}-validator"
+lighthouse_validator_container_image: "{{ lighthouse_container_image }}"
+lighthouse_validator_container_env: {}
+lighthouse_validator_container_ports: []
+lighthouse_validator_container_volumes:
+  - "{{ lighthouse_validator_datadir }}:/validator-data"
+lighthouse_validator_container_stop_timeout: "300"
+lighthouse_validator_container_networks: []
+lighthouse_validator_container_command:
+  - lighthouse
+  - validator_client
+  - --validators-dir=/validator-data/validators
+  - --secrets-dir=/validator-data/secrets
+  - --beacon-nodes=http://{{ lighthouse_container_name }}:{{ lighthouse_ports_http_beacon }}
+  - --init-slashing-protection
+  - --suggested-fee-recipient={{ lighthouse_validator_fee_recipient }}
+  - --metrics
+  - --metrics-address=0.0.0.0
+  - --metrics-allow-origin=*
+  - --metrics-port={{ lighthouse_ports_metrics }}
+lighthouse_validator_container_command_extra_args: []
+  # - --http
+  # - --http-port=5062

--- a/roles/lighthouse/tasks/cleanup.yaml
+++ b/roles/lighthouse/tasks/cleanup.yaml
@@ -8,4 +8,4 @@
   community.docker.docker_container:
     name: "{{ lighthouse_validator_container_name }}"
     state: absent
-  when: lighthouse_cleanup OR lighthouse_validator_enabled == false
+  when: lighthouse_cleanup or (not lighthouse_validator_enabled)

--- a/roles/lighthouse/tasks/cleanup.yaml
+++ b/roles/lighthouse/tasks/cleanup.yaml
@@ -3,3 +3,9 @@
     name: "{{ lighthouse_container_name }}"
     state: absent
   when: lighthouse_cleanup
+
+- name: Remove lighthouse validator container
+  community.docker.docker_container:
+    name: "{{ lighthouse_validator_container_name }}"
+    state: absent
+  when: lighthouse_cleanup OR lighthouse_validator_enabled == false

--- a/roles/lighthouse/tasks/main.yaml
+++ b/roles/lighthouse/tasks/main.yaml
@@ -4,4 +4,3 @@
 
 - name: Cleanup lighthouse
   ansible.builtin.import_tasks: cleanup.yaml
-  when: lighthouse_cleanup

--- a/roles/lighthouse/tasks/setup.yaml
+++ b/roles/lighthouse/tasks/setup.yaml
@@ -32,6 +32,7 @@
     recurse: true
     owner: "{{ lighthouse_user }}"
     group: "{{ lighthouse_user }}"
+  loop:
     - "{{ lighthouse_validator_datadir }}/keys"
     - "{{ lighthouse_validator_datadir }}/secrets"
   when: lighthouse_validator_enabled

--- a/roles/lighthouse/tasks/setup.yaml
+++ b/roles/lighthouse/tasks/setup.yaml
@@ -32,9 +32,6 @@
     recurse: true
     owner: "{{ lighthouse_user }}"
     group: "{{ lighthouse_user }}"
-  #loop:
-  #  - "{{ lighthouse_validator_datadir }}/secrets"
-  #  - "{{ lighthouse_validator_datadir }}/validators"
   when: lighthouse_validator_enabled
 
 - name: Run lighthouse validator container

--- a/roles/lighthouse/tasks/setup.yaml
+++ b/roles/lighthouse/tasks/setup.yaml
@@ -24,3 +24,30 @@
     networks: "{{ lighthouse_container_networks }}"
     command: "{{ lighthouse_container_command + lighthouse_container_command_extra_args }} "
     user: "{{ lighthouse_user_meta.uid }}"
+
+- name: Create validator data dir
+  ansible.builtin.file:
+    path: "{{ lighthouse_validator_datadir }}"
+    state: directory
+    recurse: true
+    owner: "{{ lighthouse_user }}"
+    group: "{{ lighthouse_user }}"
+  #loop:
+  #  - "{{ lighthouse_validator_datadir }}/secrets"
+  #  - "{{ lighthouse_validator_datadir }}/validators"
+  when: lighthouse_validator_enabled
+
+- name: Run lighthouse validator container
+  community.docker.docker_container:
+    name: "{{ lighthouse_validator_container_name }}"
+    image: "{{ lighthouse_validator_container_image }}"
+    state: started
+    restart_policy: always
+    stop_timeout: "{{ lighthouse_validator_container_stop_timeout }}"
+    ports: "{{ lighthouse_validator_container_ports }}"
+    volumes: "{{ lighthouse_validator_container_volumes }}"
+    env: "{{ lighthouse_validator_container_env }}"
+    networks: "{{ lighthouse_validator_container_networks }}"
+    command: "{{ lighthouse_validator_container_command + lighthouse_validator_container_command_extra_args }} "
+    user: "{{ lighthouse_user_meta.uid }}"
+  when: lighthouse_validator_enabled

--- a/roles/lighthouse/tasks/setup.yaml
+++ b/roles/lighthouse/tasks/setup.yaml
@@ -27,11 +27,13 @@
 
 - name: Create validator data dir
   ansible.builtin.file:
-    path: "{{ lighthouse_validator_datadir }}"
+    path: "{{ item }}"
     state: directory
     recurse: true
     owner: "{{ lighthouse_user }}"
     group: "{{ lighthouse_user }}"
+    - "{{ lighthouse_validator_datadir }}/keys"
+    - "{{ lighthouse_validator_datadir }}/secrets"
   when: lighthouse_validator_enabled
 
 - name: Run lighthouse validator container

--- a/roles/lodestar/defaults/main.yaml
+++ b/roles/lodestar/defaults/main.yaml
@@ -67,7 +67,7 @@ lodestar_validator_container_networks: []
 lodestar_validator_container_command:
   - validator
   - --dataDir=/validator-data
-  - --keystoresDir=/validator-data/keystores
+  - --keystoresDir=/validator-data/keys
   - --secretsDir=/validator-data/secrets
   - --beaconNodes=http://{{ lodestar_container_name }}:{{ lodestar_ports_http_beacon }}
   - --suggestedFeeRecipient={{ lodestar_validator_fee_recipient }}

--- a/roles/lodestar/defaults/main.yaml
+++ b/roles/lodestar/defaults/main.yaml
@@ -3,7 +3,7 @@ lodestar_datadir: /data/lodestar
 lodestar_auth_jwt_path: /data/execution-auth.secret
 lodestar_execution_engine_endpoint: http://geth:8551
 
-lodestar_cleanup: false # when set to "true" it will remove the container
+lodestar_cleanup: false # when set to "true" it will remove the container(s)
 
 lodestar_ports_p2p_tcp: 9000
 lodestar_ports_p2p_udp: 9000

--- a/roles/lodestar/defaults/main.yaml
+++ b/roles/lodestar/defaults/main.yaml
@@ -10,6 +10,15 @@ lodestar_ports_p2p_udp: 9000
 lodestar_ports_http_beacon: 9596
 lodestar_ports_metrics: 8008
 
+lodestar_validator_enabled: false
+lodestar_validator_fee_recipient: "0xF29Ff96aaEa6C9A1fBa851f74737f3c069d4f1a9" # theprotocolguild.eth
+lodestar_validator_datadir: /data/lodestar-validator
+
+################################################################################
+##
+## Beacon node container configuration
+##
+################################################################################
 lodestar_container_name: lodestar
 lodestar_container_image: chainsafe/lodestar:latest
 lodestar_container_env: {}
@@ -41,3 +50,27 @@ lodestar_container_command:
   - --metrics.port={{ lodestar_ports_metrics }}
 lodestar_container_command_extra_args: []
 # - --checkpointSyncUrl=http://your-other-node
+
+################################################################################
+##
+## Validator container configuration
+##
+################################################################################
+lodestar_validator_container_name: "{{ lodestar_container_name }}-validator"
+lodestar_validator_container_image: "{{ lodestar_container_image }}"
+lodestar_validator_container_env: {}
+lodestar_validator_container_ports: []
+lodestar_validator_container_volumes:
+  - "{{ lodestar_validator_datadir }}:/validator-data"
+lodestar_validator_container_stop_timeout: "300"
+lodestar_validator_container_networks: []
+lodestar_validator_container_command:
+  - validator
+  - --dataDir=/validator-data
+  - --keystoresDir=/validator-data/keystores
+  - --secretsDir=/validator-data/secrets
+  - --beaconNodes=http://{{ lodestar_container_name }}:{{ lodestar_ports_http_beacon }}
+  - --suggestedFeeRecipient={{ lodestar_validator_fee_recipient }}
+lodestar_validator_container_command_extra_args: []
+  # - --builder
+  # - --graffiti=hello-world

--- a/roles/lodestar/tasks/cleanup.yaml
+++ b/roles/lodestar/tasks/cleanup.yaml
@@ -3,3 +3,9 @@
     name: "{{ lodestar_container_name }}"
     state: absent
   when: lodestar_cleanup
+
+- name: Remove lodestar validator container
+  community.docker.docker_container:
+    name: "{{ lodestar_validator_container_name }}"
+    state: absent
+  when: lodestar_cleanup or (not lodestar_validator_enabled)

--- a/roles/lodestar/tasks/main.yaml
+++ b/roles/lodestar/tasks/main.yaml
@@ -4,4 +4,3 @@
 
 - name: Cleanup lodestar
   ansible.builtin.import_tasks: cleanup.yaml
-  when: lodestar_cleanup

--- a/roles/lodestar/tasks/setup.yaml
+++ b/roles/lodestar/tasks/setup.yaml
@@ -27,11 +27,14 @@
 
 - name: Create validator data dir
   ansible.builtin.file:
-    path: "{{ lodestar_validator_datadir }}"
+    path: "{{ item }}"
     state: directory
     recurse: true
     owner: "{{ lodestar_user }}"
     group: "{{ lodestar_user }}"
+  loop:
+    - "{{ lodestar_validator_datadir }}/keys"
+    - "{{ lodestar_validator_datadir }}/secrets"
   when: lodestar_validator_enabled
 
 - name: Run lodestar validator container

--- a/roles/lodestar/tasks/setup.yaml
+++ b/roles/lodestar/tasks/setup.yaml
@@ -24,3 +24,27 @@
     networks: "{{ lodestar_container_networks }}"
     command: "{{ lodestar_container_command }} "
     user: "{{ lodestar_user_meta.uid }}"
+
+- name: Create validator data dir
+  ansible.builtin.file:
+    path: "{{ lodestar_validator_datadir }}"
+    state: directory
+    recurse: true
+    owner: "{{ lodestar_user }}"
+    group: "{{ lodestar_user }}"
+  when: lodestar_validator_enabled
+
+- name: Run lodestar validator container
+  community.docker.docker_container:
+    name: "{{ lodestar_validator_container_name }}"
+    image: "{{ lodestar_validator_container_image }}"
+    state: started
+    restart_policy: always
+    stop_timeout: "{{ lodestar_validator_container_stop_timeout }}"
+    ports: "{{ lodestar_validator_container_ports }}"
+    volumes: "{{ lodestar_validator_container_volumes }}"
+    env: "{{ lodestar_validator_container_env }}"
+    networks: "{{ lodestar_validator_container_networks }}"
+    command: "{{ lodestar_validator_container_command + lodestar_validator_container_command_extra_args }} "
+    user: "{{ lodestar_user_meta.uid }}"
+  when: lodestar_validator_enabled

--- a/roles/nimbus/defaults/main.yaml
+++ b/roles/nimbus/defaults/main.yaml
@@ -50,6 +50,7 @@ nimbus_container_command:
   - --metrics-port={{ nimbus_ports_metrics }}
   - --metrics-address=0.0.0.0
 nimbus_container_command_extra_args: []
+  # - --graffiti=hello-world
 
 ################################################################################
 ##

--- a/roles/nimbus/defaults/main.yaml
+++ b/roles/nimbus/defaults/main.yaml
@@ -10,6 +10,15 @@ nimbus_ports_p2p_udp: 9000
 nimbus_ports_http_beacon: 5051
 nimbus_ports_metrics: 8008
 
+nimbus_validator_enabled: false
+nimbus_validator_fee_recipient: "0xF29Ff96aaEa6C9A1fBa851f74737f3c069d4f1a9" # theprotocolguild.eth
+nimbus_validator_datadir: /data/nimbus-validator
+
+################################################################################
+##
+## Beacon node container configuration
+##
+################################################################################
 nimbus_container_name: nimbus
 nimbus_container_image: statusim/nimbus-eth2:amd64-latest
 nimbus_container_env: {}
@@ -34,10 +43,22 @@ nimbus_container_command:
   - --rest
   - --rest-port={{ nimbus_ports_http_beacon }}
   - --rest-address=0.0.0.0
-  - --rest-allow-origin="*"
+  - --rest-allow-origin=*
   - --web3-url={{ nimbus_execution_engine_endpoint }}
   - --jwt-secret=/execution-auth.jwt
   - --metrics
   - --metrics-port={{ nimbus_ports_metrics }}
   - --metrics-address=0.0.0.0
 nimbus_container_command_extra_args: []
+
+################################################################################
+##
+## Validator specific configuration
+##
+################################################################################
+nimbus_container_validator_args:
+  - --validators-dir=/validator-data/keys
+  - --secrets-dir=/validator-data/secrets
+  - --suggested-fee-recipient={{ nimbus_validator_fee_recipient }}
+nimbus_container_validator_volumes:
+  - "{{ nimbus_validator_datadir }}:/validator-data"

--- a/roles/nimbus/tasks/setup.yaml
+++ b/roles/nimbus/tasks/setup.yaml
@@ -12,7 +12,6 @@
     owner: "{{ nimbus_user }}"
     group: "{{ nimbus_user }}"
 
-
 - name: Create validator data dir
   ansible.builtin.file:
     path: "{{ item }}"
@@ -24,7 +23,6 @@
     - "{{ nimbus_validator_datadir }}/keys"
     - "{{ nimbus_validator_datadir }}/secrets"
   when: nimbus_validator_enabled
-
 
 - name: Run nimbus container
   community.docker.docker_container:

--- a/roles/nimbus/tasks/setup.yaml
+++ b/roles/nimbus/tasks/setup.yaml
@@ -12,6 +12,20 @@
     owner: "{{ nimbus_user }}"
     group: "{{ nimbus_user }}"
 
+
+- name: Create validator data dir
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    recurse: true
+    owner: "{{ nimbus_user }}"
+    group: "{{ nimbus_user }}"
+  loop:
+    - "{{ nimbus_validator_datadir }}/keys"
+    - "{{ nimbus_validator_datadir }}/secrets"
+  when: nimbus_validator_enabled
+
+
 - name: Run nimbus container
   community.docker.docker_container:
     name: "{{ nimbus_container_name }}"
@@ -20,8 +34,20 @@
     restart_policy: always
     stop_timeout: "{{ nimbus_container_stop_timeout }}"
     ports: "{{ nimbus_container_ports }}"
-    volumes: "{{ nimbus_container_volumes }}"
+    volumes: >-
+      {{
+        nimbus_validator_enabled | ternary(
+          nimbus_container_volumes + nimbus_container_validator_volumes,
+          nimbus_container_volumes
+        )
+      }}
     env: "{{ nimbus_container_env }}"
     networks: "{{ nimbus_container_networks }}"
-    command: "{{ nimbus_container_command + nimbus_container_command_extra_args }} "
+    command: >-
+      {{
+        nimbus_validator_enabled | ternary(
+          nimbus_container_command + nimbus_container_validator_args + nimbus_container_command_extra_args,
+          nimbus_container_command + nimbus_container_command_extra_args,
+        )
+      }}
     user: "{{ nimbus_user_meta.uid }}"

--- a/roles/prysm/defaults/main.yaml
+++ b/roles/prysm/defaults/main.yaml
@@ -3,7 +3,7 @@ prysm_datadir: /data/prysm
 prysm_auth_jwt_path: /data/execution-auth.secret
 prysm_execution_engine_endpoint: http://geth:8551
 
-prysm_cleanup: false # when set to "true" it will remove the container
+prysm_cleanup: false # when set to "true" it will remove the container(s)
 
 prysm_ports_p2p_tcp: 13000
 prysm_ports_p2p_udp: 12000
@@ -11,6 +11,15 @@ prysm_ports_http_beacon: 4000
 prysm_ports_metrics: 8080
 prysm_ports_grpc: 3500
 
+prysm_validator_enabled: false
+prysm_validator_fee_recipient: "0xF29Ff96aaEa6C9A1fBa851f74737f3c069d4f1a9" # theprotocolguild.eth
+prysm_validator_datadir: /data/prysm-validator
+
+################################################################################
+##
+## Beacon node container configuration
+##
+################################################################################
 prysm_container_name: prysm
 prysm_container_image: gcr.io/prysmaticlabs/prysm/beacon-chain:stable
 prysm_container_env: {}
@@ -40,3 +49,29 @@ prysm_container_command:
 prysm_container_command_extra_args: []
 # - --checkpoint-sync-url=http://your-other-node
 # - --genesis-beacon-api-url=http://your-other-node
+
+################################################################################
+##
+## Validator container configuration
+##
+################################################################################
+prysm_validator_container_name: "{{ prysm_container_name }}-validator"
+prysm_validator_container_image: "gcr.io/prysmaticlabs/prysm/validator:stable"
+prysm_validator_container_env: {}
+prysm_validator_container_ports: []
+prysm_validator_container_volumes:
+  - "{{ prysm_validator_datadir }}:/validator-data"
+prysm_validator_container_stop_timeout: "300"
+prysm_validator_container_networks: []
+prysm_validator_container_command:
+  - --accept-terms-of-use=true
+  - --datadir=/validator-data
+  - --wallet-dir=/validator-data/wallet
+  - --wallet-password-file=/validator-data/wallet_pass.txt
+  - --beacon-rpc-provider=http://{{ prysm_container_name }}:{{ prysm_ports_http_beacon }}
+  - --suggested-fee-recipient={{ prysm_validator_fee_recipient }}
+  - --monitoring-host=0.0.0.0
+  - --monitoring-port={{ prysm_ports_metrics }}
+
+prysm_validator_container_command_extra_args: []
+  # - --graffiti=hello-world

--- a/roles/prysm/tasks/cleanup.yaml
+++ b/roles/prysm/tasks/cleanup.yaml
@@ -3,3 +3,9 @@
     name: "{{ prysm_container_name }}"
     state: absent
   when: prysm_cleanup
+
+- name: Remove prysm validator container
+  community.docker.docker_container:
+    name: "{{ prysm_validator_container_name }}"
+    state: absent
+  when: prysm_cleanup or (not prysm_validator_enabled)

--- a/roles/prysm/tasks/main.yaml
+++ b/roles/prysm/tasks/main.yaml
@@ -4,4 +4,3 @@
 
 - name: Cleanup prysm
   ansible.builtin.import_tasks: cleanup.yaml
-  when: prysm_cleanup

--- a/roles/prysm/tasks/setup.yaml
+++ b/roles/prysm/tasks/setup.yaml
@@ -24,3 +24,27 @@
     networks: "{{ prysm_container_networks }}"
     command: "{{ prysm_container_command + prysm_container_command_extra_args }} "
     user: "{{ prysm_user_meta.uid }}"
+
+- name: Create validator data dir
+  ansible.builtin.file:
+    path: "{{ prysm_validator_datadir }}"
+    state: directory
+    recurse: true
+    owner: "{{ prysm_user }}"
+    group: "{{ prysm_user }}"
+  when: prysm_validator_enabled
+
+- name: Run prysm validator container
+  community.docker.docker_container:
+    name: "{{ prysm_validator_container_name }}"
+    image: "{{ prysm_validator_container_image }}"
+    state: started
+    restart_policy: always
+    stop_timeout: "{{ prysm_validator_container_stop_timeout }}"
+    ports: "{{ prysm_validator_container_ports }}"
+    volumes: "{{ prysm_validator_container_volumes }}"
+    env: "{{ prysm_validator_container_env }}"
+    networks: "{{ prysm_validator_container_networks }}"
+    command: "{{ prysm_validator_container_command + prysm_validator_container_command_extra_args }} "
+    user: "{{ prysm_user_meta.uid }}"
+  when: prysm_validator_enabled

--- a/roles/teku/defaults/main.yaml
+++ b/roles/teku/defaults/main.yaml
@@ -10,6 +10,15 @@ teku_ports_p2p_udp: 9000
 teku_ports_http_beacon: 5051
 teku_ports_metrics: 8008
 
+teku_validator_enabled: false
+teku_validator_fee_recipient: "0xF29Ff96aaEa6C9A1fBa851f74737f3c069d4f1a9" # theprotocolguild.eth
+teku_validator_datadir: /data/teku-validator
+
+################################################################################
+##
+## Beacon node container configuration
+##
+################################################################################
 teku_container_name: teku
 teku_container_image: consensys/teku:latest
 teku_container_env: {}
@@ -33,15 +42,28 @@ teku_container_command:
   - --rest-api-enabled
   - --rest-api-interface=0.0.0.0
   - --rest-api-port={{ teku_ports_http_beacon }}
-  - --rest-api-host-allowlist="*"
+  - --rest-api-host-allowlist=*
   - --ee-endpoint={{ teku_execution_engine_endpoint }}
   - --ee-jwt-secret-file=/execution-auth.jwt
   - --metrics-enabled=true
   - --metrics-interface=0.0.0.0
   - --metrics-port={{ teku_ports_metrics }}
-  - --metrics-host-allowlist="*"
+  - --metrics-host-allowlist=*
 teku_container_command_extra_args:
   - --data-storage-mode=PRUNE
 # - --network=mainnet
 # - --initial-state=http://your-other-node/eth/v2/debug/beacon/states/finalized
 # - --logging=INFO
+# - ---validators-graffiti=hello-world
+
+################################################################################
+##
+## Validator specific configuration
+##
+################################################################################
+teku_container_validator_args:
+  - --validator-keys=/validator-data/keys:/validator-data/secrets
+  - --validators-proposer-default-fee-recipient={{ teku_validator_fee_recipient }}
+  - --validators-keystore-locking-enabled=false
+teku_container_validator_volumes:
+  - "{{ teku_validator_datadir }}:/validator-data"

--- a/roles/teku/tasks/setup.yaml
+++ b/roles/teku/tasks/setup.yaml
@@ -11,6 +11,18 @@
     owner: "{{ teku_user }}"
     group: "{{ teku_user }}"
 
+- name: Create validator data dir
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    recurse: true
+    owner: "{{ teku_user }}"
+    group: "{{ teku_user }}"
+  loop:
+    - "{{ teku_validator_datadir }}/keys"
+    - "{{ teku_validator_datadir }}/secrets"
+  when: teku_validator_enabled
+
 - name: Run teku container
   community.docker.docker_container:
     name: "{{ teku_container_name }}"
@@ -19,8 +31,20 @@
     restart_policy: always
     stop_timeout: "{{ teku_container_stop_timeout }}"
     ports: "{{ teku_container_ports }}"
-    volumes: "{{ teku_container_volumes }}"
+    volumes: >-
+      {{
+        teku_validator_enabled | ternary(
+          teku_container_volumes + teku_container_validator_volumes,
+          teku_container_volumes
+        )
+      }}
     env: "{{ teku_container_env }}"
     networks: "{{ teku_container_networks }}"
-    command: "{{ teku_container_command + teku_container_command_extra_args }} "
+    command: >-
+      {{
+        teku_validator_enabled | ternary(
+          teku_container_command + teku_container_validator_args + teku_container_command_extra_args,
+          teku_container_command + teku_container_command_extra_args,
+        )
+      }}
     user: "{{ teku_user_meta.uid }}"


### PR DESCRIPTION
Added validator support to the following CL clients:
- [x] lighthouse
- [x] prysm
- [x] lodestar
- [x] nimbus
- [x] teku

Additionally also:
- [x] updated the generic ethereum_node role to support validator vars


Notes:
- Key imports will be done in a separate PR once I start using the roles on the 4844 testnets. With that I'll also add a bit better documentation on where keys should be put and in which format. 