### PR TITLE
Switching default client image pull policy as `true`

### DIFF
--- a/roles/besu/defaults/main.yaml
+++ b/roles/besu/defaults/main.yaml
@@ -41,4 +41,4 @@ besu_container_command:
 besu_container_command_extra_args: []
 
 # Default image pull policy
-besu_container_pull: false
+besu_container_pull: true

--- a/roles/erigon/defaults/main.yaml
+++ b/roles/erigon/defaults/main.yaml
@@ -59,4 +59,4 @@ erigon_init_custom_network_container_command:
   - /genesis.json
 
 # Default image pull policy
-erigon_container_pull: false
+erigon_container_pull: true

--- a/roles/ethereumjs/defaults/main.yaml
+++ b/roles/ethereumjs/defaults/main.yaml
@@ -36,4 +36,4 @@ ethereumjs_container_command:
 ethereumjs_container_command_extra_args: []
 
 # Default image pull policy
-ethereumjs_container_pull: false
+ethereumjs_container_pull: true

--- a/roles/geth/defaults/main.yaml
+++ b/roles/geth/defaults/main.yaml
@@ -54,4 +54,4 @@ geth_init_custom_network_container_command:
   - /genesis.json
 
 # Default image pull policy
-geth_container_pull: false
+geth_container_pull: true

--- a/roles/lighthouse/defaults/main.yaml
+++ b/roles/lighthouse/defaults/main.yaml
@@ -86,4 +86,4 @@ lighthouse_validator_container_command_extra_args: []
   # - --graffiti=hello-world
 
 # Default image pull policy
-lighthouse_container_pull: false
+lighthouse_container_pull: true

--- a/roles/lodestar/defaults/main.yaml
+++ b/roles/lodestar/defaults/main.yaml
@@ -76,4 +76,4 @@ lodestar_validator_container_command_extra_args: []
   # - --graffiti=hello-world
 
 # Default image pull policy
-lodestar_container_pull: false
+lodestar_container_pull: true

--- a/roles/nethermind/defaults/main.yaml
+++ b/roles/nethermind/defaults/main.yaml
@@ -44,4 +44,4 @@ nethermind_container_command:
 nethermind_container_command_extra_args: []
 
 # Default image pull policy
-nethermind_container_pull: false
+nethermind_container_pull: true

--- a/roles/nimbus/defaults/main.yaml
+++ b/roles/nimbus/defaults/main.yaml
@@ -77,4 +77,4 @@ nimbus_container_validator_volumes:
   - "{{ nimbus_validator_datadir }}:/validator-data"
 
 # Default image pull policy
-nimbus_container_pull: false
+nimbus_container_pull: true

--- a/roles/prysm/defaults/main.yaml
+++ b/roles/prysm/defaults/main.yaml
@@ -81,4 +81,4 @@ prysm_validator_container_command_extra_args: []
   # - --graffiti=hello-world
 
 # Default image pull policy
-prysm_container_pull: false
+prysm_container_pull: true

--- a/roles/teku/defaults/main.yaml
+++ b/roles/teku/defaults/main.yaml
@@ -69,4 +69,4 @@ teku_container_validator_volumes:
   - "{{ teku_validator_datadir }}:/validator-data"
 
 # Default image pull policy
-teku_container_pull: false
+teku_container_pull: true


### PR DESCRIPTION
The reason for the PR is that if testnets use the same image tag, then the image is definitely updated. I'm not sure if there was a reason for it to have been `false`, but usually on our setup it wouldn't matter since we use unique tags. But we had an issue where I left it at the default and then deposit-devnets was handed over to an external party who reused the same tags. That led to a ton of wasted time debugging issues where the image was never updated. 

Switching the default to true shouldn't affect our setup since we use the new tags everywhere, but at the same time would help out external entities with a sane default. 
