### PR TITLE
bootstrap: avoid lookup plugin due to github rate limiting

### DIFF
--- a/roles/bootstrap/tasks/add_github_ssh_key.yml
+++ b/roles/bootstrap/tasks/add_github_ssh_key.yml
@@ -5,7 +5,7 @@
     mode: '0440'
     backup: true
 
-- name: Read user ssh keys from file
+- name: Read user SSH keys from file
   ansible.builtin.command: cat ~/.ssh/github_{{ outer_item }}.keys
   register: bootstrap_downloaded_ssh_keys
   changed_when: false

--- a/roles/bootstrap/tasks/add_github_ssh_key.yml
+++ b/roles/bootstrap/tasks/add_github_ssh_key.yml
@@ -1,5 +1,17 @@
+- name: Download SSH keys for github user
+  ansible.builtin.get_url:
+    url: "https://github.com/{{ outer_item }}.keys"
+    dest: "~/.ssh/github_{{ outer_item }}.keys"
+    mode: '0440'
+    backup: true
+
+- name: Read user ssh keys from file
+  ansible.builtin.command: cat ~/.ssh/github_{{ outer_item }}.keys
+  register: bootstrap_downloaded_ssh_keys
+  changed_when: false
+
 - name: Add SSH keys from github user
-  loop: "{{ lookup('url', 'https://github.com/' + outer_item + '.keys', wantlist=True) }}"
+  loop: "{{ bootstrap_downloaded_ssh_keys.stdout_lines }}"
   ansible.posix.authorized_key:
     user: "{{ bootstrap_default_user }}"
     state: present


### PR DESCRIPTION
Fixes https://github.com/ethpandaops/ansible-collection-general/issues/81

Now instead of using the lookup plugin (which executes directly on the ansible controller), we're downloading the keys directly from the servers. This won't make us get rate limited again since all the key queries will be done from the individual servers instead from the single ansible contoller machine. 