### PR TITLE
ethereum_genesis: avoid calling rescue, we want it to fail and stop

### DIFF
--- a/roles/ethereum_genesis/tasks/generate_genesis.yaml
+++ b/roles/ethereum_genesis/tasks/generate_genesis.yaml
@@ -63,10 +63,11 @@
     - name: Info
       ansible.builtin.debug:
         msg: "Genesis configs can be found in the following directory: {{ ethereum_genesis_generator_output_dir }}"
-  rescue:
+  always:
     - name: Inform of failure
       ansible.builtin.debug:
         msg: |
           Something went wrong. Some useful information that can be used to debug the problem:
           - Temp config dir: {{ ethereum_genesis_generator_tmp_config_dir_register.path }}
           - Temp output dir: {{ ethereum_genesis_generator_tmp_output_dir_register.path }}
+      when: (ethereum_genesis_generator_cmd.rc != 0) or (ethereum_genesis_generator_cmd.stdout == "")


### PR DESCRIPTION
We want it to fail and stop. With `rescue` it would continue.