### PR TITLE
fix: deprecation warning message fix

### DIFF
--- a/roles/arbitrum_node/tasks/main.yaml
+++ b/roles/arbitrum_node/tasks/main.yaml
@@ -14,6 +14,7 @@
   community.docker.docker_container:
     name: "{{ arbitrum_node_container_name }}"
     image: "{{ arbitrum_node_container_image }}"
+    image_name_mismatch: recreate
     state: started
     restart_policy: always
     stop_timeout: "{{ arbitrum_node_container_stop_timeout }}"

--- a/roles/besu/tasks/setup.yaml
+++ b/roles/besu/tasks/setup.yaml
@@ -19,6 +19,7 @@
   community.docker.docker_container:
     name: "{{ besu_container_name }}"
     image: "{{ besu_container_image }}"
+    image_name_mismatch: recreate
     state: started
     restart_policy: always
     stop_timeout: "{{ besu_container_stop_timeout }}"

--- a/roles/blobber/tasks/setup.yaml
+++ b/roles/blobber/tasks/setup.yaml
@@ -41,6 +41,7 @@
   community.docker.docker_container:
     name: "{{ blobber_container_name }}"
     image: "{{ blobber_container_image }}"
+    image_name_mismatch: recreate
     state: started
     restart_policy: always
     volumes: "{{ blobber_container_volumes }}"

--- a/roles/blockscout/tasks/setup.yml
+++ b/roles/blockscout/tasks/setup.yml
@@ -34,6 +34,7 @@
   community.docker.docker_container:
     name: "{{ blockscout_db_container_name }}"
     image: "{{ blockscout_db_container_image }}"
+    image_name_mismatch: recreate
     state: '{{ blockscout_db_enabled | ternary("started", "absent") }}'
     restart_policy: always
     stop_timeout: "{{ blockscout_db_container_stop_timeout }}"
@@ -48,6 +49,7 @@
   community.docker.docker_container:
     name: "{{ blockscout_cache_container_name }}"
     image: "{{ blockscout_cache_container_image }}"
+    image_name_mismatch: recreate
     state: '{{ blockscout_cache_enabled | ternary("started", "absent") }}'
     restart_policy: always
     stop_timeout: "{{ blockscout_cache_container_stop_timeout }}"
@@ -62,6 +64,7 @@
   community.docker.docker_container:
     name: "{{ blockscout_smart_contract_verifier_container_name }}"
     image: "{{ blockscout_smart_contract_verifier_container_image }}"
+    image_name_mismatch: recreate
     state: '{{ blockscout_smart_contract_verifier_enabled | ternary("started", "absent") }}'
     restart_policy: always
     stop_timeout: "{{ blockscout_smart_contract_verifier_container_stop_timeout }}"
@@ -76,6 +79,7 @@
   community.docker.docker_container:
     name: "{{ blockscout_sig_provider_container_name }}"
     image: "{{ blockscout_sig_provider_container_image }}"
+    image_name_mismatch: recreate
     state: '{{ blockscout_sig_provider_enabled | ternary("started", "absent") }}'
     restart_policy: always
     stop_timeout: "{{ blockscout_sig_provider_container_stop_timeout }}"
@@ -90,6 +94,7 @@
   community.docker.docker_container:
     name: "{{ blockscout_visualizer_container_name }}"
     image: "{{ blockscout_visualizer_container_image }}"
+    image_name_mismatch: recreate
     state: '{{ blockscout_visualizer_enabled | ternary("started", "absent") }}'
     restart_policy: always
     stop_timeout: "{{ blockscout_visualizer_container_stop_timeout }}"
@@ -104,6 +109,7 @@
   community.docker.docker_container:
     name: "{{ blockscout_container_name }}"
     image: "{{ blockscout_container_image }}"
+    image_name_mismatch: recreate
     state: 'started'
     restart_policy: always
     stop_timeout: "{{ blockscout_container_stop_timeout }}"

--- a/roles/cl_bootnode/tasks/main.yaml
+++ b/roles/cl_bootnode/tasks/main.yaml
@@ -2,6 +2,7 @@
   community.docker.docker_container:
     name: "{{ cl_bootnode_container_name }}"
     image: "{{ cl_bootnode_container_image }}"
+    image_name_mismatch: recreate
     state: started
     restart_policy: always
     stop_timeout: "{{ cl_bootnode_container_stop_timeout }}"

