### PR TITLE
Added `beaconlight_explorer` role that installs light-beaconchain-explorer

### DIFF
--- a/roles/beaconlight_explorer/README.md
+++ b/roles/beaconlight_explorer/README.md
@@ -1,0 +1,43 @@
+# ethpandaops.general.beaconlight_explorer
+
+Setup [light-beaconchain-explorer](https://github.com/pk910/light-beaconchain-explorer) and all required dependencies all in one server.
+
+## Requirements
+
+You'll need docker on the target system. Make sure to install it upfront.
+
+## Role Variables
+
+Default variables are defined in [defaults/main.yaml](defaults/main.yaml)
+
+## Dependencies
+
+You'll need docker to run this role. One way of installing docker could be via ansible galaxy with the following dependencies set within `requirements.yaml`:
+
+```yaml
+roles:
+- src: geerlingguy.docker
+  version: 6.0.3
+- src: geerlingguy.pip
+  version: 2.2.0
+```
+
+## Example Playbook
+
+Your playbook could look like this:
+
+```yaml
+- hosts: beaconlight
+  become: true
+  roles:
+  # Docker. Required dependency
+  - role: geerlingguy.docker
+    tags: [docker]
+  - role: geerlingguy.pip
+    pip_install_packages:
+    - name: docker
+    tags: [docker]
+  # light-beaconchain-explorer
+  - role: beaconlight_explorer
+    tags: [beaconlight]
+```

--- a/roles/beaconlight_explorer/defaults/main.yml
+++ b/roles/beaconlight_explorer/defaults/main.yml
@@ -119,16 +119,11 @@ beaconlight_config: |
     # number of seconds to wait between each epoch (don't overload CL client)
     syncEpochCooldown: 1
 
-  readerDatabase:
-    host: "beaconlight-database"
-    port: 5432
-    user: "postgres"
-    password: "postgres"
-    name: "beaconlight"
-
-  writerDatabase:
-    host: "beaconlight-database"
-    port: 5432
-    user: "postgres"
-    password: "postgres"
-    name: "beaconlight"
+  database:
+    engine: "pgsql"
+    pgsql:
+      host: "beaconlight-database"
+      port: 5432
+      user: "postgres"
+      password: "postgres"
+      name: "beaconlight"

--- a/roles/beaconlight_explorer/defaults/main.yml
+++ b/roles/beaconlight_explorer/defaults/main.yml
@@ -1,0 +1,130 @@
+---
+
+# Set this to true if you want to stop everything and wipe the databases
+beaconlight_cleanup_all: false
+
+
+beaconlight_user: beaconlight
+beaconlight_datadir: "/data/beaconlight"
+beaconlight_docker_network_name: shared
+beaconlight_docker_networks:
+  - name: "{{ beaconlight_docker_network_name }}"
+
+# explorer config
+beaconlight_beaconapi_endpoint: "http://your-cl-node:5052"
+beaconlight_chain_name: sepolia
+beaconlight_chain_displayname: ""
+beaconlight_chain_config: ""
+beaconlight_chain_genesistime: 0
+beaconlight_frontend_title: "Beaconchain Light"
+beaconlight_frontend_subtitle: "Testnet"
+beaconlight_frontend_ethexplorer: ""
+beaconlight_frontend_validatornames: ""
+beaconlight_frontend_validatornames_inventory: ""
+
+# ------------------------------------------------------------------
+
+# beaconlight
+beaconlight_enabled: true
+beaconlight_container_name: beaconlight
+beaconlight_container_image: pk910/light-beaconchain-explorer:latest
+beaconlight_container_env: {}
+beaconlight_container_ports: []
+beaconlight_container_volumes:
+  - "{{ beaconlight_datadir }}/explorer:/config"
+beaconlight_container_stop_timeout: "600"
+beaconlight_container_pull: true
+beaconlight_container_networks: "{{ beaconlight_docker_networks }}"
+beaconlight_container_command: -config=/config/explorer.yaml
+
+# beaconlight-database
+beaconlight_db_enabled: true
+beaconlight_db_datadir: "{{ beaconlight_datadir }}/database"
+beaconlight_db_container_name: beaconlight-database
+beaconlight_db_container_image: bitnami/postgresql:15
+beaconlight_db_container_env:
+  POSTGRESQL_USERNAME: postgres
+  POSTGRESQL_PASSWORD: postgres
+  POSTGRESQL_DATABASE: beaconlight
+beaconlight_db_custom_postgres_config: |
+  max_connections = 1024
+beaconlight_db_container_ports: []
+beaconlight_db_container_volumes:
+  - "{{ beaconlight_db_datadir }}/db:/bitnami/postgresql"
+  - "{{ beaconlight_db_datadir }}/conf.d://opt/bitnami/postgresql/conf/conf.d:ro"
+beaconlight_db_container_stop_timeout: "300"
+beaconlight_db_container_pull: false
+beaconlight_db_container_networks: "{{ beaconlight_docker_networks }}"
+
+
+beaconlight_config: |
+  # Chain network configuration
+  chain:
+    name: "{{ beaconlight_chain_name }}"
+    genesisTimestamp: {{ beaconlight_chain_genesistime }}
+    configPath: "{{ beaconlight_chain_config }}"
+    displayName: "{{ beaconlight_chain_displayname }}"
+
+  # HTTP Server configuration
+  server:
+    host: "0.0.0.0" # Address to listen on
+    port: "8080" # Port to listen on
+
+  frontend:
+    enabled: true # Enable or disable to web frontend
+    debug: false
+    minimize: false # minimize html templates
+
+    # Name of the site, displayed in the title tag
+    siteName: "{{ beaconlight_frontend_title }}"
+    siteSubtitle: "{{ beaconlight_frontend_subtitle }}"
+    
+    # link to EL Explorer
+    ethExplorerLink: "{{ beaconlight_frontend_ethexplorer }}"
+
+    # file or inventory url to load validator names from
+    validatorNamesYaml: "{{ beaconlight_frontend_validatornames }}"
+    validatorNamesInventory: "{{ beaconlight_frontend_validatornames_inventory }}"
+    
+  beaconapi:
+    # CL Client RPC
+    endpoint: "{{ beaconlight_beaconapi_endpoint }}"
+
+    # local cache for page models
+    localCacheSize: 100 # 100MB
+
+    # remote cache for page models
+    redisCacheAddr: ""
+    redisCachePrefix: ""
+
+  # indexer keeps track of the latest epochs in memory.
+  indexer:
+    # number of epochs to load on startup
+    prepopulateEpochs: 2
+
+    # max number of epochs to keep in memory
+    inMemoryEpochs: 10
+
+    # epoch processing delay (should be >= 2)
+    epochProcessingDelay: 2
+
+    # disable synchronizing and everything that writes to the db (indexer just maintains local cache)
+    disableIndexWriter: false
+
+    # number of seconds to wait between each epoch (don't overload CL client)
+    syncEpochCooldown: 1
+
+
+  readerDatabase:
+    host: "beaconlight-database"
+    port: 5432
+    user: "postgres"
+    password: "postgres"
+    name: "beaconlight"
+    
+  writerDatabase:
+    host: "beaconlight-database"
+    port: 5432
+    user: "postgres"
+    password: "postgres"
+    name: "beaconlight"

--- a/roles/beaconlight_explorer/defaults/main.yml
+++ b/roles/beaconlight_explorer/defaults/main.yml
@@ -62,7 +62,6 @@ beaconlight_db_container_stop_timeout: "300"
 beaconlight_db_container_pull: false
 beaconlight_db_container_networks: "{{ beaconlight_docker_networks }}"
 
-
 beaconlight_config: |
   # Chain network configuration
   chain:
@@ -84,14 +83,14 @@ beaconlight_config: |
     # Name of the site, displayed in the title tag
     siteName: "{{ beaconlight_frontend_title }}"
     siteSubtitle: "{{ beaconlight_frontend_subtitle }}"
-    
+
     # link to EL Explorer
     ethExplorerLink: "{{ beaconlight_frontend_ethexplorer }}"
 
     # file or inventory url to load validator names from
     validatorNamesYaml: "{{ beaconlight_frontend_validatornames }}"
     validatorNamesInventory: "{{ beaconlight_frontend_validatornames_inventory }}"
-    
+
   beaconapi:
     # CL Client RPC
     endpoint: "{{ beaconlight_beaconapi_endpoint }}"
@@ -120,14 +119,13 @@ beaconlight_config: |
     # number of seconds to wait between each epoch (don't overload CL client)
     syncEpochCooldown: 1
 
-
   readerDatabase:
     host: "beaconlight-database"
     port: 5432
     user: "postgres"
     password: "postgres"
     name: "beaconlight"
-    
+
   writerDatabase:
     host: "beaconlight-database"
     port: 5432

--- a/roles/beaconlight_explorer/defaults/main.yml
+++ b/roles/beaconlight_explorer/defaults/main.yml
@@ -22,6 +22,12 @@ beaconlight_frontend_ethexplorer: ""
 beaconlight_frontend_validatornames: ""
 beaconlight_frontend_validatornames_inventory: ""
 
+# This can be used to create additional config files for the beaconchain explorer.
+# It's useful when using private testnets and you need to mount a custom network config
+# as the chain config. All files will be available within the explorer containers on the
+# /config directory.
+beaconlight_extra_config_files: {}
+
 # ------------------------------------------------------------------
 
 # beaconlight

--- a/roles/beaconlight_explorer/tasks/cleanup.yml
+++ b/roles/beaconlight_explorer/tasks/cleanup.yml
@@ -13,4 +13,3 @@
   loop:
     - "{{ beaconlight_db_datadir }}"
     - "{{ beaconlight_datadir }}"
-

--- a/roles/beaconlight_explorer/tasks/cleanup.yml
+++ b/roles/beaconlight_explorer/tasks/cleanup.yml
@@ -1,0 +1,16 @@
+- name: Stop beaconlight containers
+  community.docker.docker_container:
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ beaconlight_container_name }}"
+    - "{{ beaconlight_db_container_name }}"
+
+- name: Delete data directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ beaconlight_db_datadir }}"
+    - "{{ beaconlight_datadir }}"
+

