### PR TITLE
all clients: add data dir permission fixup 

### DIFF
--- a/roles/arbitrum_node/tasks/main.yaml
+++ b/roles/arbitrum_node/tasks/main.yaml
@@ -7,7 +7,8 @@
     mode: "0750"
 
 - name: Set permissions
-  ansible.builtin.shell: "chown -R 1000:1000 {{ arbitrum_node_datadir }}"
+  ansible.builtin.command: "chown -R 1000:1000 {{ arbitrum_node_datadir }}" # noqa deprecated-command-syntax
+  changed_when: false
 
 - name: Run arbitrum_node container
   community.docker.docker_container:

--- a/roles/arbitrum_node/tasks/main.yaml
+++ b/roles/arbitrum_node/tasks/main.yaml
@@ -6,6 +6,9 @@
     state: directory
     mode: "0750"
 
+- name: Set permissions
+  ansible.builtin.shell: "chown -R 1000:1000 {{ arbitrum_node_datadir }}"
+
 - name: Run arbitrum_node container
   community.docker.docker_container:
     name: "{{ arbitrum_node_container_name }}"

--- a/roles/besu/tasks/setup.yaml
+++ b/roles/besu/tasks/setup.yaml
@@ -11,6 +11,9 @@
     owner: "{{ besu_user }}"
     group: "{{ besu_user }}"
 
+- name: Set permissions
+  ansible.builtin.shell: "chown -R {{ besu_user }}:{{ besu_user }} {{ besu_datadir }}"
+
 - name: Run besu container
   community.docker.docker_container:
     name: "{{ besu_container_name }}"

--- a/roles/besu/tasks/setup.yaml
+++ b/roles/besu/tasks/setup.yaml
@@ -13,6 +13,7 @@
 
 - name: Set permissions
   ansible.builtin.command: "chown -R {{ besu_user }}:{{ besu_user }} {{ besu_datadir }}" # noqa deprecated-command-syntax
+  changed_when: false
 
 - name: Run besu container
   community.docker.docker_container:

--- a/roles/besu/tasks/setup.yaml
+++ b/roles/besu/tasks/setup.yaml
@@ -12,7 +12,7 @@
     group: "{{ besu_user }}"
 
 - name: Set permissions
-  ansible.builtin.shell: "chown -R {{ besu_user }}:{{ besu_user }} {{ besu_datadir }}"
+  ansible.builtin.command: "chown -R {{ besu_user }}:{{ besu_user }} {{ besu_datadir }}" # noqa deprecated-command-syntax
 
 - name: Run besu container
   community.docker.docker_container:

--- a/roles/erigon/tasks/setup.yaml
+++ b/roles/erigon/tasks/setup.yaml
@@ -13,6 +13,7 @@
 
 - name: Set permissions
   ansible.builtin.command: "chown -R {{ erigon_user }}:{{ erigon_user }} {{ erigon_datadir }}" # noqa deprecated-command-syntax
+  changed_when: false
 
 - name: Init custom network
   when: erigon_init_custom_network

--- a/roles/erigon/tasks/setup.yaml
+++ b/roles/erigon/tasks/setup.yaml
@@ -12,7 +12,7 @@
     group: "{{ erigon_user }}"
 
 - name: Set permissions
-  ansible.builtin.shell: "chown -R {{ erigon_user }}:{{ erigon_user }} {{ erigon_datadir }}"
+  ansible.builtin.command: "chown -R {{ erigon_user }}:{{ erigon_user }} {{ erigon_datadir }}" # noqa deprecated-command-syntax
 
 - name: Init custom network
   when: erigon_init_custom_network

--- a/roles/erigon/tasks/setup.yaml
+++ b/roles/erigon/tasks/setup.yaml
@@ -11,6 +11,9 @@
     owner: "{{ erigon_user }}"
     group: "{{ erigon_user }}"
 
+- name: Set permissions
+  ansible.builtin.shell: "chown -R {{ erigon_user }}:{{ erigon_user }} {{ erigon_datadir }}"
+
 - name: Init custom network
   when: erigon_init_custom_network
   block:

