### PR TITLE
ethereum_node: add single var to always pull

### DIFF
--- a/roles/ethereum_node/defaults/main.yaml
+++ b/roles/ethereum_node/defaults/main.yaml
@@ -1,5 +1,6 @@
 ethereum_node_docker_network_name: shared
 ethereum_node_skip_cleanup: false
+ethereum_node_images_always_pull: false
 
 # Execution layer client
 ethereum_node_el: ethereumjs # Valid options: besu, geth, erigon, nethermind

--- a/roles/ethereum_node/tasks/setup_cl.yaml
+++ b/roles/ethereum_node/tasks/setup_cl.yaml
@@ -9,8 +9,7 @@
     lighthouse_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     lighthouse_container_networks: "{{ ethereum_node_docker_networks }}"
     lighthouse_container_pull: "{{ ethereum_node_images_always_pull }}"
-    lighthouse_execution_engine_endpoint: >-
-      {{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}
+    lighthouse_execution_engine_endpoint: "{{ ethereum_node_execution_engine_endpoint }}"
     lighthouse_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     lighthouse_validator_container_networks: "{{ ethereum_node_docker_networks }}"
     lighthouse_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
@@ -26,8 +25,7 @@
     teku_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     teku_container_networks: "{{ ethereum_node_docker_networks }}"
     teku_container_pull: "{{ ethereum_node_images_always_pull }}"
-    teku_execution_engine_endpoint: >-
-      {{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}
+    teku_execution_engine_endpoint: "{{ ethereum_node_execution_engine_endpoint }}"
     teku_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     teku_validator_container_networks: "{{ ethereum_node_docker_networks }}"
     teku_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
@@ -43,8 +41,7 @@
     prysm_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     prysm_container_networks: "{{ ethereum_node_docker_networks }}"
     prysm_container_pull: "{{ ethereum_node_images_always_pull }}"
-    prysm_execution_engine_endpoint: >-
-      {{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}
+    prysm_execution_engine_endpoint: "{{ ethereum_node_execution_engine_endpoint }}"
     prysm_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     prysm_validator_container_networks: "{{ ethereum_node_docker_networks }}"
     prysm_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
@@ -60,8 +57,7 @@
     lodestar_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     lodestar_container_networks: "{{ ethereum_node_docker_networks }}"
     lodestar_container_pull: "{{ ethereum_node_images_always_pull }}"
-    lodestar_execution_engine_endpoint: >-
-      {{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}
+    lodestar_execution_engine_endpoint: "{{ ethereum_node_execution_engine_endpoint }}"
     lodestar_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     lodestar_validator_container_networks: "{{ ethereum_node_docker_networks }}"
     lodestar_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
@@ -77,8 +73,7 @@
     nimbus_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     nimbus_container_networks: "{{ ethereum_node_docker_networks }}"
     nimbus_container_pull: "{{ ethereum_node_images_always_pull }}"
-    nimbus_execution_engine_endpoint: >-
-      {{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}
+    nimbus_execution_engine_endpoint: "{{ ethereum_node_execution_engine_endpoint }}"
     nimbus_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     nimbus_validator_container_networks: "{{ ethereum_node_docker_networks }}"
     nimbus_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"

--- a/roles/ethereum_node/tasks/setup_cl.yaml
+++ b/roles/ethereum_node/tasks/setup_cl.yaml
@@ -8,6 +8,7 @@
     lighthouse_ports_http_beacon: "{{ ethereum_node_cl_ports_http_beacon }}"
     lighthouse_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     lighthouse_container_networks: "{{ ethereum_node_docker_networks }}"
+    lighthouse_container_pull: "{{ ethereum_node_images_always_pull }}"
     lighthouse_execution_engine_endpoint: >-
       {{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}
     lighthouse_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
@@ -24,6 +25,7 @@
     teku_ports_http_beacon: "{{ ethereum_node_cl_ports_http_beacon }}"
     teku_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     teku_container_networks: "{{ ethereum_node_docker_networks }}"
+    teku_container_pull: "{{ ethereum_node_images_always_pull }}"
     teku_execution_engine_endpoint: >-
       {{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}
     teku_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
@@ -40,6 +42,7 @@
     prysm_ports_http_beacon: "{{ ethereum_node_cl_ports_http_beacon }}"
     prysm_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     prysm_container_networks: "{{ ethereum_node_docker_networks }}"
+    prysm_container_pull: "{{ ethereum_node_images_always_pull }}"
     prysm_execution_engine_endpoint: >-
       {{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}
     prysm_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
@@ -56,6 +59,7 @@
     lodestar_ports_http_beacon: "{{ ethereum_node_cl_ports_http_beacon }}"
     lodestar_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     lodestar_container_networks: "{{ ethereum_node_docker_networks }}"
+    lodestar_container_pull: "{{ ethereum_node_images_always_pull }}"
     lodestar_execution_engine_endpoint: >-
       {{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}
     lodestar_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
@@ -72,6 +76,7 @@
     nimbus_ports_http_beacon: "{{ ethereum_node_cl_ports_http_beacon }}"
     nimbus_ports_metrics: "{{ ethereum_node_cl_ports_metrics }}"
     nimbus_container_networks: "{{ ethereum_node_docker_networks }}"
+    nimbus_container_pull: "{{ ethereum_node_images_always_pull }}"
     nimbus_execution_engine_endpoint: >-
       {{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}
     nimbus_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"

--- a/roles/ethereum_node/tasks/setup_el.yaml
+++ b/roles/ethereum_node/tasks/setup_el.yaml
@@ -8,6 +8,7 @@
     besu_ports_engine: "{{ ethereum_node_el_ports_engine }}"
     besu_ports_metrics: "{{ ethereum_node_el_ports_metrics }}"
     besu_container_networks: "{{ ethereum_node_docker_networks }}"
+    besu_container_pull: "{{ ethereum_node_images_always_pull }}"
 
 - name: "Execution client: geth"
   when: ethereum_node_el == "geth"
@@ -19,6 +20,7 @@
     geth_ports_engine: "{{ ethereum_node_el_ports_engine }}"
     geth_ports_metrics: "{{ ethereum_node_el_ports_metrics }}"
     geth_container_networks: "{{ ethereum_node_docker_networks }}"
+    geth_container_pull: "{{ ethereum_node_images_always_pull }}"
 
 - name: "Execution client: erigon"
   when: ethereum_node_el == "erigon"
@@ -30,6 +32,7 @@
     erigon_ports_engine: "{{ ethereum_node_el_ports_engine }}"
     erigon_ports_metrics: "{{ ethereum_node_el_ports_metrics }}"
     erigon_container_networks: "{{ ethereum_node_docker_networks }}"
+    erigon_container_pull: "{{ ethereum_node_images_always_pull }}"
 
 - name: "Execution client: nethermind"
   when: ethereum_node_el == "nethermind"
@@ -41,6 +44,7 @@
     nethermind_ports_engine: "{{ ethereum_node_el_ports_engine }}"
     nethermind_ports_metrics: "{{ ethereum_node_el_ports_metrics }}"
     nethermind_container_networks: "{{ ethereum_node_docker_networks }}"
+    nethermind_container_pull: "{{ ethereum_node_images_always_pull }}"
 
 - name: "Execution client: ethereumjs"
   when: ethereum_node_el == "ethereumjs"
@@ -51,3 +55,4 @@
     ethereumjs_ports_http_rpc: "{{ ethereum_node_el_ports_http_rpc }}"
     ethereumjs_ports_engine: "{{ ethereum_node_el_ports_engine }}"
     ethereumjs_container_networks: "{{ ethereum_node_docker_networks }}"
+    ethereumjs_container_pull: "{{ ethereum_node_images_always_pull }}"

--- a/roles/ethereum_node/vars/main.yaml
+++ b/roles/ethereum_node/vars/main.yaml
@@ -14,3 +14,6 @@ ethereum_node_supported_cl:
 
 ethereum_node_docker_networks:
   - name: "{{ ethereum_node_docker_network_name }}"
+
+ethereum_node_execution_engine_endpoint: >-
+  {{ ethereum_node_json_rpc_snooper_engine_enabled | ternary(ethereum_node_el_engine_snooper_endpoint, ethereum_node_el_engine_endpoint) }}


### PR DESCRIPTION
Add `ethereum_node_images_always_pull` which can be used to always pull images from all ethereum clients. 