### PR TITLE
add override for bootstrap packages

### DIFF
--- a/roles/bootstrap/defaults/main.yml
+++ b/roles/bootstrap/defaults/main.yml
@@ -23,6 +23,20 @@ bootstrap_default_common_packages:
       - cron
       - nfs-common
 
+_bootstrap_packages:
+      Alpine: python3 sudo
+      Archlinux: python sudo
+      Debian: python3 sudo gnupg python3-apt
+      Gentoo: python sudo gentoolkit
+      RedHat: &redhat_packages python3 sudo
+      Rocky: *redhat_packages
+      Suse: python3 python3-xml sudo
+      Amazon: python sudo
+      CentOS_7: python sudo
+      Debian_8: python sudo gnupg
+      Debian_9: python sudo gnupg
+      RedHat_7: python sudo
+
 bootstrap_harden_sshd_config: true
 bootstrap_rpcbind_disable: false
 bootstrap_swap_disable: true

--- a/roles/bootstrap/meta/main.yml
+++ b/roles/bootstrap/meta/main.yml
@@ -9,3 +9,5 @@ galaxy_info:
       versions: ["all"]
 dependencies:
   - role: robertdebock.bootstrap
+    vars:
+      _bootstrap_packages: {{  _bootstrap_packages }}


### PR DESCRIPTION
We normally would add this to the existing variable `bootstrap_default_common_packages`, but sometimes there are packages that are needed before the python check is done and that dependency management is done by the variable `_bootstrap_packages` in the role `robertdebock.bootstrap`. 
This role is called as a dependency of `ethpandaops.general.bootstrap`, but the variables are not passed onwards from the inventory to the downstream dependency role. This means we cannot modify what gets installed in the downstream dependency. 

This PR adds the variable explicitly, so as to pass it downstream. Allowing us to define `_bootstrap_packages` in `all.yaml` for e.g and ensure that the packages are downloaded before python checks commence. 

This PR was necessitated due to the deb11 image being installed in syndey missing some python distutils and basic packages. These missing packages meant that the python check could never be done and bootstrap would fail before it got to any step installing packages. 