### PR TITLE
never use recurse on data dirs as it could break ansible due to files appearing/disapearing

### DIFF
--- a/roles/arbitrum_node/tasks/main.yaml
+++ b/roles/arbitrum_node/tasks/main.yaml
@@ -4,6 +4,7 @@
     owner: 1000
     group: 1000
     state: directory
+    mode: "0750"
 
 - name: Run arbitrum_node container
   community.docker.docker_container:

--- a/roles/arbitrum_node/tasks/main.yaml
+++ b/roles/arbitrum_node/tasks/main.yaml
@@ -4,7 +4,6 @@
     owner: 1000
     group: 1000
     state: directory
-    recurse: true
 
 - name: Run arbitrum_node container
   community.docker.docker_container:

--- a/roles/beaconchain_explorer_aio/tasks/setup.yml
+++ b/roles/beaconchain_explorer_aio/tasks/setup.yml
@@ -11,7 +11,7 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
-    mode: '0750'
+    mode: "0750"
     owner: "{{ beaconchain_explorer_aio_user }}"
     group: "{{ beaconchain_explorer_aio_user }}"
   loop:

--- a/roles/besu/tasks/setup.yaml
+++ b/roles/besu/tasks/setup.yaml
@@ -7,6 +7,7 @@
   ansible.builtin.file:
     path: "{{ besu_datadir }}"
     state: directory
+    mode: "0750"
     owner: "{{ besu_user }}"
     group: "{{ besu_user }}"
 

--- a/roles/besu/tasks/setup.yaml
+++ b/roles/besu/tasks/setup.yaml
@@ -7,7 +7,6 @@
   ansible.builtin.file:
     path: "{{ besu_datadir }}"
     state: directory
-    recurse: true
     owner: "{{ besu_user }}"
     group: "{{ besu_user }}"
 

--- a/roles/erigon/tasks/setup.yaml
+++ b/roles/erigon/tasks/setup.yaml
@@ -7,7 +7,6 @@
   ansible.builtin.file:
     path: "{{ erigon_datadir }}"
     state: directory
-    recurse: true
     owner: "{{ erigon_user }}"
     group: "{{ erigon_user }}"
 

--- a/roles/erigon/tasks/setup.yaml
+++ b/roles/erigon/tasks/setup.yaml
@@ -7,6 +7,7 @@
   ansible.builtin.file:
     path: "{{ erigon_datadir }}"
     state: directory
+    mode: "0750"
     owner: "{{ erigon_user }}"
     group: "{{ erigon_user }}"
 

--- a/roles/ethereumjs/tasks/setup.yaml
+++ b/roles/ethereumjs/tasks/setup.yaml
@@ -7,6 +7,7 @@
   ansible.builtin.file:
     path: "{{ ethereumjs_datadir }}"
     state: directory
+    mode: "0750"
     owner: "{{ ethereumjs_user }}"
     group: "{{ ethereumjs_user }}"
 

--- a/roles/ethereumjs/tasks/setup.yaml
+++ b/roles/ethereumjs/tasks/setup.yaml
@@ -7,7 +7,6 @@
   ansible.builtin.file:
     path: "{{ ethereumjs_datadir }}"
     state: directory
-    recurse: true
     owner: "{{ ethereumjs_user }}"
     group: "{{ ethereumjs_user }}"
 

--- a/roles/geth/tasks/setup.yaml
+++ b/roles/geth/tasks/setup.yaml
@@ -7,6 +7,7 @@
   ansible.builtin.file:
     path: "{{ geth_datadir }}"
     state: directory
+    mode: "0750"
     owner: "{{ geth_user }}"
     group: "{{ geth_user }}"
 

--- a/roles/geth/tasks/setup.yaml
+++ b/roles/geth/tasks/setup.yaml
@@ -7,7 +7,6 @@
   ansible.builtin.file:
     path: "{{ geth_datadir }}"
     state: directory
-    recurse: true
     owner: "{{ geth_user }}"
     group: "{{ geth_user }}"
 