--- a/roles/ethereumjs/tasks/setup.yaml
+++ b/roles/ethereumjs/tasks/setup.yaml
@@ -13,6 +13,7 @@
 
 - name: Set permissions
   ansible.builtin.command: "chown -R {{ ethereumjs_user }}:{{ ethereumjs_user }} {{ ethereumjs_datadir }}" # noqa deprecated-command-syntax
+  changed_when: false
 
 - name: Run ethereumjs container
   community.docker.docker_container:

--- a/roles/ethereumjs/tasks/setup.yaml
+++ b/roles/ethereumjs/tasks/setup.yaml
@@ -11,6 +11,9 @@
     owner: "{{ ethereumjs_user }}"
     group: "{{ ethereumjs_user }}"
 
+- name: Set permissions
+  ansible.builtin.shell: "chown -R {{ ethereumjs_user }}:{{ ethereumjs_user }} {{ ethereumjs_datadir }}"
+
 - name: Run ethereumjs container
   community.docker.docker_container:
     name: "{{ ethereumjs_container_name }}"

--- a/roles/ethereumjs/tasks/setup.yaml
+++ b/roles/ethereumjs/tasks/setup.yaml
@@ -12,7 +12,7 @@
     group: "{{ ethereumjs_user }}"
 
 - name: Set permissions
-  ansible.builtin.shell: "chown -R {{ ethereumjs_user }}:{{ ethereumjs_user }} {{ ethereumjs_datadir }}"
+  ansible.builtin.command: "chown -R {{ ethereumjs_user }}:{{ ethereumjs_user }} {{ ethereumjs_datadir }}" # noqa deprecated-command-syntax
 
 - name: Run ethereumjs container
   community.docker.docker_container:

--- a/roles/geth/tasks/setup.yaml
+++ b/roles/geth/tasks/setup.yaml
@@ -12,7 +12,7 @@
     group: "{{ geth_user }}"
 
 - name: Set permissions
-  ansible.builtin.shell: "chown -R {{ geth_user }}:{{ geth_user }} {{ geth_datadir }}"
+  ansible.builtin.command: "chown -R {{ geth_user }}:{{ geth_user }} {{ geth_datadir }}" # noqa deprecated-command-syntax
 
 - name: Init custom network
   when: geth_init_custom_network

--- a/roles/geth/tasks/setup.yaml
+++ b/roles/geth/tasks/setup.yaml
@@ -11,6 +11,9 @@
     owner: "{{ geth_user }}"
     group: "{{ geth_user }}"
 
+- name: Set permissions
+  ansible.builtin.shell: "chown -R {{ geth_user }}:{{ geth_user }} {{ geth_datadir }}"
+
 - name: Init custom network
   when: geth_init_custom_network
   block:

--- a/roles/geth/tasks/setup.yaml
+++ b/roles/geth/tasks/setup.yaml
@@ -13,6 +13,7 @@
 
 - name: Set permissions
   ansible.builtin.command: "chown -R {{ geth_user }}:{{ geth_user }} {{ geth_datadir }}" # noqa deprecated-command-syntax
+  changed_when: false
 
 - name: Init custom network
   when: geth_init_custom_network

--- a/roles/lighthouse/tasks/setup.yaml
+++ b/roles/lighthouse/tasks/setup.yaml
@@ -12,7 +12,7 @@
     group: "{{ lighthouse_user }}"
 
 - name: Set permissions
-  ansible.builtin.shell: "chown -R {{ lighthouse_user }}:{{ lighthouse_user }} {{ lighthouse_datadir }}"
+  ansible.builtin.command: "chown -R {{ lighthouse_user }}:{{ lighthouse_user }} {{ lighthouse_datadir }}" # noqa deprecated-command-syntax
 
 - name: Run lighthouse container
   community.docker.docker_container:
@@ -42,7 +42,7 @@
   when: lighthouse_validator_enabled
 
 - name: Set permissions for validator data dir
