### PR TITLE
ethereum_node: make rpc snooper available for default rpc or engine endpoints

### DIFF
--- a/roles/ethereum_node/defaults/main.yaml
+++ b/roles/ethereum_node/defaults/main.yaml
@@ -25,7 +25,13 @@ ethereum_node_cl_validator_fee_recipient: "0xF29Ff96aaEa6C9A1fBa851f74737f3c069d
 ethereum_node_fact_discovery_enabled: true
 
 # Json RPC snooper
-ethereum_node_json_rpc_snooper_enabled: true
+ethereum_node_json_rpc_snooper_enabled: false
+ethereum_node_json_rpc_snooper_port: 8560
+ethereum_node_json_rpc_snooper_name: "snooper"
+
+ethereum_node_json_rpc_snooper_engine_enabled: false
+ethereum_node_json_rpc_snooper_engine_port: 8561
+ethereum_node_json_rpc_snooper_engine_name: "snooper-engine"
 
 # Mev boost
 ethereum_node_mev_boost_enabled: false
@@ -38,5 +44,7 @@ ethereum_node_xatu_sentry_enabled: false
 
 # Generated RPC/Engine/Beacon endpoints
 ethereum_node_el_engine_endpoint: "http://{{ ethereum_node_el }}:{{ ethereum_node_el_ports_engine }}"
+ethereum_node_el_engine_snooper_endpoint: "http://{{ ethereum_node_json_rpc_snooper_engine_name }}:{{ ethereum_node_json_rpc_snooper_engine_port }}"
 ethereum_node_el_rpc_endpoint: "http://{{ ethereum_node_el }}:{{ ethereum_node_el_ports_http_rpc }}"
+ethereum_node_el_rpc_snooper_endpoint: "http://{{ ethereum_node_json_rpc_snooper_name }}:{{ ethereum_node_json_rpc_snooper_port }}"
 ethereum_node_cl_beacon_endpoint: "http://{{ ethereum_node_cl }}:{{ ethereum_node_cl_ports_http_beacon }}"

--- a/roles/ethereum_node/tasks/main.yaml
+++ b/roles/ethereum_node/tasks/main.yaml
@@ -17,16 +17,13 @@
     mev_boost_container_networks: "{{ ethereum_node_docker_networks }}"
   when: ethereum_node_mev_boost_enabled
 
-- name: Setup json_rpc_snooper
-  ansible.builtin.include_role:
-    name: ethpandaops.general.json_rpc_snooper
-  vars:
-    json_rpc_snooper_container_networks: "{{ ethereum_node_docker_networks }}"
-  when: ethereum_node_json_rpc_snooper_enabled
-
 - name: Setup execution client
   ansible.builtin.import_tasks: setup_el.yaml
   when: ethereum_node_el_enabled
+
+- name: Setup execution client rpc snooper
+  ansible.builtin.import_tasks: setup_snooper.yaml
+  when: ethereum_node_json_rpc_snooper_enabled or ethereum_node_json_rpc_snooper_engine_enabled
 
 - name: Setup consensus client
   ansible.builtin.import_tasks: setup_cl.yaml

--- a/roles/ethereum_node/tasks/setup_cl.yaml
+++ b/roles/ethereum_node/tasks/setup_cl.yaml
@@ -8,7 +8,8 @@
     lighthouse_ports_http_beacon: "{{ ethereum_node_cl_ports_http_beacon }}"
     lighthouse_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     lighthouse_container_networks: "{{ ethereum_node_docker_networks }}"
-    lighthouse_execution_engine_endpoint: "{{ ethereum_node_el_engine_endpoint }}"
+    lighthouse_execution_engine_endpoint: >-
+      "{{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint,ethereum_node_el_engine_endpoint) }}"
     lighthouse_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     lighthouse_validator_container_networks: "{{ ethereum_node_docker_networks }}"
     lighthouse_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
@@ -23,7 +24,8 @@
     teku_ports_http_beacon: "{{ ethereum_node_cl_ports_http_beacon }}"
     teku_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     teku_container_networks: "{{ ethereum_node_docker_networks }}"
