### PR TITLE
bootstrap: fix for users that have multiple keys on github

### DIFF
--- a/roles/bootstrap/tasks/add_github_ssh_key.yml
+++ b/roles/bootstrap/tasks/add_github_ssh_key.yml
@@ -1,5 +1,5 @@
 - name: Add SSH keys from github user
-  loop: "{{ lookup('url', 'https://github.com/' + outer_item + '.keys').splitlines() }}"
+  loop: "{{ lookup('url', 'https://github.com/' + outer_item + '.keys', wantlist=True) }}"
   ansible.posix.authorized_key:
     user: "{{ bootstrap_default_user }}"
     state: present


### PR DESCRIPTION
This fix will make sure to add each key on a new line. Currently there were accidentally being comma separated. 