### PR TITLE
Revert "Fixing nethermind entrypoint "

### DIFF
--- a/roles/nethermind/defaults/main.yaml
+++ b/roles/nethermind/defaults/main.yaml
@@ -25,7 +25,7 @@ nethermind_container_security_opts: []
 nethermind_container_stop_timeout: "300"
 nethermind_container_networks: []
 nethermind_container_entrypoint:
-  - /nethermind/nethermind
+  - /nethermind/Nethermind.Runner
 nethermind_container_command:
   - --datadir=/data
   - --KeyStore.KeyStoreDirectory=/data/keystore


### PR DESCRIPTION
Reverts ethpandaops/ansible-collection-general#127

Waiting until a new nethermind release as this doesn't match current `latest`  ( 1.20.1 ) 