--- a/roles/cloudwatch_exporter/tasks/setup.yaml
+++ b/roles/cloudwatch_exporter/tasks/setup.yaml
@@ -25,6 +25,7 @@
   community.general.docker_container:
     name: "{{ cloudwatch_exporter_container_name }}"
     image: "{{ cloudwatch_exporter_container_image }}"
+    image_name_mismatch: recreate
     ports: "{{ cloudwatch_exporter_container_ports }}"
     restart_policy: "{{ cloudwatch_exporter_container_restart_policy }}"
     networks: "{{ cloudwatch_exporter_container_networks }}"

--- a/roles/docker_nginx_proxy/tasks/main.yaml
+++ b/roles/docker_nginx_proxy/tasks/main.yaml
@@ -29,6 +29,7 @@
   community.general.docker_container:
     name: "{{ docker_nginx_proxy_container_name }}"
     image: "{{ docker_nginx_proxy_container_image }}"
+    image_name_mismatch: recreate
     published_ports: "{{ docker_nginx_proxy_container_published_ports }}"
     restart_policy: "{{ docker_nginx_proxy_container_restart_policy }}"
     networks: "{{ docker_nginx_proxy_container_networks }}"
@@ -41,6 +42,7 @@
   community.general.docker_container:
     name: "{{ docker_nginx_proxy_docker_gen_container_name }}"
     image: "{{ docker_nginx_proxy_docker_gen_container_image }}"
+    image_name_mismatch: recreate
     command: "{{ docker_nginx_proxy_docker_gen_container_command }}"
     restart_policy: "{{ docker_nginx_proxy_docker_gen_container_restart_policy }}"
     networks: "{{ docker_nginx_proxy_acme_companion_container_networks }}"
@@ -54,6 +56,7 @@
   community.general.docker_container:
     name: "{{ docker_nginx_proxy_acme_companion_container_name }}"
     image: "{{ docker_nginx_proxy_acme_companion_container_image }}"
+    image_name_mismatch: recreate
     restart_policy: "{{ docker_nginx_proxy_acme_companion_container_restart_policy }}"
     networks: "{{ docker_nginx_proxy_acme_companion_container_networks }}"
     networks_cli_compatible: "{{ docker_nginx_proxy_acme_companion_container_networks_cli_compatible }}"

--- a/roles/dora/tasks/setup.yml
+++ b/roles/dora/tasks/setup.yml
@@ -65,6 +65,7 @@
   community.docker.docker_container:
     name: "{{ dora_container_name }}"
     image: "{{ dora_container_image }}"
+    image_name_mismatch: recreate
     state: 'started'
     restart_policy: always
     stop_timeout: "{{ dora_container_stop_timeout }}"

--- a/roles/dshackle/tasks/main.yaml
+++ b/roles/dshackle/tasks/main.yaml
@@ -24,6 +24,7 @@
   community.general.docker_container:
     name: "{{ dshackle_container_name }}"
     image: "{{ dshackle_container_image }}"
+    image_name_mismatch: recreate
     published_ports: "{{ dshackle_container_published_ports }}"
     restart_policy: "{{ dshackle_container_restart_policy }}"
     networks: "{{ dshackle_container_networks }}"

--- a/roles/dugtrio/tasks/setup.yml
+++ b/roles/dugtrio/tasks/setup.yml
@@ -31,6 +31,7 @@
   community.docker.docker_container:
     name: "{{ dugtrio_container_name }}"
     image: "{{ dugtrio_container_image }}"
+    image_name_mismatch: recreate
     state: 'started'
     restart_policy: always
     stop_timeout: "{{ dugtrio_container_stop_timeout }}"

--- a/roles/erigon/tasks/setup.yaml
+++ b/roles/erigon/tasks/setup.yaml
@@ -26,6 +26,7 @@
       community.docker.docker_container:
         name: "{{ erigon_container_name }}-init"
         image: "{{ erigon_container_image }}"
+        image_name_mismatch: recreate
         detach: false
         auto_remove: true
         restart_policy: "no"
@@ -45,6 +46,7 @@
   community.docker.docker_container:
     name: "{{ erigon_container_name }}"
     image: "{{ erigon_container_image }}"
+    image_name_mismatch: recreate
     state: started
     restart_policy: always
     stop_timeout: "{{ erigon_container_stop_timeout }}"