-  ansible.builtin.shell: "chown -R {{ lighthouse_user }}:{{ lighthouse_user }} {{ lighthouse_validator_datadir }}"
+  ansible.builtin.command: "chown -R {{ lighthouse_user }}:{{ lighthouse_user }} {{ lighthouse_validator_datadir }}" # noqa deprecated-command-syntax
   when: lighthouse_validator_enabled
 
 - name: Run lighthouse validator container

--- a/roles/lighthouse/tasks/setup.yaml
+++ b/roles/lighthouse/tasks/setup.yaml
@@ -13,6 +13,7 @@
 
 - name: Set permissions
   ansible.builtin.command: "chown -R {{ lighthouse_user }}:{{ lighthouse_user }} {{ lighthouse_datadir }}" # noqa deprecated-command-syntax
+  changed_when: false
 
 - name: Run lighthouse container
   community.docker.docker_container:
@@ -43,6 +44,7 @@
 
 - name: Set permissions for validator data dir
   ansible.builtin.command: "chown -R {{ lighthouse_user }}:{{ lighthouse_user }} {{ lighthouse_validator_datadir }}" # noqa deprecated-command-syntax
+  changed_when: false
   when: lighthouse_validator_enabled
 
 - name: Run lighthouse validator container

--- a/roles/lighthouse/tasks/setup.yaml
+++ b/roles/lighthouse/tasks/setup.yaml
@@ -11,6 +11,9 @@
     owner: "{{ lighthouse_user }}"
     group: "{{ lighthouse_user }}"
 
+- name: Set permissions
+  ansible.builtin.shell: "chown -R {{ lighthouse_user }}:{{ lighthouse_user }} {{ lighthouse_datadir }}"
+
 - name: Run lighthouse container
   community.docker.docker_container:
     name: "{{ lighthouse_container_name }}"
@@ -36,6 +39,10 @@
     - "{{ lighthouse_validator_datadir }}"
     - "{{ lighthouse_validator_datadir }}/keys"
     - "{{ lighthouse_validator_datadir }}/secrets"
+  when: lighthouse_validator_enabled
+
+- name: Set permissions for validator data dir
+  ansible.builtin.shell: "chown -R {{ lighthouse_user }}:{{ lighthouse_user }} {{ lighthouse_validator_datadir }}"
   when: lighthouse_validator_enabled
 
 - name: Run lighthouse validator container

--- a/roles/lodestar/tasks/setup.yaml
+++ b/roles/lodestar/tasks/setup.yaml
@@ -13,6 +13,7 @@
 
 - name: Set permissions
   ansible.builtin.command: "chown -R {{ lodestar_user }}:{{ lodestar_user }} {{ lodestar_datadir }}" # noqa deprecated-command-syntax
+  changed_when: false
 
 - name: Run lodestar container
   community.docker.docker_container:
@@ -43,6 +44,7 @@
 
 - name: Set permissions for validator data dir
   ansible.builtin.command: "chown -R {{ lodestar_user }}:{{ lodestar_user }} {{ lodestar_validator_datadir }}" # noqa deprecated-command-syntax
+  changed_when: false
   when: lodestar_validator_enabled
 
 - name: Run lodestar validator container

--- a/roles/lodestar/tasks/setup.yaml
+++ b/roles/lodestar/tasks/setup.yaml
@@ -11,6 +11,9 @@
     owner: "{{ lodestar_user }}"
     group: "{{ lodestar_user }}"
 
+- name: Set permissions
+  ansible.builtin.shell: "chown -R {{ lodestar_user }}:{{ lodestar_user }} {{ lodestar_datadir }}"
+
 - name: Run lodestar container
   community.docker.docker_container:
     name: "{{ lodestar_container_name }}"
@@ -36,6 +39,10 @@
     - "{{ lodestar_validator_datadir }}"
     - "{{ lodestar_validator_datadir }}/keys"
     - "{{ lodestar_validator_datadir }}/secrets"
+  when: lodestar_validator_enabled
+
+- name: Set permissions for validator data dir
+  ansible.builtin.shell: "chown -R {{ lodestar_user }}:{{ lodestar_user }} {{ lodestar_validator_datadir }}"
   when: lodestar_validator_enabled
 
 - name: Run lodestar validator container

