### PR TITLE
Add nimbus checkpoint sync

### DIFF
--- a/roles/geth/defaults/main.yaml
+++ b/roles/geth/defaults/main.yaml
@@ -42,6 +42,7 @@ geth_container_command_extra_args: []
 
 # Only required changing when running custom networks
 geth_init_custom_network: false
+geth_init_autoremove_enabled: true
 geth_init_custom_network_genesis_file: /config/genesis.json
 geth_init_custom_network_container_env: {}
 geth_init_custom_network_container_volumes:

--- a/roles/geth/defaults/main.yaml
+++ b/roles/geth/defaults/main.yaml
@@ -42,7 +42,7 @@ geth_container_command_extra_args: []
 
 # Only required changing when running custom networks
 geth_init_custom_network: false
-geth_init_autoremove_enabled: true
+geth_init_autoremove_enabled: false
 geth_init_custom_network_genesis_file: /config/genesis.json
 geth_init_custom_network_container_env: {}
 geth_init_custom_network_container_volumes:

--- a/roles/geth/tasks/setup.yaml
+++ b/roles/geth/tasks/setup.yaml
@@ -23,7 +23,7 @@
         name: "{{ geth_container_name }}-init"
         image: "{{ geth_container_image }}"
         detach: false
-        auto_remove: true
+        auto_remove: {{ geth_init_autoremove_enabled }}
         restart_policy: "no"
         state: started
         volumes: "{{ geth_init_custom_network_container_volumes }}"

--- a/roles/geth/tasks/setup.yaml
+++ b/roles/geth/tasks/setup.yaml
@@ -23,7 +23,7 @@
         name: "{{ geth_container_name }}-init"
         image: "{{ geth_container_image }}"
         detach: false
-        auto_remove: {{ geth_init_autoremove_enabled }}
+        auto_remove: "{{ geth_init_autoremove_enabled }}"
         restart_policy: "no"
         state: started
         volumes: "{{ geth_init_custom_network_container_volumes }}"

--- a/roles/nimbus/defaults/main.yaml
+++ b/roles/nimbus/defaults/main.yaml
@@ -26,7 +26,7 @@ nimbus_checkpoint_container_command:
   - --data-dir=/data
 nimbus_checkpoint_container_command_extra_args: []
 nimbus_checkpoint_sync_enabled: false
-nimbus_checkpoint_autoremove_enabled: true
+nimbus_checkpoint_autoremove_enabled: false
 ################################################################################
 ##
 ## Beacon node container configuration

--- a/roles/nimbus/defaults/main.yaml
+++ b/roles/nimbus/defaults/main.yaml
@@ -16,6 +16,18 @@ nimbus_validator_datadir: /data/nimbus-validator
 
 ################################################################################
 ##
+## Checkpoint sync container configuration
+##
+################################################################################
+nimbus_checkpoint_container_name: nimbus_checkpoint
+nimbus_checkpoint_container_command:
+  - nimbus_beacon_node trustedNodeSync
+  - --data-dir=/data
+nimbus_checkpoint_container_command_extra_args: []
+nimbus_checkpoint_sync_enabled: false
+
+################################################################################
+##
 ## Beacon node container configuration
 ##
 ################################################################################

--- a/roles/nimbus/defaults/main.yaml
+++ b/roles/nimbus/defaults/main.yaml
@@ -21,11 +21,12 @@ nimbus_validator_datadir: /data/nimbus-validator
 ################################################################################
 nimbus_checkpoint_container_name: nimbus_checkpoint
 nimbus_checkpoint_container_command:
-  - nimbus_beacon_node trustedNodeSync
+  - nimbus_beacon_node
+  - trustedNodeSync
   - --data-dir=/data
 nimbus_checkpoint_container_command_extra_args: []
 nimbus_checkpoint_sync_enabled: false
-
+nimbus_checkpoint_autoremove_enabled: true
 ################################################################################
 ##
 ## Beacon node container configuration

--- a/roles/nimbus/tasks/setup.yaml
+++ b/roles/nimbus/tasks/setup.yaml
@@ -31,13 +31,13 @@
     image: "{{ nimbus_container_image }}"
     state: started
     detach: false