--- a/roles/ethereum_inventory_web/tasks/main.yaml
+++ b/roles/ethereum_inventory_web/tasks/main.yaml
@@ -43,6 +43,7 @@
   community.general.docker_container:
     name: "{{ eth_inventory_web_container_name }}"
     image: "{{ eth_inventory_web_container_image }}"
+    image_name_mismatch: recreate
     published_ports: "{{ eth_inventory_web_container_published_ports }}"
     restart_policy: "{{ eth_inventory_web_container_restart_policy }}"
     networks: "{{ eth_inventory_web_container_networks }}"

--- a/roles/ethereum_metrics_exporter/tasks/setup.yaml
+++ b/roles/ethereum_metrics_exporter/tasks/setup.yaml
@@ -2,6 +2,7 @@
   community.docker.docker_container:
     name: "{{ ethereum_metrics_exporter_container_name }}"
     image: "{{ ethereum_metrics_exporter_container_image }}"
+    image_name_mismatch: recreate
     state: started
     restart_policy: always
     stop_timeout: "{{ ethereum_metrics_exporter_container_stop_timeout }}"

--- a/roles/ethereumjs/tasks/setup.yaml
+++ b/roles/ethereumjs/tasks/setup.yaml
@@ -19,6 +19,7 @@
   community.docker.docker_container:
     name: "{{ ethereumjs_container_name }}"
     image: "{{ ethereumjs_container_image }}"
+    image_name_mismatch: recreate
     state: started
     restart_policy: always
     stop_timeout: "{{ ethereumjs_container_stop_timeout }}"

--- a/roles/ethstats/tasks/main.yaml
+++ b/roles/ethstats/tasks/main.yaml
@@ -13,6 +13,7 @@
   community.general.docker_container:
     name: "{{ ethstats_container_name }}"
     image: "{{ ethstats_container_image }}"
+    image_name_mismatch: recreate
     published_ports: "{{ ethstats_container_published_ports }}"
     restart_policy: "{{ ethstats_container_restart_policy }}"
     networks: "{{ ethstats_container_networks }}"

--- a/roles/geth/tasks/setup.yaml
+++ b/roles/geth/tasks/setup.yaml
@@ -26,6 +26,7 @@
       community.docker.docker_container:
         name: "{{ geth_container_name }}-init"
         image: "{{ geth_container_image }}"
+        image_name_mismatch: recreate
         detach: false
         auto_remove: "{{ geth_init_autoremove_enabled }}"
         restart_policy: "no"
@@ -43,6 +44,7 @@
   community.docker.docker_container:
     name: "{{ geth_container_name }}"
     image: "{{ geth_container_image }}"
+    image_name_mismatch: recreate
     state: started
     restart_policy: always
     stop_timeout: "{{ geth_container_stop_timeout }}"

--- a/roles/goomy/tasks/setup.yaml
+++ b/roles/goomy/tasks/setup.yaml
@@ -13,6 +13,7 @@
   community.docker.docker_container:
     name: "{{ goomy_container_name }}"
     image: "{{ goomy_container_image }}"
+    image_name_mismatch: recreate
     user: "{{ goomy_user_getent.ansible_facts.getent_passwd[goomy_user][1] }}"
     state: started
     restart_policy: always

--- a/roles/json_exporter/tasks/main.yaml
+++ b/roles/json_exporter/tasks/main.yaml
@@ -25,6 +25,7 @@
   community.general.docker_container:
     name: "{{ json_exporter_container_name }}"
     image: "{{ json_exporter_container_image }}"
+    image_name_mismatch: recreate
     ports: "{{ json_exporter_container_ports }}"
     restart_policy: "{{ json_exporter_container_restart_policy }}"
     networks: "{{ json_exporter_container_networks }}"

--- a/roles/json_rpc_snooper/tasks/setup.yaml
+++ b/roles/json_rpc_snooper/tasks/setup.yaml
@@ -7,6 +7,7 @@
   community.docker.docker_container:
     name: "{{ json_rpc_snooper_container_name }}"
     image: "{{ json_rpc_snooper_container_image }}"
+    image_name_mismatch: recreate
     state: started
     restart_policy: always
     volumes: "{{ json_rpc_snooper_container_volumes }}"