--- a/roles/lodestar/tasks/setup.yaml
+++ b/roles/lodestar/tasks/setup.yaml
@@ -12,7 +12,7 @@
     group: "{{ lodestar_user }}"
 
 - name: Set permissions
-  ansible.builtin.shell: "chown -R {{ lodestar_user }}:{{ lodestar_user }} {{ lodestar_datadir }}"
+  ansible.builtin.command: "chown -R {{ lodestar_user }}:{{ lodestar_user }} {{ lodestar_datadir }}" # noqa deprecated-command-syntax
 
 - name: Run lodestar container
   community.docker.docker_container:
@@ -42,7 +42,7 @@
   when: lodestar_validator_enabled
 
 - name: Set permissions for validator data dir
-  ansible.builtin.shell: "chown -R {{ lodestar_user }}:{{ lodestar_user }} {{ lodestar_validator_datadir }}"
+  ansible.builtin.command: "chown -R {{ lodestar_user }}:{{ lodestar_user }} {{ lodestar_validator_datadir }}" # noqa deprecated-command-syntax
   when: lodestar_validator_enabled
 
 - name: Run lodestar validator container

--- a/roles/nethermind/tasks/setup.yaml
+++ b/roles/nethermind/tasks/setup.yaml
@@ -16,6 +16,7 @@
 
 - name: Set permissions
   ansible.builtin.command: "chown -R {{ nethermind_user }}:{{ nethermind_user }} {{ nethermind_datadir }}" # noqa deprecated-command-syntax
+  changed_when: false
 
 - name: Run nethermind container
   community.docker.docker_container:

--- a/roles/nethermind/tasks/setup.yaml
+++ b/roles/nethermind/tasks/setup.yaml
@@ -15,7 +15,7 @@
     - "{{ nethermind_datadir }}/nethermind"
 
 - name: Set permissions
-  ansible.builtin.shell: "chown -R {{ nethermind_user }}:{{ nethermind_user }} {{ nethermind_datadir }}"
+  ansible.builtin.command: "chown -R {{ nethermind_user }}:{{ nethermind_user }} {{ nethermind_datadir }}" # noqa deprecated-command-syntax
 
 - name: Run nethermind container
   community.docker.docker_container:

--- a/roles/nethermind/tasks/setup.yaml
+++ b/roles/nethermind/tasks/setup.yaml
@@ -14,6 +14,9 @@
     - "{{ nethermind_datadir }}"
     - "{{ nethermind_datadir }}/nethermind"
 
+- name: Set permissions
+  ansible.builtin.shell: "chown -R {{ nethermind_user }}:{{ nethermind_user }} {{ nethermind_datadir }}"
+
 - name: Run nethermind container
   community.docker.docker_container:
     name: "{{ nethermind_container_name }}"

--- a/roles/nimbus/tasks/setup.yaml
+++ b/roles/nimbus/tasks/setup.yaml
@@ -12,7 +12,7 @@
     group: "{{ nimbus_user }}"
 
 - name: Set permissions
-  ansible.builtin.shell: "chown -R {{ nimbus_user }}:{{ nimbus_user }} {{ nimbus_datadir }}"
+  ansible.builtin.command: "chown -R {{ nimbus_user }}:{{ nimbus_user }} {{ nimbus_datadir }}" # noqa deprecated-command-syntax
 
 - name: Create validator data dir
   ansible.builtin.file:
@@ -28,7 +28,7 @@
   when: nimbus_validator_enabled
 
 - name: Set permissions for validator data dir
-  ansible.builtin.shell: "chown -R {{ nimbus_user }}:{{ nimbus_user }} {{ nimbus_validator_datadir }}"
+  ansible.builtin.command: "chown -R {{ nimbus_user }}:{{ nimbus_user }} {{ nimbus_validator_datadir }}" # noqa deprecated-command-syntax
   when: nimbus_validator_enabled
 
 - name: Checkpoint sync nimbus node

