### PR TITLE
Adding Json rpc snooper mitm

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ A collection of reusable ansible components used by the EthPandaOps team.
 - [oh_my_zsh](roles/oh_my_zsh)
 - [prometheus](roles/prometheus)
 - [s3_cron_backup](roles/s3_cron_backup)
+- [json_rpc_snooper](roles/json_rpc_snooper)
 
 ## Usage
 

--- a/roles/ethereum_node/defaults/main.yaml
+++ b/roles/ethereum_node/defaults/main.yaml
@@ -27,7 +27,7 @@ ethereum_node_fact_discovery_enabled: true
 # Json RPC snooper
 ethereum_node_json_rpc_snooper_enabled: false
 ethereum_node_json_rpc_snooper_port: 8560
-ethereum_node_json_rpc_snooper_name: "snooper"
+ethereum_node_json_rpc_snooper_name: "snooper-rpc"
 
 ethereum_node_json_rpc_snooper_engine_enabled: false
 ethereum_node_json_rpc_snooper_engine_port: 8561

--- a/roles/ethereum_node/defaults/main.yaml
+++ b/roles/ethereum_node/defaults/main.yaml
@@ -24,6 +24,9 @@ ethereum_node_cl_validator_fee_recipient: "0xF29Ff96aaEa6C9A1fBa851f74737f3c069d
 # Fact discovery
 ethereum_node_fact_discovery_enabled: true
 
+# Json RPC snooper
+ethereum_node_json_rpc_snooper_enabled: true
+
 # Mev boost
 ethereum_node_mev_boost_enabled: false
 

--- a/roles/ethereum_node/tasks/main.yaml
+++ b/roles/ethereum_node/tasks/main.yaml
@@ -17,6 +17,14 @@
     mev_boost_container_networks: "{{ ethereum_node_docker_networks }}"
   when: ethereum_node_mev_boost_enabled
 
+- name: Setup json_rpc_snooper
+  ansible.builtin.include_role:
+    name: ethpandaops.general.json_rpc_snooper
+  vars:
+    json_rpc_snooper_container_networks: "{{ ethereum_node_docker_networks }}"
+    el_engine_port: "{{ ethereum_node_el_ports_engine }}"
+  when: ethereum_node_json_rpc_snooper_enabled
+
 - name: Setup execution client
   ansible.builtin.import_tasks: setup_el.yaml
   when: ethereum_node_el_enabled

--- a/roles/ethereum_node/tasks/main.yaml
+++ b/roles/ethereum_node/tasks/main.yaml
@@ -22,7 +22,6 @@
     name: ethpandaops.general.json_rpc_snooper
   vars:
     json_rpc_snooper_container_networks: "{{ ethereum_node_docker_networks }}"
-    el_engine_port: "{{ ethereum_node_el_ports_engine }}"
   when: ethereum_node_json_rpc_snooper_enabled
 
 - name: Setup execution client

--- a/roles/ethereum_node/tasks/setup_cl.yaml
+++ b/roles/ethereum_node/tasks/setup_cl.yaml
@@ -9,7 +9,7 @@
     lighthouse_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     lighthouse_container_networks: "{{ ethereum_node_docker_networks }}"
     lighthouse_execution_engine_endpoint: >-