-    teku_execution_engine_endpoint: "{{ ethereum_node_el_engine_endpoint }}"
+    teku_execution_engine_endpoint: >-
+      "{{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint,ethereum_node_el_engine_endpoint) }}"
     teku_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     teku_validator_container_networks: "{{ ethereum_node_docker_networks }}"
     teku_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
@@ -38,7 +40,8 @@
     prysm_ports_http_beacon: "{{ ethereum_node_cl_ports_http_beacon }}"
     prysm_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     prysm_container_networks: "{{ ethereum_node_docker_networks }}"
-    prysm_execution_engine_endpoint: "{{ ethereum_node_el_engine_endpoint }}"
+    prysm_execution_engine_endpoint: >-
+      "{{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint,ethereum_node_el_engine_endpoint) }}"
     prysm_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     prysm_validator_container_networks: "{{ ethereum_node_docker_networks }}"
     prysm_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
@@ -53,7 +56,8 @@
     lodestar_ports_http_beacon: "{{ ethereum_node_cl_ports_http_beacon }}"
     lodestar_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     lodestar_container_networks: "{{ ethereum_node_docker_networks }}"
-    lodestar_execution_engine_endpoint: "{{ ethereum_node_el_engine_endpoint }}"
+    lodestar_execution_engine_endpoint: >-
+      "{{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint,ethereum_node_el_engine_endpoint) }}"
     lodestar_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     lodestar_validator_container_networks: "{{ ethereum_node_docker_networks }}"
     lodestar_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
@@ -68,7 +72,8 @@
     nimbus_ports_http_beacon: "{{ ethereum_node_cl_ports_http_beacon }}"
     nimbus_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     nimbus_container_networks: "{{ ethereum_node_docker_networks }}"
-    nimbus_execution_engine_endpoint: "{{ ethereum_node_el_engine_endpoint }}"
+    nimbus_execution_engine_endpoint: >-
+      "{{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint,ethereum_node_el_engine_endpoint) }}"
     nimbus_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     nimbus_validator_container_networks: "{{ ethereum_node_docker_networks }}"
     nimbus_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"

--- a/roles/ethereum_node/tasks/setup_cl.yaml
+++ b/roles/ethereum_node/tasks/setup_cl.yaml
@@ -9,7 +9,7 @@
     lighthouse_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     lighthouse_container_networks: "{{ ethereum_node_docker_networks }}"
     lighthouse_execution_engine_endpoint: >-
-      "{{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint,ethereum_node_el_engine_endpoint) }}"
+      "{{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}"
     lighthouse_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     lighthouse_validator_container_networks: "{{ ethereum_node_docker_networks }}"
     lighthouse_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
@@ -25,7 +25,7 @@
     teku_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     teku_container_networks: "{{ ethereum_node_docker_networks }}"
     teku_execution_engine_endpoint: >-
-      "{{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint,ethereum_node_el_engine_endpoint) }}"
+      "{{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}"
     teku_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     teku_validator_container_networks: "{{ ethereum_node_docker_networks }}"
     teku_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
@@ -41,7 +41,7 @@
     prysm_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     prysm_container_networks: "{{ ethereum_node_docker_networks }}"
     prysm_execution_engine_endpoint: >-
-      "{{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint,ethereum_node_el_engine_endpoint) }}"
+      "{{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}"
     prysm_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     prysm_validator_container_networks: "{{ ethereum_node_docker_networks }}"
     prysm_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
@@ -57,7 +57,7 @@
     lodestar_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     lodestar_container_networks: "{{ ethereum_node_docker_networks }}"
     lodestar_execution_engine_endpoint: >-
-      "{{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint,ethereum_node_el_engine_endpoint) }}"
+      "{{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}"
     lodestar_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     lodestar_validator_container_networks: "{{ ethereum_node_docker_networks }}"
     lodestar_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
@@ -73,7 +73,7 @@
     nimbus_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     nimbus_container_networks: "{{ ethereum_node_docker_networks }}"
     nimbus_execution_engine_endpoint: >-
-      "{{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint,ethereum_node_el_engine_endpoint) }}"
+      "{{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}"
     nimbus_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     nimbus_validator_container_networks: "{{ ethereum_node_docker_networks }}"
     nimbus_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"