--- a/roles/nimbus/tasks/setup.yaml
+++ b/roles/nimbus/tasks/setup.yaml
@@ -11,6 +11,9 @@
     owner: "{{ nimbus_user }}"
     group: "{{ nimbus_user }}"
 
+- name: Set permissions
+  ansible.builtin.shell: "chown -R {{ nimbus_user }}:{{ nimbus_user }} {{ nimbus_datadir }}"
+
 - name: Create validator data dir
   ansible.builtin.file:
     path: "{{ item }}"
@@ -22,6 +25,10 @@
     - "{{ nimbus_validator_datadir }}"
     - "{{ nimbus_validator_datadir }}/keys"
     - "{{ nimbus_validator_datadir }}/secrets"
+  when: nimbus_validator_enabled
+
+- name: Set permissions for validator data dir
+  ansible.builtin.shell: "chown -R {{ nimbus_user }}:{{ nimbus_user }} {{ nimbus_validator_datadir }}"
   when: nimbus_validator_enabled
 
 - name: Checkpoint sync nimbus node

--- a/roles/nimbus/tasks/setup.yaml
+++ b/roles/nimbus/tasks/setup.yaml
@@ -13,6 +13,7 @@
 
 - name: Set permissions
   ansible.builtin.command: "chown -R {{ nimbus_user }}:{{ nimbus_user }} {{ nimbus_datadir }}" # noqa deprecated-command-syntax
+  changed_when: false
 
 - name: Create validator data dir
   ansible.builtin.file:
@@ -29,6 +30,7 @@
 
 - name: Set permissions for validator data dir
   ansible.builtin.command: "chown -R {{ nimbus_user }}:{{ nimbus_user }} {{ nimbus_validator_datadir }}" # noqa deprecated-command-syntax
+  changed_when: false
   when: nimbus_validator_enabled
 
 - name: Checkpoint sync nimbus node

--- a/roles/prysm/tasks/setup.yaml
+++ b/roles/prysm/tasks/setup.yaml
@@ -11,6 +11,9 @@
     owner: "{{ prysm_user }}"
     group: "{{ prysm_user }}"
 
+- name: Set permissions
+  ansible.builtin.shell: "chown -R {{ prysm_user }}:{{ prysm_user }} {{ prysm_datadir }}"
+
 - name: Run prysm container
   community.docker.docker_container:
     name: "{{ prysm_container_name }}"
@@ -33,6 +36,10 @@
     mode: "0750"
     owner: "{{ prysm_user }}"
     group: "{{ prysm_user }}"
+  when: prysm_validator_enabled
+
+- name: Set permissions for validator data dir
+  ansible.builtin.shell: "chown -R {{ prysm_user }}:{{ prysm_user }} {{ prysm_validator_datadir }}"
   when: prysm_validator_enabled
 
 - name: Run prysm validator container

--- a/roles/prysm/tasks/setup.yaml
+++ b/roles/prysm/tasks/setup.yaml
@@ -12,7 +12,7 @@
     group: "{{ prysm_user }}"
 
 - name: Set permissions
-  ansible.builtin.shell: "chown -R {{ prysm_user }}:{{ prysm_user }} {{ prysm_datadir }}"
+  ansible.builtin.command: "chown -R {{ prysm_user }}:{{ prysm_user }} {{ prysm_datadir }}" # noqa deprecated-command-syntax
 
 - name: Run prysm container
   community.docker.docker_container:
@@ -39,7 +39,7 @@
   when: prysm_validator_enabled
 
 - name: Set permissions for validator data dir
-  ansible.builtin.shell: "chown -R {{ prysm_user }}:{{ prysm_user }} {{ prysm_validator_datadir }}"
+  ansible.builtin.command: "chown -R {{ prysm_user }}:{{ prysm_user }} {{ prysm_validator_datadir }}" # noqa deprecated-command-syntax
   when: prysm_validator_enabled
 
 - name: Run prysm validator container