--- a/roles/lighthouse/tasks/setup.yaml
+++ b/roles/lighthouse/tasks/setup.yaml
@@ -19,6 +19,7 @@
   community.docker.docker_container:
     name: "{{ lighthouse_container_name }}"
     image: "{{ lighthouse_container_image }}"
+    image_name_mismatch: recreate
     state: started
     restart_policy: always
     stop_timeout: "{{ lighthouse_container_stop_timeout }}"
@@ -59,6 +60,7 @@
   community.docker.docker_container:
     name: "{{ lighthouse_validator_container_name }}"
     image: "{{ lighthouse_validator_container_image }}"
+    image_name_mismatch: recreate
     state: started
     restart_policy: always
     stop_timeout: "{{ lighthouse_validator_container_stop_timeout }}"

--- a/roles/litestream/tasks/main.yaml
+++ b/roles/litestream/tasks/main.yaml
@@ -32,6 +32,7 @@
   community.docker.docker_container:
     name: "{{ litestream_container_name }}"
     image: "{{ litestream_container_image }}"
+    image_name_mismatch: recreate
     user: "{{ litestream_user_getent.ansible_facts.getent_passwd[litestream_user][1] }}"
     state: started
     restart_policy: always

--- a/roles/lodestar/tasks/setup.yaml
+++ b/roles/lodestar/tasks/setup.yaml
@@ -19,6 +19,7 @@
   community.docker.docker_container:
     name: "{{ lodestar_container_name }}"
     image: "{{ lodestar_container_image }}"
+    image_name_mismatch: recreate
     state: started
     restart_policy: always
     stop_timeout: "{{ lodestar_container_stop_timeout }}"
@@ -59,6 +60,7 @@
   community.docker.docker_container:
     name: "{{ lodestar_validator_container_name }}"
     image: "{{ lodestar_validator_container_image }}"
+    image_name_mismatch: recreate
     state: started
     restart_policy: always
     stop_timeout: "{{ lodestar_validator_container_stop_timeout }}"

--- a/roles/logsprout/tasks/setup.yaml
+++ b/roles/logsprout/tasks/setup.yaml
@@ -2,6 +2,7 @@
   community.docker.docker_container:
     name: "{{ logsprout_container_name }}"
     image: "{{ logsprout_container_image }}"
+    image_name_mismatch: recreate
     state: started
     restart_policy: always
     stop_timeout: "{{ logsprout_container_stop_timeout }}"

--- a/roles/mev_boost/tasks/setup.yaml
+++ b/roles/mev_boost/tasks/setup.yaml
@@ -13,6 +13,7 @@
   community.docker.docker_container:
     name: "{{ mev_boost_container_name }}"
     image: "{{ mev_boost_container_image }}"
+    image_name_mismatch: recreate
     state: started
     restart_policy: always
     stop_timeout: "{{ mev_boost_container_stop_timeout }}"

--- a/roles/mev_flood/tasks/setup.yaml
+++ b/roles/mev_flood/tasks/setup.yaml
@@ -27,6 +27,7 @@
   community.docker.docker_container:
     name: "{{ mev_flood_container_name }}"
     image: "{{ mev_flood_container_image }}"
+    image_name_mismatch: recreate
     restart_policy: always
     stop_timeout: "{{ mev_flood_container_stop_timeout }}"
     volumes: "{{ mev_flood_container_volumes }}"
@@ -40,6 +41,7 @@
   community.docker.docker_container:
     name: "{{ mev_flood_spam_container_name }}"
     image: "{{ mev_flood_spam_container_image }}"
+    image_name_mismatch: recreate
     state: started
     restart_policy: always
     stop_timeout: "{{ mev_flood_spam_container_stop_timeout }}"

--- a/roles/mev_mock_relay_builder/tasks/setup.yaml
+++ b/roles/mev_mock_relay_builder/tasks/setup.yaml
@@ -7,6 +7,7 @@
   community.docker.docker_container:
     name: "{{ mev_mock_relay_builder_container_name }}"
     image: "{{ mev_mock_relay_builder_container_image }}"
+    image_name_mismatch: recreate
     state: started
     restart_policy: always
     stop_timeout: "{{ mev_mock_relay_builder_container_stop_timeout }}"

--- a/roles/mev_relay/tasks/setup.yml
+++ b/roles/mev_relay/tasks/setup.yml
@@ -26,6 +26,7 @@
   community.docker.docker_container:
     name: "{{ mev_relay_db_container_name }}"
     image: "{{ mev_relay_db_container_image }}"