--- a/roles/beaconlight_explorer/tasks/main.yml
+++ b/roles/beaconlight_explorer/tasks/main.yml
@@ -1,0 +1,7 @@
+- name: Setup beaconchain-light
+  ansible.builtin.import_tasks: setup.yml
+  when: not beaconlight_cleanup_all
+
+- name: Cleanup everything
+  ansible.builtin.import_tasks: cleanup.yml
+  when: beaconlight_cleanup_all

--- a/roles/beaconlight_explorer/tasks/setup.yml
+++ b/roles/beaconlight_explorer/tasks/setup.yml
@@ -52,6 +52,15 @@
     group: "{{ beaconlight_user }}"
     mode: '0640'
 
+- name: Create custom config files
+  ansible.builtin.copy:
+    content: "{{ item.value }}"
+    dest: "{{ beaconlight_datadir }}/explorer/{{ item.key }}"
+    owner: "{{ beaconlight_user }}"
+    group: "{{ beaconlight_user }}"
+    mode: '0640'
+  loop: "{{ beaconlight_extra_config_files | dict2items }}"
+
 - name: Setup beaconlight
   community.docker.docker_container:
     name: "{{ beaconlight_container_name }}"

--- a/roles/beaconlight_explorer/tasks/setup.yml
+++ b/roles/beaconlight_explorer/tasks/setup.yml
@@ -1,0 +1,68 @@
+- name: Add beaconlight user
+  ansible.builtin.user:
+    name: "{{ beaconlight_user }}"
+  register: beaconlight_user_meta
+
+- name: Setup docker network
+  ansible.builtin.include_role:
+    name: ethpandaops.general.docker_network
+  vars:
+    docker_network_name: "{{ beaconlight_docker_network_name }}"
+
+- name: Create directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: "0750"
+    owner: "{{ beaconlight_user }}"
+    group: "{{ beaconlight_user }}"
+  loop:
+    - "{{ beaconlight_datadir }}"
+    - "{{ beaconlight_datadir }}/explorer"
+    - "{{ beaconlight_db_datadir }}/conf.d"
+    - "{{ beaconlight_db_datadir }}/db"
+
+- name: Copy custom postgres config
+  ansible.builtin.copy:
+    content: "{{ beaconlight_db_custom_postgres_config }}"
+    dest: "{{ beaconlight_db_datadir }}/conf.d/custom.conf"
+    owner: "{{ beaconlight_user }}"
+    group: "{{ beaconlight_user }}"
+    mode: '0664'
+
+- name: Setup beaconlight database container
+  community.docker.docker_container:
+    name: "{{ beaconlight_db_container_name }}"
+    image: "{{ beaconlight_db_container_image }}"
+    state: '{{ beaconlight_db_enabled | ternary("started", "absent") }}'
+    restart_policy: always
+    stop_timeout: "{{ beaconlight_db_container_stop_timeout }}"
+    ports: "{{ beaconlight_db_container_ports }}"
+    volumes: "{{ beaconlight_db_container_volumes }}"
+    env: "{{ beaconlight_db_container_env }}"
+    networks: "{{ beaconlight_db_container_networks }}"
+    pull: "{{ beaconlight_db_container_pull | bool }}"
+    user: "{{ beaconlight_user_meta.uid }}"
+
+- name: Create explorer config file
+  ansible.builtin.copy:
+    content: "{{ beaconlight_config }}"
+    dest: "{{ beaconlight_datadir }}/explorer/explorer.yaml"
+    owner: "{{ beaconlight_user }}"
+    group: "{{ beaconlight_user }}"
+    mode: '0640'
+
+- name: Setup beaconlight
+  community.docker.docker_container:
+    name: "{{ beaconlight_container_name }}"
+    image: "{{ beaconlight_container_image }}"
+    state: 'started'
+    restart_policy: always
+    stop_timeout: "{{ beaconlight_container_stop_timeout }}"
+    ports: "{{ beaconlight_container_ports }}"
+    volumes: "{{ beaconlight_container_volumes }}"
+    env: "{{ beaconlight_container_env }}"
+    networks: "{{ beaconlight_container_networks }}"
+    pull: "{{ beaconlight_container_pull | bool }}"
+    user: "{{ beaconlight_user_meta.uid }}"
+    command: "{{ beaconlight_container_command }}"


### PR DESCRIPTION
Added new role `ethpandaops.general.beaconlight_explorer`, which installs my [lightweight beaconchain explorer](https://github.com/pk910/light-beaconchain-explorer) using docker images (defaults to the latest stable release).
Structure is mostly copied from the `blockscout` role, so it should hopefully be conform with the repository standards ;)

Works on my side in a [test-playbook](https://gist.github.com/pk910/04188cfe175d990cc6ba5247f4f690cb) which deploys the explorer for ephemery on a test vm.