### PR TITLE
ethereum_node: fix 'dict object' has no attribute 'geth_container_name'

### DIFF
--- a/roles/ethereum_node/defaults/main.yaml
+++ b/roles/ethereum_node/defaults/main.yaml
@@ -48,8 +48,13 @@ ethereum_node_metrics_exporter_enabled: false
 ethereum_node_xatu_sentry_enabled: false
 
 # Generated RPC/Engine/Beacon endpoints
-ethereum_node_el_engine_endpoint: "http://{{ vars[ethereum_node_el + '_container_name'] }}:{{ ethereum_node_el_ports_engine }}"
-ethereum_node_el_engine_snooper_endpoint: "http://{{ ethereum_node_json_rpc_snooper_engine_name }}:{{ ethereum_node_json_rpc_snooper_engine_port }}"
-ethereum_node_el_rpc_endpoint: "http://{{ vars[ethereum_node_el + '_container_name'] }}:{{ ethereum_node_el_ports_http_rpc }}"
-ethereum_node_el_rpc_snooper_endpoint: "http://{{ ethereum_node_json_rpc_snooper_name }}:{{ ethereum_node_json_rpc_snooper_port }}"
-ethereum_node_cl_beacon_endpoint: "http://{{ vars[ethereum_node_cl + '_container_name'] }}:{{ ethereum_node_cl_ports_http_beacon }}"
+ethereum_node_el_engine_endpoint: >-
+  http://{{ vars[ethereum_node_el + '_container_name'] | default(ethereum_node_el) }}:{{ ethereum_node_el_ports_engine }}
+ethereum_node_el_engine_snooper_endpoint: >-
+  http://{{ ethereum_node_json_rpc_snooper_engine_name }}:{{ ethereum_node_json_rpc_snooper_engine_port }}
+ethereum_node_el_rpc_endpoint: >-
+  http://{{ vars[ethereum_node_el + '_container_name'] | default(efault(ethereum_node_el)) }}:{{ ethereum_node_el_ports_http_rpc }}
+ethereum_node_el_rpc_snooper_endpoint: >-
+  http://{{ ethereum_node_json_rpc_snooper_name }}:{{ ethereum_node_json_rpc_snooper_port }}
+ethereum_node_cl_beacon_endpoint: >-
+  http://{{ vars[ethereum_node_cl + '_container_name'] | default(efault(ethereum_node_cl)) }}:{{ ethereum_node_cl_ports_http_beacon }}

--- a/roles/ethereum_node/defaults/main.yaml
+++ b/roles/ethereum_node/defaults/main.yaml
@@ -53,8 +53,8 @@ ethereum_node_el_engine_endpoint: >-
 ethereum_node_el_engine_snooper_endpoint: >-
   http://{{ ethereum_node_json_rpc_snooper_engine_name }}:{{ ethereum_node_json_rpc_snooper_engine_port }}
 ethereum_node_el_rpc_endpoint: >-
-  http://{{ vars[ethereum_node_el + '_container_name'] | default(efault(ethereum_node_el)) }}:{{ ethereum_node_el_ports_http_rpc }}
+  http://{{ vars[ethereum_node_el + '_container_name'] | default(ethereum_node_el) }}:{{ ethereum_node_el_ports_http_rpc }}
 ethereum_node_el_rpc_snooper_endpoint: >-
   http://{{ ethereum_node_json_rpc_snooper_name }}:{{ ethereum_node_json_rpc_snooper_port }}
 ethereum_node_cl_beacon_endpoint: >-
-  http://{{ vars[ethereum_node_cl + '_container_name'] | default(efault(ethereum_node_cl)) }}:{{ ethereum_node_cl_ports_http_beacon }}
+  http://{{ vars[ethereum_node_cl + '_container_name'] | default(ethereum_node_cl) }}:{{ ethereum_node_cl_ports_http_beacon }}


### PR DESCRIPTION
Falling back to the previous values if the other var isn't defined. 

I was getting this error on my CI runs:

>  FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'geth_container_name'

https://github.com/ethpandaops/ansible-collection-general/actions/runs/5588348838/jobs/10215015075