### PR TITLE
added config variables for powfaucet proxy count

### DIFF
--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -70,7 +70,7 @@ gen_kubernetes_config_helm_charts:
     dependencies:
       - name: powfaucet
         repository: https://ethpandaops.github.io/ethereum-helm-charts
-        version: 0.0.1
+        version: 0.0.2
   faucet-2:
     valuesTemplatePath: templates/eth-faucet.yaml.j2
     dependencies:

--- a/roles/generate_kubernetes_config/templates/powfaucet.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/powfaucet.yaml.j2
@@ -6,6 +6,7 @@ powfaucet:
   image:
     repository: {{ default_tooling_images.powfaucet.split(':') | first }}
     tag: {{ default_tooling_images.powfaucet.split(':') | last}}
+    pullPolicy: Always
 
   resources:
     requests:
@@ -25,6 +26,7 @@ powfaucet:
         paths:
           - path: /
             pathType: Prefix
+  httpProxyCount: 2
 
   faucetTitle: "{{ ethereum_network_name }} PoW Faucet"
   faucetPrivkey: "<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.dencun-devnets.faucet_private_key}>"

--- a/roles/powfaucet/defaults/main.yml
+++ b/roles/powfaucet/defaults/main.yml
@@ -9,6 +9,7 @@ powfaucet_datadir: "/data/powfaucet"
 powfaucet_docker_network_name: shared
 powfaucet_docker_networks:
   - name: "{{ powfaucet_docker_network_name }}"
+powfaucet_proxy_count: 1
 
 # powfaucet config
 powfaucet_title: "PoW Faucet"
@@ -110,6 +111,9 @@ powfaucet_config: |
 
   # faucet http/ws server port
   serverPort: 8080
+
+  # number of http proxies in front of this faucet
+  httpProxyCount: {{ powfaucet_proxy_count }}
 
   # title of the faucet
   faucetTitle: "{{ powfaucet_title }}"


### PR DESCRIPTION
powfaucet needs to know how many proxy servers are in front of it.
Otherwise it cannot safely select the correct remote IP from the list of forwarder addresses in the `X-Forwarded-For` header.