--- a/roles/prysm/tasks/setup.yaml
+++ b/roles/prysm/tasks/setup.yaml
@@ -13,6 +13,7 @@
 
 - name: Set permissions
   ansible.builtin.command: "chown -R {{ prysm_user }}:{{ prysm_user }} {{ prysm_datadir }}" # noqa deprecated-command-syntax
+  changed_when: false
 
 - name: Run prysm container
   community.docker.docker_container:
@@ -40,6 +41,7 @@
 
 - name: Set permissions for validator data dir
   ansible.builtin.command: "chown -R {{ prysm_user }}:{{ prysm_user }} {{ prysm_validator_datadir }}" # noqa deprecated-command-syntax
+  changed_when: false
   when: prysm_validator_enabled
 
 - name: Run prysm validator container

--- a/roles/teku/tasks/setup.yaml
+++ b/roles/teku/tasks/setup.yaml
@@ -13,6 +13,7 @@
 
 - name: Set permissions
   ansible.builtin.command: "chown -R {{ teku_user }}:{{ teku_user }} {{ teku_datadir }}" # noqa deprecated-command-syntax
+  changed_when: false
 
 - name: Create validator data dir
   ansible.builtin.file:
@@ -29,6 +30,7 @@
 
 - name: Set permissions for validator data dir
   ansible.builtin.command: "chown -R {{ teku_user }}:{{ teku_user }} {{ teku_validator_datadir }}" # noqa deprecated-command-syntax
+  changed_when: false
   when: teku_validator_enabled
 
 - name: Run teku container

--- a/roles/teku/tasks/setup.yaml
+++ b/roles/teku/tasks/setup.yaml
@@ -11,6 +11,9 @@
     owner: "{{ teku_user }}"
     group: "{{ teku_user }}"
 
+- name: Set permissions
+  ansible.builtin.shell: "chown -R {{ teku_user }}:{{ teku_user }} {{ teku_datadir }}"
+
 - name: Create validator data dir
   ansible.builtin.file:
     path: "{{ item }}"
@@ -22,6 +25,10 @@
     - "{{ teku_validator_datadir }}"
     - "{{ teku_validator_datadir }}/keys"
     - "{{ teku_validator_datadir }}/secrets"
+  when: teku_validator_enabled
+
+- name: Set permissions for validator data dir
+  ansible.builtin.shell: "chown -R {{ teku_user }}:{{ teku_user }} {{ teku_validator_datadir }}"
   when: teku_validator_enabled
 
 - name: Run teku container

--- a/roles/teku/tasks/setup.yaml
+++ b/roles/teku/tasks/setup.yaml
@@ -12,7 +12,7 @@
     group: "{{ teku_user }}"
 
 - name: Set permissions
-  ansible.builtin.shell: "chown -R {{ teku_user }}:{{ teku_user }} {{ teku_datadir }}"
+  ansible.builtin.command: "chown -R {{ teku_user }}:{{ teku_user }} {{ teku_datadir }}" # noqa deprecated-command-syntax
 
 - name: Create validator data dir
   ansible.builtin.file:
@@ -28,7 +28,7 @@
   when: teku_validator_enabled
 
 - name: Set permissions for validator data dir
-  ansible.builtin.shell: "chown -R {{ teku_user }}:{{ teku_user }} {{ teku_validator_datadir }}"
+  ansible.builtin.command: "chown -R {{ teku_user }}:{{ teku_user }} {{ teku_validator_datadir }}" # noqa deprecated-command-syntax
   when: teku_validator_enabled
 
 - name: Run teku container


### PR DESCRIPTION
This existed before already, and was removed in here: https://github.com/ethpandaops/ansible-collection-general/commit/d905b59a997aa24223642ccf1fdf9c776505a3b0 

Unfortunately we can't rely on the `file` module using the [`recurse`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/file_module.html#parameter-recurse)  attribute. 

The problem with that approach is that there can be race conditions because the module does the following:
1. List all files that need to have the permissions fixed
2. Apply the permission fix

The problem happens if a file gets deleted between step 1 and 2 by a running node. Then ansible will crash saying that the file wasn't found and that it couldn't update its permissions. 

As a workaround, we need to use `chown` via the shell module.