-      "{{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}"
+      {{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}
     lighthouse_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     lighthouse_validator_container_networks: "{{ ethereum_node_docker_networks }}"
     lighthouse_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
@@ -25,7 +25,7 @@
     teku_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     teku_container_networks: "{{ ethereum_node_docker_networks }}"
     teku_execution_engine_endpoint: >-
-      "{{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}"
+      {{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}
     teku_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     teku_validator_container_networks: "{{ ethereum_node_docker_networks }}"
     teku_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
@@ -41,7 +41,7 @@
     prysm_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     prysm_container_networks: "{{ ethereum_node_docker_networks }}"
     prysm_execution_engine_endpoint: >-
-      "{{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}"
+      {{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}
     prysm_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     prysm_validator_container_networks: "{{ ethereum_node_docker_networks }}"
     prysm_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
@@ -57,7 +57,7 @@
     lodestar_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     lodestar_container_networks: "{{ ethereum_node_docker_networks }}"
     lodestar_execution_engine_endpoint: >-
-      "{{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}"
+      {{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}
     lodestar_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     lodestar_validator_container_networks: "{{ ethereum_node_docker_networks }}"
     lodestar_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
@@ -73,7 +73,7 @@
     nimbus_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     nimbus_container_networks: "{{ ethereum_node_docker_networks }}"
     nimbus_execution_engine_endpoint: >-
-      "{{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}"
+      {{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}
     nimbus_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     nimbus_validator_container_networks: "{{ ethereum_node_docker_networks }}"
     nimbus_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"

--- a/roles/ethereum_node/tasks/setup_snooper.yaml
+++ b/roles/ethereum_node/tasks/setup_snooper.yaml
@@ -15,7 +15,7 @@
     json_rpc_snooper_container_networks: "{{ ethereum_node_docker_networks }}"
     json_rpc_snooper_container_name: "{{ ethereum_node_json_rpc_snooper_name }}"
     json_rpc_snooper_port: "{{ ethereum_node_json_rpc_snooper_port }}"
-    json_rpc_snooper_target: "{{ ethereum_node_el_rpc_snooper_endpoint }}"
+    json_rpc_snooper_target: "{{ ethereum_node_el_rpc_endpoint }}"
   when: ethereum_node_json_rpc_snooper_enabled
 
 - name: Cleanup json_rpc_snooper on EL engine

--- a/roles/ethereum_node/tasks/setup_snooper.yaml
+++ b/roles/ethereum_node/tasks/setup_snooper.yaml
@@ -3,7 +3,7 @@
     name: ethpandaops.general.json_rpc_snooper
   vars:
     json_rpc_snooper_container_networks: "{{ ethereum_node_docker_networks }}"
-    json_rpc_snooper_container_name: "{{ ethereum_node_json_rpc_snooper_name }}"
+    json_rpc_snooper_container_name: "{{ ethereum_node_json_rpc_snooper_engine_name }}"
     json_rpc_snooper_port: "{{ ethereum_node_json_rpc_snooper_engine_port }}"
     json_rpc_snooper_target: "{{ ethereum_node_el_engine_endpoint }}"
   when: ethereum_node_json_rpc_snooper_engine_enabled
@@ -23,7 +23,7 @@
     name: ethpandaops.general.json_rpc_snooper
   vars:
     json_rpc_snooper_cleanup: true
-    json_rpc_snooper_container_name: "{{ ethereum_node_json_rpc_snooper_name }}"
+    json_rpc_snooper_container_name: "{{ ethereum_node_json_rpc_snooper_engine_name }}"
   when: not ethereum_node_json_rpc_snooper_engine_enabled
 
 - name: Cleanup json_rpc_snooper on EL rpc

--- a/roles/ethereum_node/tasks/setup_snooper.yaml
+++ b/roles/ethereum_node/tasks/setup_snooper.yaml
@@ -15,7 +15,7 @@
     json_rpc_snooper_container_networks: "{{ ethereum_node_docker_networks }}"
     json_rpc_snooper_container_name: "{{ ethereum_node_json_rpc_snooper_name }}"
     json_rpc_snooper_port: "{{ ethereum_node_json_rpc_snooper_port }}"
-    json_rpc_snooper_target: "{{ ethereum_node_el_endpoint }}"
+    json_rpc_snooper_target: "{{ ethereum_node_el_rpc_snooper_endpoint }}"
   when: ethereum_node_json_rpc_snooper_enabled
 
 - name: Cleanup json_rpc_snooper on EL engine

--- a/roles/ethereum_node/tasks/setup_snooper.yaml
+++ b/roles/ethereum_node/tasks/setup_snooper.yaml
@@ -32,4 +32,4 @@
   vars:
     json_rpc_snooper_cleanup: true
     json_rpc_snooper_container_name: "{{ ethereum_node_json_rpc_snooper_name }}"
-  when: ethereum_node_json_rpc_snooper_enabled
+  when: not ethereum_node_json_rpc_snooper_enabled

--- a/roles/json_rpc_snooper/README.md
+++ b/roles/json_rpc_snooper/README.md
@@ -1,0 +1,38 @@
+# ethpandaops.general.json_rpc_snooper
+
+This role will run [json_rpc_snooper](https://github.com/ethDreamer/json_rpc_snoop) within a docker container.
+
+## Requirements
+
+You'll need docker on the target system. Make sure to install it upfront.
+
+## Role Variables
+
+Default variables are defined in [defaults/main.yaml](defaults/main.yaml)
+
+## Dependencies
+
+You'll need docker to run this role. One way of installing docker could be via ansible galaxy with the following dependencies set within `requirements.yaml`:
+
+```yaml
+roles:
+- src: geerlingguy.docker
+  version: latest
+- src: geerlingguy.pip
+  version: latest
+```
+
+## Example Playbook
+
+Your playbook could look like this:
+
+```yaml
+- hosts: localhost
+  become: true
+  roles:
+  - role: geerlingguy.docker
+  - role: geerlingguy.pip
+    pip_install_packages:
+    - name: docker
+  - role: ethpandaops.general.json_rpc_snooper
+```

--- a/roles/json_rpc_snooper/defaults/main.yml
+++ b/roles/json_rpc_snooper/defaults/main.yml
@@ -19,6 +19,7 @@ json_rpc_snooper_container_networks: []
 json_rpc_snooper_container_volumes: []
 json_rpc_snooper_container_command:
   - "./json_rpc_snoop"
+  - "-b=0.0.0.0"
   - "-p={{ json_rpc_snooper_port }}"
   - "{{ json_rpc_snooper_target }}"
 

--- a/roles/json_rpc_snooper/defaults/main.yml
+++ b/roles/json_rpc_snooper/defaults/main.yml
@@ -1,0 +1,23 @@
+json_rpc_snooper_user: json_rpc_snooper
+
+json_rpc_snooper_cleanup: false # when set to "true" it will remove the container(s)
+
+################################################################################
+##
+## json_rpc_snooper container configuration
+##
+################################################################################
+json_rpc_snooper_container_name: snooper
+json_rpc_snooper_container_image: parithoshj/json_rpc_snoop:v1.0.0-x86
+json_rpc_snooper_container_env: {}
+el_engine_snoop_port: 8560
+el_engine_port: 8551
+json_rpc_snooper_container_ports:
+  - "127.0.0.1:{{ el_engine_snoop_port }}:{{ el_engine_snoop_port }}"
+
+json_rpc_snooper_container_networks: []
+json_rpc_snooper_container_volumes: []
+json_rpc_snooper_container_command:
+  - "./json_rpc_snoop -p {{el_engine_snoop_port}} http://127.0.0.1:{{el_engine_port}}"
+
+json_rpc_snooper_container_command_extra_args: []

--- a/roles/json_rpc_snooper/defaults/main.yml
+++ b/roles/json_rpc_snooper/defaults/main.yml
@@ -11,13 +11,15 @@ json_rpc_snooper_container_name: snooper
 json_rpc_snooper_container_image: parithoshj/json_rpc_snoop:v1.0.0-x86
 json_rpc_snooper_container_env: {}
 json_rpc_snooper_port: 8560
-json_rpc_snooper_target: http:127.0.0.1:8888
+json_rpc_snooper_target: http://jsonrpc-target:8888
 json_rpc_snooper_container_ports:
   - "127.0.0.1:{{ json_rpc_snooper_port }}:{{ json_rpc_snooper_port }}"
 
 json_rpc_snooper_container_networks: []
 json_rpc_snooper_container_volumes: []
 json_rpc_snooper_container_command:
-  - "./json_rpc_snoop -p {{ json_rpc_snooper_port }} {{ json_rpc_snooper_target }}"
+  - "./json_rpc_snoop"
+  - "-p={{ json_rpc_snooper_port }}"
+  - "{{ json_rpc_snooper_target }}"
 
 json_rpc_snooper_container_command_extra_args: []

--- a/roles/json_rpc_snooper/defaults/main.yml
+++ b/roles/json_rpc_snooper/defaults/main.yml
@@ -11,13 +11,13 @@ json_rpc_snooper_container_name: snooper
 json_rpc_snooper_container_image: parithoshj/json_rpc_snoop:v1.0.0-x86
 json_rpc_snooper_container_env: {}
 json_rpc_snooper_port: 8560
-json_rpc_snooper_taget: http:127.0.0.1:8888
+json_rpc_snooper_target: http:127.0.0.1:8888
 json_rpc_snooper_container_ports:
   - "127.0.0.1:{{ json_rpc_snooper_port }}:{{ json_rpc_snooper_port }}"
 
 json_rpc_snooper_container_networks: []
 json_rpc_snooper_container_volumes: []
 json_rpc_snooper_container_command:
-  - "./json_rpc_snoop -p {{json_rpc_snooper_port}} {{ json_rpc_snooper_taget }}"
+  - "./json_rpc_snoop -p {{json_rpc_snooper_port}} {{ json_rpc_snooper_target }}"
 
 json_rpc_snooper_container_command_extra_args: []

--- a/roles/json_rpc_snooper/defaults/main.yml
+++ b/roles/json_rpc_snooper/defaults/main.yml
@@ -10,14 +10,14 @@ json_rpc_snooper_cleanup: false # when set to "true" it will remove the containe
 json_rpc_snooper_container_name: snooper
 json_rpc_snooper_container_image: parithoshj/json_rpc_snoop:v1.0.0-x86
 json_rpc_snooper_container_env: {}
-el_engine_snoop_port: 8560
-el_engine_port: 8551
+json_rpc_snooper_port: 8560
+json_rpc_snooper_taget: http:127.0.0.1:8888
 json_rpc_snooper_container_ports:
-  - "127.0.0.1:{{ el_engine_snoop_port }}:{{ el_engine_snoop_port }}"
+  - "127.0.0.1:{{ json_rpc_snooper_port }}:{{ json_rpc_snooper_port }}"
 
 json_rpc_snooper_container_networks: []
 json_rpc_snooper_container_volumes: []
 json_rpc_snooper_container_command:
-  - "./json_rpc_snoop -p {{el_engine_snoop_port}} http://127.0.0.1:{{el_engine_port}}"
+  - "./json_rpc_snoop -p {{json_rpc_snooper_port}} {{ json_rpc_snooper_taget }}"
 
 json_rpc_snooper_container_command_extra_args: []

--- a/roles/json_rpc_snooper/tasks/cleanup.yaml
+++ b/roles/json_rpc_snooper/tasks/cleanup.yaml
@@ -1,0 +1,5 @@
+- name: Remove json_rpc_snooper container
+  community.docker.docker_container:
+    name: "{{ json_rpc_snooper_container_name }}"
+    state: absent
+  when: json_rpc_snooper_cleanup

--- a/roles/json_rpc_snooper/tasks/main.yml
+++ b/roles/json_rpc_snooper/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+# tasks file for json_rpc_snooper
+- name: Setup json_rpc_snooper
+  ansible.builtin.import_tasks: setup.yaml
+  when: not json_rpc_snooper_cleanup
+
+- name: Cleanup json_rpc_snooper
+  ansible.builtin.import_tasks: cleanup.yaml

--- a/roles/json_rpc_snooper/tasks/setup.yaml
+++ b/roles/json_rpc_snooper/tasks/setup.yaml
@@ -14,4 +14,4 @@
     networks: "{{ json_rpc_snooper_container_networks }}"
     ports: "{{ json_rpc_snooper_container_ports }}"
     command: "{{ json_rpc_snooper_container_command + json_rpc_snooper_container_command_extra_args }} "
-    user: "{{ json_rpc_snooper_user.uid }}"
+    user: "{{ json_rpc_snooper_user_meta.uid }}"

--- a/roles/json_rpc_snooper/tasks/setup.yaml
+++ b/roles/json_rpc_snooper/tasks/setup.yaml
@@ -1,0 +1,17 @@
+- name: Add json_rpc_snooper user
+  ansible.builtin.user:
+    name: "{{ json_rpc_snooper_user }}"
+  register: json_rpc_snooper_user_meta
+
+- name: Run json_rpc_snooper container
+  community.docker.docker_container:
+    name: "{{ json_rpc_snooper_container_name }}"
+    image: "{{ json_rpc_snooper_container_image }}"
+    state: started
+    restart_policy: always
+    volumes: "{{ json_rpc_snooper_container_volumes }}"
+    env: "{{ json_rpc_snooper_container_env }}"
+    networks: "{{ json_rpc_snooper_container_networks }}"
+    ports: "{{ json_rpc_snooper_container_ports }}"
+    command: "{{ json_rpc_snooper_container_command + json_rpc_snooper_container_command_extra_args }} "
+    user: "{{ json_rpc_snooper_user.uid }}"


### PR DESCRIPTION
One would use this role by setting the following variables:
- `ethereum_node_json_rpc_snooper_enabled`: `true`
- `ethereum_node_el_engine_endpoint`: `http://{{ json_rpc_snooper_container_name }}:{{ el_engine_snoop_port }}`

I think i need to define `el_engine_snoop_port` in `ethereum_node` but i need to check if that makes sense or not. its currently only defined in the role `json_rpc_snooper` as a default but i guess the config is happening at the `ethereum_node` level (since it needs to set `ethereum_node_el_engine_endpoint` when starting role `lighthouse`, etc). 

This would mean:
- Json rpc snooper gets added
- traffic passes through the defined snooper port
- snooper mitm logs the requests and passes it to the actual engine port