+    image_name_mismatch: recreate
     state: '{{ mev_relay_db_enabled | ternary("started", "absent") }}'
     restart_policy: always
     stop_timeout: "{{ mev_relay_db_container_stop_timeout }}"
@@ -40,6 +41,7 @@
   community.docker.docker_container:
     name: "{{ mev_relay_redis_container_name }}"
     image: "{{ mev_relay_redis_container_image }}"
+    image_name_mismatch: recreate
     state: '{{ mev_relay_redis_enabled | ternary("started", "absent") }}'
     restart_policy: always
     stop_timeout: "{{ mev_relay_redis_container_stop_timeout }}"
@@ -54,6 +56,7 @@
   community.docker.docker_container:
     name: "{{ mev_relay_housekeeper_container_name }}"
     image: "{{ mev_relay_housekeeper_container_image }}"
+    image_name_mismatch: recreate
     state: '{{ mev_relay_housekeeper_enabled | ternary("started", "absent") }}'
     restart_policy: always
     stop_timeout: "{{ mev_relay_housekeeper_container_stop_timeout }}"
@@ -69,6 +72,7 @@
   community.docker.docker_container:
     name: "{{ mev_relay_api_container_name }}"
     image: "{{ mev_relay_api_container_image }}"
+    image_name_mismatch: recreate
     state: '{{ mev_relay_api_enabled | ternary("started", "absent") }}'
     restart_policy: always
     stop_timeout: "{{ mev_relay_api_container_stop_timeout }}"
@@ -84,6 +88,7 @@
   community.docker.docker_container:
     name: "{{ mev_relay_website_container_name }}"
     image: "{{ mev_relay_website_container_image }}"
+    image_name_mismatch: recreate
     state: '{{ mev_relay_website_enabled | ternary("started", "absent") }}'
     restart_policy: always
     stop_timeout: "{{ mev_relay_website_container_stop_timeout }}"

--- a/roles/nethermind/tasks/setup.yaml
+++ b/roles/nethermind/tasks/setup.yaml
@@ -22,6 +22,7 @@
   community.docker.docker_container:
     name: "{{ nethermind_container_name }}"
     image: "{{ nethermind_container_image }}"
+    image_name_mismatch: recreate
     state: started
     restart_policy: always
     stop_timeout: "{{ nethermind_container_stop_timeout }}"

--- a/roles/nimbus/tasks/setup.yaml
+++ b/roles/nimbus/tasks/setup.yaml
@@ -38,6 +38,7 @@
   community.docker.docker_container:
     name: "{{ nimbus_checkpoint_container_name }}"
     image: "{{ nimbus_container_image }}"
+    image_name_mismatch: recreate
     state: started
     detach: false
     auto_remove: "{{ nimbus_checkpoint_autoremove_enabled }}"
@@ -54,6 +55,7 @@
   community.docker.docker_container:
     name: "{{ nimbus_container_name }}"
     image: "{{ nimbus_container_image }}"
+    image_name_mismatch: recreate
     state: started
     restart_policy: always
     stop_timeout: "{{ nimbus_container_stop_timeout }}"

--- a/roles/node_exporter/tasks/main.yaml
+++ b/roles/node_exporter/tasks/main.yaml
@@ -2,6 +2,7 @@
   community.docker.docker_container:
     name: "{{ node_exporter_container_name }}"
     image: "{{ node_exporter_container_image }}"
+    image_name_mismatch: recreate
     state: started
     restart_policy: always
     stop_timeout: "{{ node_exporter_container_stop_timeout }}"

--- a/roles/powfaucet/tasks/setup.yml
+++ b/roles/powfaucet/tasks/setup.yml
@@ -31,6 +31,7 @@
   community.docker.docker_container:
     name: "{{ powfaucet_container_name }}"
     image: "{{ powfaucet_container_image }}"
+    image_name_mismatch: recreate
     state: 'started'
     restart_policy: always
     stop_timeout: "{{ powfaucet_container_stop_timeout }}"

--- a/roles/prometheus/tasks/main.yaml
+++ b/roles/prometheus/tasks/main.yaml
@@ -33,6 +33,7 @@
   community.docker.docker_container:
     name: "{{ prometheus_container_name }}"
     image: "{{ prometheus_container_image }}"