--- a/roles/ethereum_node/tasks/setup_snooper.yaml
+++ b/roles/ethereum_node/tasks/setup_snooper.yaml
@@ -8,7 +8,6 @@
     json_rpc_snooper_target: "{{ ethereum_node_el_engine_endpoint }}"
   when: ethereum_node_json_rpc_snooper_engine_enabled
 
-
 - name: Setup json_rpc_snooper on EL rpc
   ansible.builtin.include_role:
     name: ethpandaops.general.json_rpc_snooper
@@ -17,4 +16,20 @@
     json_rpc_snooper_container_name: "{{ ethereum_node_json_rpc_snooper_name }}"
     json_rpc_snooper_port: "{{ ethereum_node_json_rpc_snooper_port }}"
     json_rpc_snooper_target: "{{ ethereum_node_el_endpoint }}"
+  when: ethereum_node_json_rpc_snooper_enabled
+
+- name: Cleanup json_rpc_snooper on EL engine
+  ansible.builtin.include_role:
+    name: ethpandaops.general.json_rpc_snooper
+  vars:
+    json_rpc_snooper_cleanup: true
+    json_rpc_snooper_container_name: "{{ ethereum_node_json_rpc_snooper_name }}"
+  when: not ethereum_node_json_rpc_snooper_engine_enabled
+
+- name: Cleanup json_rpc_snooper on EL rpc
+  ansible.builtin.include_role:
+    name: ethpandaops.general.json_rpc_snooper
+  vars:
+    json_rpc_snooper_cleanup: true
+    json_rpc_snooper_container_name: "{{ ethereum_node_json_rpc_snooper_name }}"
   when: ethereum_node_json_rpc_snooper_enabled

--- a/roles/ethereum_node/tasks/setup_snooper.yaml
+++ b/roles/ethereum_node/tasks/setup_snooper.yaml
@@ -1,0 +1,20 @@
+- name: Setup json_rpc_snooper on EL engine
+  ansible.builtin.include_role:
+    name: ethpandaops.general.json_rpc_snooper
+  vars:
+    json_rpc_snooper_container_networks: "{{ ethereum_node_docker_networks }}"
+    json_rpc_snooper_container_name: "{{ ethereum_node_json_rpc_snooper_name }}"
+    json_rpc_snooper_port: "{{ ethereum_node_json_rpc_snooper_engine_port }}"
+    json_rpc_snooper_target: "{{ ethereum_node_el_engine_endpoint }}"
+  when: ethereum_node_json_rpc_snooper_engine_enabled
+
+
+- name: Setup json_rpc_snooper on EL rpc
+  ansible.builtin.include_role:
+    name: ethpandaops.general.json_rpc_snooper
+  vars:
+    json_rpc_snooper_container_networks: "{{ ethereum_node_docker_networks }}"
+    json_rpc_snooper_container_name: "{{ ethereum_node_json_rpc_snooper_name }}"
+    json_rpc_snooper_port: "{{ ethereum_node_json_rpc_snooper_port }}"
+    json_rpc_snooper_target: "{{ ethereum_node_el_endpoint }}"
+  when: ethereum_node_json_rpc_snooper_enabled

--- a/roles/json_rpc_snooper/defaults/main.yml
+++ b/roles/json_rpc_snooper/defaults/main.yml
@@ -18,6 +18,6 @@ json_rpc_snooper_container_ports:
 json_rpc_snooper_container_networks: []
 json_rpc_snooper_container_volumes: []
 json_rpc_snooper_container_command:
-  - "./json_rpc_snoop -p {{json_rpc_snooper_port}} {{ json_rpc_snooper_target }}"
+  - "./json_rpc_snoop -p {{ json_rpc_snooper_port }} {{ json_rpc_snooper_target }}"
 
 json_rpc_snooper_container_command_extra_args: []


### PR DESCRIPTION
- The EL's keep running on the usual ports.
- The CL's will adapt and point to the right endpoint (EL directly, or snooper) depending on if the engine snooper is enabled.
- Also added the possibility to run the snooper on the default rpc port. 