--- a/roles/lighthouse/tasks/setup.yaml
+++ b/roles/lighthouse/tasks/setup.yaml
@@ -7,6 +7,7 @@
   ansible.builtin.file:
     path: "{{ lighthouse_datadir }}"
     state: directory
+    mode: "0750"
     owner: "{{ lighthouse_user }}"
     group: "{{ lighthouse_user }}"
 
@@ -28,6 +29,7 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
+    mode: "0750"
     owner: "{{ lighthouse_user }}"
     group: "{{ lighthouse_user }}"
   loop:

--- a/roles/lighthouse/tasks/setup.yaml
+++ b/roles/lighthouse/tasks/setup.yaml
@@ -7,7 +7,6 @@
   ansible.builtin.file:
     path: "{{ lighthouse_datadir }}"
     state: directory
-    recurse: true
     owner: "{{ lighthouse_user }}"
     group: "{{ lighthouse_user }}"
 
@@ -29,7 +28,6 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
-    recurse: true
     owner: "{{ lighthouse_user }}"
     group: "{{ lighthouse_user }}"
   loop:

--- a/roles/lodestar/tasks/setup.yaml
+++ b/roles/lodestar/tasks/setup.yaml
@@ -7,7 +7,6 @@
   ansible.builtin.file:
     path: "{{ lodestar_datadir }}"
     state: directory
-    recurse: true
     owner: "{{ lodestar_user }}"
     group: "{{ lodestar_user }}"
 
@@ -29,7 +28,6 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
-    recurse: true
     owner: "{{ lodestar_user }}"
     group: "{{ lodestar_user }}"
   loop:

--- a/roles/lodestar/tasks/setup.yaml
+++ b/roles/lodestar/tasks/setup.yaml
@@ -7,6 +7,7 @@
   ansible.builtin.file:
     path: "{{ lodestar_datadir }}"
     state: directory
+    mode: "0750"
     owner: "{{ lodestar_user }}"
     group: "{{ lodestar_user }}"
 
@@ -28,6 +29,7 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
+    mode: "0750"
     owner: "{{ lodestar_user }}"
     group: "{{ lodestar_user }}"
   loop:

--- a/roles/nethermind/tasks/setup.yaml
+++ b/roles/nethermind/tasks/setup.yaml
@@ -7,6 +7,7 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
+    mode: "0750"
     owner: "{{ nethermind_user }}"
     group: "{{ nethermind_user }}"
   loop:

--- a/roles/nethermind/tasks/setup.yaml
+++ b/roles/nethermind/tasks/setup.yaml
@@ -7,7 +7,6 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
-    recurse: true
     owner: "{{ nethermind_user }}"
     group: "{{ nethermind_user }}"
   loop:

--- a/roles/nimbus/tasks/setup.yaml
+++ b/roles/nimbus/tasks/setup.yaml
@@ -7,7 +7,7 @@
   ansible.builtin.file:
     path: "{{ nimbus_datadir }}"
     state: directory
-    mode: '0700'
+    mode: "0750"
     owner: "{{ nimbus_user }}"
     group: "{{ nimbus_user }}"
 
@@ -15,6 +15,7 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
+    mode: "0750"
     owner: "{{ nimbus_user }}"
     group: "{{ nimbus_user }}"
   loop:

--- a/roles/nimbus/tasks/setup.yaml
+++ b/roles/nimbus/tasks/setup.yaml
@@ -8,7 +8,6 @@
     path: "{{ nimbus_datadir }}"
     state: directory
     mode: '0700'
-    recurse: true
     owner: "{{ nimbus_user }}"
     group: "{{ nimbus_user }}"
 
@@ -16,7 +15,6 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
-    recurse: true
     owner: "{{ nimbus_user }}"
     group: "{{ nimbus_user }}"
   loop:

--- a/roles/prysm/tasks/setup.yaml
+++ b/roles/prysm/tasks/setup.yaml
@@ -7,6 +7,7 @@
   ansible.builtin.file:
     path: "{{ prysm_datadir }}"
     state: directory
+    mode: "0750"
     owner: "{{ prysm_user }}"
     group: "{{ prysm_user }}"
 
