### PR TITLE
Set dora pull policy to `Always` if tag name contains `latest`

### DIFF
--- a/roles/generate_kubernetes_config/templates/dora.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/dora.yaml.j2
@@ -5,7 +5,7 @@ dora:
   image:
     repository: {{ default_tooling_images.dora.split(':') | first }}
     tag: {{ default_tooling_images.dora.split(':') | last }}
-    pullPolicy: {% if default_tooling_images.dora.split(':') | last == 'latest' %}Always{% else %}IfNotPresent{% endif %}
+    pullPolicy: {% if "latest" in (default_tooling_images.dora.split(':') | last) %}Always{% else %}IfNotPresent{% endif %}
 
   resources:
     requests:


### PR DESCRIPTION
Made the pull policy logic more flexible.
It'll now use `Always` for all tags that contain the word "latest".

This should work fine with the new build workflow, which uses version specific tags (`master-<commit>`) & latest tags (`master-latest`).
Testnet related branches follow the same schema, eg.  `verkle-support-<commit>` & `verkle-support-latest`