-    auto_remove: {{ nimbus_checkpoint_autoremove_enabled }}
+    auto_remove: "{{ nimbus_checkpoint_autoremove_enabled }}"
     restart_policy: "no"
     stop_timeout: "{{ nimbus_container_stop_timeout }}"
-    volumes: {{ nimbus_container_volumes }}
+    volumes: "{{ nimbus_container_volumes }}"
     env: "{{ nimbus_container_env }}"
     networks: "{{ nimbus_container_networks }}"
-    command: {{ nimbus_checkpoint_container_command + nimbus_checkpoint_container_command_extra_args }}
+    command: "{{ nimbus_checkpoint_container_command + nimbus_checkpoint_container_command_extra_args }}"
     user: "{{ nimbus_user_meta.uid }}"
 
 - name: Run nimbus container

--- a/roles/nimbus/tasks/setup.yaml
+++ b/roles/nimbus/tasks/setup.yaml
@@ -30,6 +30,9 @@
     name: "{{ nimbus_checkpoint_container_name }}"
     image: "{{ nimbus_container_image }}"
     state: started
+    detach: false
+    auto_remove: {{ nimbus_checkpoint_autoremove_enabled }}
+    restart_policy: "no"
     stop_timeout: "{{ nimbus_container_stop_timeout }}"
     volumes: {{ nimbus_container_volumes }}
     env: "{{ nimbus_container_env }}"

--- a/roles/nimbus/tasks/setup.yaml
+++ b/roles/nimbus/tasks/setup.yaml
@@ -31,13 +31,7 @@
     image: "{{ nimbus_container_image }}"
     state: started
     stop_timeout: "{{ nimbus_container_stop_timeout }}"
-    volumes: >-
-      {{
-        nimbus_validator_enabled | ternary(
-          nimbus_container_volumes + nimbus_container_validator_volumes,
-          nimbus_container_volumes
-        )
-      }}
+    volumes: {{ nimbus_container_volumes }}
     env: "{{ nimbus_container_env }}"
     networks: "{{ nimbus_container_networks }}"
     command: {{ nimbus_checkpoint_container_command + nimbus_checkpoint_container_command_extra_args }}

--- a/roles/nimbus/tasks/setup.yaml
+++ b/roles/nimbus/tasks/setup.yaml
@@ -24,6 +24,28 @@
     - "{{ nimbus_validator_datadir }}/secrets"
   when: nimbus_validator_enabled
 
+- name: Checkpoint sync nimbus node
+  when: nimbus_checkpoint_sync_enabled
+  community.docker.docker_container:
+    name: "{{ nimbus_checkpoint_container_name }}"
+    image: "{{ nimbus_container_image }}"
+    state: started
+    stop_timeout: "{{ nimbus_container_stop_timeout }}"
+    volumes: >-
+      {{
+        nimbus_validator_enabled | ternary(
+          nimbus_container_volumes + nimbus_container_validator_volumes,
+          nimbus_container_volumes
+        )
+      }}
+    env: "{{ nimbus_container_env }}"
+    networks: "{{ nimbus_container_networks }}"
+    command: >-
+      {{
+          nimbus_checkpoint_container_command + nimbus_checkpoint_container_command_extra_args,
+      }}
+    user: "{{ nimbus_user_meta.uid }}"
+
 - name: Run nimbus container
   community.docker.docker_container:
     name: "{{ nimbus_container_name }}"

--- a/roles/nimbus/tasks/setup.yaml
+++ b/roles/nimbus/tasks/setup.yaml
@@ -40,10 +40,7 @@
       }}
     env: "{{ nimbus_container_env }}"
     networks: "{{ nimbus_container_networks }}"
-    command: >-
-      {{
-          nimbus_checkpoint_container_command + nimbus_checkpoint_container_command_extra_args,
-      }}
+    command: {{ nimbus_checkpoint_container_command + nimbus_checkpoint_container_command_extra_args }}
     user: "{{ nimbus_user_meta.uid }}"
 
 - name: Run nimbus container


### PR DESCRIPTION
Nimbus requires a separate container to checkpoint sync. This PR adds the functionality to do so.