@@ -29,6 +30,7 @@
   ansible.builtin.file:
     path: "{{ prysm_validator_datadir }}"
     state: directory
+    mode: "0750"
     owner: "{{ prysm_user }}"
     group: "{{ prysm_user }}"
   when: prysm_validator_enabled

--- a/roles/prysm/tasks/setup.yaml
+++ b/roles/prysm/tasks/setup.yaml
@@ -7,7 +7,6 @@
   ansible.builtin.file:
     path: "{{ prysm_datadir }}"
     state: directory
-    recurse: true
     owner: "{{ prysm_user }}"
     group: "{{ prysm_user }}"
 
@@ -30,7 +29,6 @@
   ansible.builtin.file:
     path: "{{ prysm_validator_datadir }}"
     state: directory
-    recurse: true
     owner: "{{ prysm_user }}"
     group: "{{ prysm_user }}"
   when: prysm_validator_enabled

--- a/roles/teku/tasks/setup.yaml
+++ b/roles/teku/tasks/setup.yaml
@@ -7,6 +7,7 @@
   ansible.builtin.file:
     path: "{{ teku_datadir }}"
     state: directory
+    mode: "0750"
     owner: "{{ teku_user }}"
     group: "{{ teku_user }}"
 
@@ -14,6 +15,7 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
+    mode: "0750"
     owner: "{{ teku_user }}"
     group: "{{ teku_user }}"
   loop:

--- a/roles/teku/tasks/setup.yaml
+++ b/roles/teku/tasks/setup.yaml
@@ -7,7 +7,6 @@
   ansible.builtin.file:
     path: "{{ teku_datadir }}"
     state: directory
-    recurse: true
     owner: "{{ teku_user }}"
     group: "{{ teku_user }}"
 
@@ -15,7 +14,6 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
-    recurse: true
     owner: "{{ teku_user }}"
     group: "{{ teku_user }}"
   loop:


### PR DESCRIPTION
Example problem when using it with geth:

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: FileNotFoundError: [Errno 2] No such file or directory: b'/data/geth/geth/chaindata/107911.ldb'
fatal: [bootnode-aws-ap-southeast-1-001]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"<stdin>\", line 107, in <module>\n  File \"<stdin>\", line 99, in _ansiballz_main\n  File \"<stdin>\", line 47, in invoke_module\n  File \"/usr/lib/python3.9/runpy.py\", line 210, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib/python3.9/runpy.py\", line 97, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib/python3.9/runpy.py\", line 87, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_ansible.builtin.file_payload_u5seyj_0/ansible_ansible.builtin.file_payload.zip/ansible/modules/file.py\", line 983, in <module>\n  File \"/tmp/ansible_ansible.builtin.file_payload_u5seyj_0/ansible_ansible.builtin.file_payload.zip/ansible/modules/file.py\", line 969, in main\n  File \"/tmp/ansible_ansible.builtin.file_payload_u5seyj_0/ansible_ansible.builtin.file_payload.zip/ansible/modules/file.py\", line 679, in ensure_directory\n  File \"/tmp/ansible_ansible.builtin.file_payload_u5seyj_0/ansible_ansible.builtin.file_payload.zip/ansible/modules/file.py\", line 353, in recursive_set_attributes\n  File \"/tmp/ansible_ansible.builtin.file_payload_u5seyj_0/ansible_ansible.builtin.file_payload.zip/ansible/module_utils/basic.py\", line 1167, in set_fs_attributes_if_different\n  File \"/tmp/ansible_ansible.builtin.file_payload_u5seyj_0/ansible_ansible.builtin.file_payload.zip/ansible/module_utils/basic.py\", line 811, in set_owner_if_different\n  File \"/tmp/ansible_ansible.builtin.file_payload_u5seyj_0/ansible_ansible.builtin.file_payload.zip/ansible/module_utils/basic.py\", line 705, in user_and_group\nFileNotFoundError: [Errno 2] No such file or directory: b'/data/geth/geth/chaindata/107911.ldb'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```