### PR TITLE
Adding role for Mario's mock builder and relay 

### DIFF
--- a/roles/ethereum_node/defaults/main.yaml
+++ b/roles/ethereum_node/defaults/main.yaml
@@ -37,6 +37,9 @@ ethereum_node_json_rpc_snooper_engine_name: "snooper-engine"
 # Mev boost
 ethereum_node_mev_boost_enabled: false
 
+# Mev mock relay builder
+ethereum_node_mev_mock_relay_builder_enabled: false
+
 # Metrics exporter
 ethereum_node_metrics_exporter_enabled: false
 

--- a/roles/ethereum_node/tasks/main.yaml
+++ b/roles/ethereum_node/tasks/main.yaml
@@ -18,6 +18,16 @@
     mev_boost_container_networks: "{{ ethereum_node_docker_networks }}"
   when: ethereum_node_mev_boost_enabled
 
+- name: Setup mev_mock_relay_builder
+  ansible.builtin.include_role:
+    name: ethpandaops.general.mev_mock_relay_builder
+  vars:
+    mev_mock_relay_builder_container_networks: "{{ ethereum_node_docker_networks }}"
+    mev_mock_relay_builder_beacon_uri: "{{ ethereum_node_cl_beacon_endpoint }}"
+    mev_mock_relay_builder_el_uri: >-
+      {{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}
+  when: ethereum_node_mev_mock_relay_builder_enabled
+
 - name: Setup execution client
   ansible.builtin.import_tasks: setup_el.yaml
   when: ethereum_node_el_enabled

--- a/roles/mev_mock_relay_builder/README.md
+++ b/roles/mev_mock_relay_builder/README.md
@@ -1,0 +1,38 @@
+# ethpandaops.general.mev_mock_relay_builder
+
+This role will run [mev_mock_relay_builder](https://github.com/marioevz/mock-builder) within a docker container.
+
+## Requirements
+
+You'll need docker on the target system. Make sure to install it upfront.
+
+## Role Variables
+
+Default variables are defined in [defaults/main.yaml](defaults/main.yaml)
+
+## Dependencies
+
+You'll need docker to run this role. One way of installing docker could be via ansible galaxy with the following dependencies set within `requirements.yaml`:
+
+```yaml
+roles:
+- src: geerlingguy.docker
+  version: latest
+- src: geerlingguy.pip
+  version: latest
+```
+
+## Example Playbook
+
+Your playbook could look like this:
+
+```yaml
+- hosts: localhost
+  become: true
+  roles:
+  - role: geerlingguy.docker
+  - role: geerlingguy.pip
+    pip_install_packages:
+    - name: docker
+  - role: ethpandaops.general.mev_mock_relay_builder
+```

--- a/roles/mev_mock_relay_builder/defaults/main.yml
+++ b/roles/mev_mock_relay_builder/defaults/main.yml
@@ -20,7 +20,7 @@ mev_mock_relay_builder_container_volumes:
   - "{{ mev_mock_relay_builder_auth_jwt_path }}:/execution-auth.jwt:ro"
 
 mev_mock_relay_builder_container_command:
-  - -port={{mev_mock_relay_builder_server_port}}
+  - -port={{ mev_mock_relay_builder_server_port }}
   - -jwt-secret=/execution-auth.jwt
   - -bid-multiplier=2
   - -cl={{ mev_mock_relay_builder_beacon_uri }}

--- a/roles/mev_mock_relay_builder/defaults/main.yml
+++ b/roles/mev_mock_relay_builder/defaults/main.yml
@@ -1,0 +1,32 @@
+mev_mock_relay_builder_user: mev_mock_relay_builder
+
+mev_mock_relay_builder_cleanup: false # when set to "true" it will remove the container(s)
+
+################################################################################
+##
+## mev_mock_relay_builder container configuration
+##
+################################################################################
+mev_mock_relay_builder_container_name: mev_mock_relay_builder
+mev_mock_relay_builder_container_image: ethpandaops/mock-builder:1.0.0
+mev_mock_relay_builder_container_env: {}
+mev_mock_relay_builder_server_port: 18550
+mev_mock_relay_builder_container_ports:
+  - "127.0.0.1:{{ mev_mock_relay_builder_server_port }}:{{ mev_mock_relay_builder_server_port }}"
+
+mev_mock_relay_builder_container_stop_timeout: "300"
+mev_mock_relay_builder_container_networks: []
+mev_mock_relay_builder_container_volumes:
+  - "{{ mev_mock_relay_builder_auth_jwt_path }}:/execution-auth.jwt:ro"
+
+mev_mock_relay_builder_container_command:
+  - -port={{mev_mock_relay_builder_server_port}}
+  - -jwt-secret=/execution-auth.jwt
+  - -bid-multiplier=2
+  - -cl={{ mev_mock_relay_builder_beacon_uri }}
+  - -el={{ mev_mock_relay_builder_el_uri }}
+
+mev_mock_relay_builder_beacon_uri: your-beacon-node:5052
+mev_mock_relay_builder_el_uri: your-engine-api:8551
+mev_mock_relay_builder_auth_jwt_path: /data/execution-auth.secret
+mev_mock_relay_builder_container_command_extra_args: []

--- a/roles/mev_mock_relay_builder/tasks/cleanup.yaml
+++ b/roles/mev_mock_relay_builder/tasks/cleanup.yaml
@@ -1,0 +1,5 @@
+- name: Remove mev_mock_relay_builder container
+  community.docker.docker_container:
+    name: "{{ mev_mock_relay_builder_container_name }}"
+    state: absent
+  when: mev_mock_relay_builder_cleanup

--- a/roles/mev_mock_relay_builder/tasks/main.yml
+++ b/roles/mev_mock_relay_builder/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+# tasks file for mev_mock_relay_builder
+- name: Setup mev_mock_relay_builder
+  ansible.builtin.import_tasks: setup.yaml
+  when: not mev_mock_relay_builder_cleanup
+
+- name: Cleanup mev_mock_relay_builder
+  ansible.builtin.import_tasks: cleanup.yaml

--- a/roles/mev_mock_relay_builder/tasks/setup.yaml
+++ b/roles/mev_mock_relay_builder/tasks/setup.yaml
@@ -1,0 +1,18 @@
+- name: Add mev_mock_relay_builder user
+  ansible.builtin.user:
+    name: "{{ mev_mock_relay_builder_user }}"
+  register: mev_mock_relay_builder_user_meta
+
+- name: Run mev_mock_relay_builder container
+  community.docker.docker_container:
+    name: "{{ mev_mock_relay_builder_container_name }}"
+    image: "{{ mev_mock_relay_builder_container_image }}"
+    state: started
+    restart_policy: always
+    stop_timeout: "{{ mev_mock_relay_builder_container_stop_timeout }}"
+    volumes: "{{ mev_mock_relay_builder_container_volumes }}"
+    env: "{{ mev_mock_relay_builder_container_env }}"
+    networks: "{{ mev_mock_relay_builder_container_networks }}"
+    ports: "{{ mev_mock_relay_builder_container_ports }}"
+    command: "{{ mev_mock_relay_builder_container_command + mev_mock_relay_builder_container_command_extra_args }} "
+    user: "{{ mev_mock_relay_builder_user_meta.uid }}"


### PR DESCRIPTION
Note: not to be confused with the flashbots relay and builder. 

Adds:
- Role for mock relay and builder
- Allows it to be enabled by the ethereum_node role

We need to make sure that the enable/disable isn't done in the group_vars definition of the `ethereum_node.yml` group, as then we would have one mock builder per node. Instead one per testnet would suffice. The playbook.yaml could probably ensure the hosts it runs on are only on the `mock_relay_and_builder` group perhaps, so even if mistakenly set as a group var it wouldn't run the role on all nodes. Lemme know if this is a fair way to set it up. The main reason its a part of the ethereum_node role is since it needs access to the EL and Beacon node RPC endpoints, Similar to Xatu/etc

