### PR TITLE
docs: fix the link error in the markdown.

### DIFF
--- a/roles/ethereum_genesis/README.md
+++ b/roles/ethereum_genesis/README.md
@@ -1,7 +1,7 @@
 # ethpandaops.general.ethereum_genesis
 
 This role will generate a Ethereum genesis network configuration and required validator keys.
-It uses the []`ethereum-genesis-generator`](https://github.com/ethpandaops/ethereum-genesis-generator)
+It uses the [`ethereum-genesis-generator`](https://github.com/ethpandaops/ethereum-genesis-generator)
 
 ## Requirements
 


### PR DESCRIPTION
The md link symbol is broken, use this change to fix it.