### PR TITLE
geth/erigon: support custom genesis configs.

### DIFF
--- a/roles/erigon/defaults/main.yaml
+++ b/roles/erigon/defaults/main.yaml
@@ -43,3 +43,18 @@ erigon_container_command:
   - --metrics.port={{ erigon_ports_metrics }}
 erigon_container_command_extra_args: []
 #  - --prune=htc
+
+
+# Only required changing when running custom networks
+erigon_init_custom_network: false
+erigon_init_custom_network_genesis_file: /config/genesis.json
+erigon_init_custom_network_container_env: {}
+erigon_init_custom_network_container_volumes:
+  - "{{ erigon_datadir }}:/data"
+  - "{{ erigon_init_custom_network_genesis_file }}:/genesis.json:ro"
+erigon_init_custom_network_container_entrypoint:
+  - erigon
+erigon_init_custom_network_container_command:
+  - --datadir=/data
+  - init
+  - /genesis.json

--- a/roles/erigon/tasks/cleanup.yaml
+++ b/roles/erigon/tasks/cleanup.yaml
@@ -1,4 +1,7 @@
-- name: Remove erigon container
+- name: Remove erigon containers
   community.docker.docker_container:
-    name: "{{ erigon_container_name }}"
+    name: "{{ item }}"
     state: absent
+  loop:
+    - "{{ erigon_container_name }}"
+    - "{{ erigon_container_name }}-init"

--- a/roles/erigon/tasks/setup.yaml
+++ b/roles/erigon/tasks/setup.yaml
@@ -11,6 +11,29 @@
     owner: "{{ erigon_user }}"
     group: "{{ erigon_user }}"
 
+- name: Init custom network
+  when: erigon_init_custom_network
+  block:
+    - name: Check for empty chaindata dir
+      ansible.builtin.stat:
+        path: "{{ erigon_datadir }}/chaindata"
+      register: erigon_init_custom_network_chaindata_stat
+    - name: Chaindata is empty, run erigon init container
+      community.docker.docker_container:
+        name: "{{ erigon_container_name }}-init"
+        image: "{{ erigon_container_image }}"
+        detach: false
+        auto_remove: true
+        restart_policy: "no"
+        state: started
+        volumes: "{{ erigon_init_custom_network_container_volumes }}"
+        env: "{{ erigon_init_custom_network_container_env }}"
+        networks: "{{ erigon_container_networks }}"
+        entrypoint: "{{ erigon_init_custom_network_container_entrypoint }}"
+        command: "{{ erigon_init_custom_network_container_command }}"
+        user: "{{ erigon_user_meta.uid }}"
+      when: not erigon_init_custom_network_chaindata_stat.stat.exists
+
 - name: Run erigon container
   community.docker.docker_container:
     name: "{{ erigon_container_name }}"

--- a/roles/geth/defaults/main.yaml
+++ b/roles/geth/defaults/main.yaml
@@ -39,3 +39,15 @@ geth_container_command:
   - --metrics.port={{ geth_ports_metrics }}
   - --metrics.addr=0.0.0.0
 geth_container_command_extra_args: []
+
+# Only required changing when running custom networks
+geth_init_custom_network: false
+geth_init_custom_network_genesis_file: /config/genesis.json
+geth_init_custom_network_container_env: {}
+geth_init_custom_network_container_volumes:
+  - "{{ geth_datadir }}:/data"
+  - "{{ geth_init_custom_network_genesis_file }}:/genesis.json:ro"
+geth_init_custom_network_container_command:
+  - --datadir=/data
+  - init
+  - /genesis.json

--- a/roles/geth/tasks/cleanup.yaml
+++ b/roles/geth/tasks/cleanup.yaml
@@ -1,4 +1,7 @@
-- name: Remove geth container
+- name: Remove geth containers
   community.docker.docker_container:
-    name: "{{ geth_container_name }}"
+    name: "{{ item }}"
     state: absent
+  loop:
+    - "{{ geth_container_name }}"
+    - "{{ geth_container_name }}-init"

--- a/roles/geth/tasks/setup.yaml
+++ b/roles/geth/tasks/setup.yaml
@@ -11,6 +11,28 @@
     owner: "{{ geth_user }}"
     group: "{{ geth_user }}"
 
+- name: Init custom network
+  when: geth_init_custom_network
+  block:
+    - name: Check for empty chaindata dir
+      ansible.builtin.stat:
+        path: "{{ geth_datadir }}/geth/chaindata"
+      register: geth_init_custom_network_chaindata_stat
+    - name: Chaindata is empty, run geth init container
+      community.docker.docker_container:
+        name: "{{ geth_container_name }}-init"
+        image: "{{ geth_container_image }}"
+        detach: false
+        auto_remove: true
+        restart_policy: "no"
+        state: started
+        volumes: "{{ geth_init_custom_network_container_volumes }}"
+        env: "{{ geth_init_custom_network_container_env }}"
+        networks: "{{ geth_container_networks }}"
+        command: "{{ geth_init_custom_network_container_command }}"
+        user: "{{ geth_user_meta.uid }}"
+      when: not geth_init_custom_network_chaindata_stat.stat.exists
+
 - name: Run geth container
   community.docker.docker_container:
     name: "{{ geth_container_name }}"


### PR DESCRIPTION
Allow configuring custom networks by adding the required "init" step when using a custom genesis.json