+    image_name_mismatch: recreate
     user: "{{ prometheus_user_getent.ansible_facts.getent_passwd[prometheus_user][1] }}"
     state: started
     restart_policy: always

--- a/roles/prysm/tasks/setup.yaml
+++ b/roles/prysm/tasks/setup.yaml
@@ -19,6 +19,7 @@
   community.docker.docker_container:
     name: "{{ prysm_container_name }}"
     image: "{{ prysm_container_image }}"
+    image_name_mismatch: recreate
     state: started
     restart_policy: always
     stop_timeout: "{{ prysm_container_stop_timeout }}"
@@ -56,6 +57,7 @@
   community.docker.docker_container:
     name: "{{ prysm_validator_container_name }}"
     image: "{{ prysm_validator_container_image }}"
+    image_name_mismatch: recreate
     state: started
     restart_policy: always
     stop_timeout: "{{ prysm_validator_container_stop_timeout }}"

--- a/roles/reth/tasks/setup.yaml
+++ b/roles/reth/tasks/setup.yaml
@@ -19,6 +19,7 @@
   community.docker.docker_container:
     name: "{{ reth_container_name }}"
     image: "{{ reth_container_image }}"
+    image_name_mismatch: recreate
     state: started
     restart_policy: always
     stop_timeout: "{{ reth_container_stop_timeout }}"

--- a/roles/s3_cron_backup/tasks/main.yaml
+++ b/roles/s3_cron_backup/tasks/main.yaml
@@ -2,6 +2,7 @@
   community.docker.docker_container:
     name: "{{ s3_cron_backup_container_name }}"
     image: "{{ s3_cron_backup_container_image }}"
+    image_name_mismatch: recreate
     state: started
     restart_policy: always
     stop_timeout: "{{ s3_cron_backup_container_stop_timeout }}"

--- a/roles/teku/tasks/setup.yaml
+++ b/roles/teku/tasks/setup.yaml
@@ -37,6 +37,7 @@
   community.docker.docker_container:
     name: "{{ teku_container_name }}"
     image: "{{ teku_container_image }}"
+    image_name_mismatch: recreate
     state: started
     restart_policy: always
     stop_timeout: "{{ teku_container_stop_timeout }}"

--- a/roles/tx_fuzz/tasks/setup.yaml
+++ b/roles/tx_fuzz/tasks/setup.yaml
@@ -14,6 +14,7 @@
   community.docker.docker_container:
     name: "{{ tx_fuzz_container_name }}"
     image: "{{ tx_fuzz_container_image }}"
+    image_name_mismatch: recreate
     user: "{{ tx_fuzz_user_getent.ansible_facts.getent_passwd[tx_fuzz_user][1] }}"
     state: started
     restart_policy: always

--- a/roles/vector/tasks/setup.yaml
+++ b/roles/vector/tasks/setup.yaml
@@ -32,6 +32,7 @@
   community.general.docker_container:
     name: "{{ vector_container_name }}"
     image: "{{ vector_container_image }}"
+    image_name_mismatch: recreate
     ports: "{{ vector_container_ports }}"
     restart_policy: "{{ vector_container_restart_policy }}"
     networks: "{{ vector_container_networks }}"

--- a/roles/xatu_sentry/tasks/setup.yaml
+++ b/roles/xatu_sentry/tasks/setup.yaml
@@ -32,6 +32,7 @@
   community.docker.docker_container:
     name: "{{ xatu_sentry_container_name }}"
     image: "{{ xatu_sentry_container_image }}"
+    image_name_mismatch: recreate
     user: "{{ xatu_sentry_user_getent.ansible_facts.getent_passwd[xatu_sentry_user][1] }}"
     state: started
     restart_policy: always


### PR DESCRIPTION
In order to get ahead of the curve:

```
TASK [ethpandaops.general.geth : Run geth container] ***********************************************************************************************************************************************************************************************************************************************************
[DEPRECATION WARNING]: The default value "ignore" for image_name_mismatch has been deprecated and will change to "recreate" in community.docker 4.0.0. In the current situation, this would cause the container to be recreated since the current container's image name "ethpandaops/geth:kaustinen-with-
shapella-linux-amd64" does not match the desired image name "ethpandaops/geth:kaustinen-with-shapella-28ec376". This feature will be removed from community.docker in version 4.0.0. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
changed: [lodestar-geth-5]
```