### PR TITLE
bootstrap: add cron to default packages to install

### DIFF
--- a/roles/bootstrap/defaults/main.yml
+++ b/roles/bootstrap/defaults/main.yml
@@ -20,6 +20,7 @@ bootstrap_default_common_packages:
       - screen
       - chrony # enabled by default on Debian
       - bat
+      - cron
 
 bootstrap_harden_sshd_config: true
 bootstrap_rpcbind_disable: false


### PR DESCRIPTION
The OVH debian template didn't have cron installed. 