### PR TITLE
bootstap: move dependency code to role itself

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -24,6 +24,7 @@ jobs:
         with:
           filters: |
             blockscout: roles/blockscout/**
+            bootstrap: roles/bootstrap/**
 
   # Integration test using molecule
   job:

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -11,7 +11,5 @@ roles:
     version: "6.0.3"
   - src: geerlingguy.pip
     version: "2.2.0"
-  - src: robertdebock.bootstrap
-    version: 5.2.5 # Don't update this. Newer versions contain a bug.
   - name: gantsign.oh-my-zsh
     version: "2.4.0"

--- a/roles/bootstrap/defaults/main.yml
+++ b/roles/bootstrap/defaults/main.yml
@@ -31,6 +31,7 @@ bootstrap_default_common_packages:
       - cron
       - nfs-common
 
+bootstrap_hostname_set: true
 bootstrap_harden_sshd_config: true
 bootstrap_rpcbind_disable: false
 bootstrap_swap_disable: true

--- a/roles/bootstrap/defaults/main.yml
+++ b/roles/bootstrap/defaults/main.yml
@@ -1,6 +1,14 @@
+# The bootstrap user to use for an initial connection.
+# This is useful when a machine is new and the "{{ ansible_user }}" hasn't been created yet.
 bootstrap_user: root
+# The number of seconds you want to wait during connection test before failing.
 bootstrap_timeout: 3
+# Do you want to wait for the host to be available?
+bootstrap_wait_for_host: false
 
+# The default bootstrap user to create. This is the user that will also be used
+# to connect to the machine after the first boostrap run.
+# In normal cases the `bootstrap_default_user` is equal to the `ansible_user` var.
 bootstrap_default_user_create: true
 bootstrap_default_user: devops
 bootstrap_default_user_authorized_keys_github: []

--- a/roles/bootstrap/handlers/main.yml
+++ b/roles/bootstrap/handlers/main.yml
@@ -1,6 +1,6 @@
 - name: Restart sshd
   ansible.builtin.service:
-    name: sshd
+    name: ssh
     state: restarted
 
 - name: Disable SWAP

--- a/roles/bootstrap/meta/main.yml
+++ b/roles/bootstrap/meta/main.yml
@@ -7,5 +7,4 @@ galaxy_info:
   platforms:
     - name: GenericLinux
       versions: ["all"]
-dependencies:
-  - role: robertdebock.bootstrap
+dependencies: []

--- a/roles/bootstrap/meta/requirements.yml
+++ b/roles/bootstrap/meta/requirements.yml
@@ -1,7 +1,3 @@
-roles:
-  - src: robertdebock.bootstrap
-    version: "5.2.5"
-
 collections:
   - name: ansible.posix
     version: ">=1.0.0,<2.0.0"

--- a/roles/bootstrap/molecule/default/converge.yml
+++ b/roles/bootstrap/molecule/default/converge.yml
@@ -1,10 +1,6 @@
 - name: Converge
   hosts: all
   become: true
-  pre_tasks:
-    - name: Update apt cache
-      ansible.builtin.apt:
-        update_cache: true
-        cache_valid_time: 3600
+  gather_facts: false
   roles:
     - role: bootstrap

--- a/roles/bootstrap/molecule/default/converge.yml
+++ b/roles/bootstrap/molecule/default/converge.yml
@@ -1,0 +1,10 @@
+- name: Converge
+  hosts: all
+  become: true
+  pre_tasks:
+    - name: Update apt cache
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 3600
+  roles:
+    - role: bootstrap

--- a/roles/bootstrap/molecule/default/molecule.yml
+++ b/roles/bootstrap/molecule/default/molecule.yml
@@ -8,7 +8,7 @@ scenario:
     - create
     - prepare
     - converge
-    # - idempotence
+    - idempotence
     - side_effect
     - verify
     - cleanup
@@ -32,11 +32,15 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
-  #env:
+  # env:
   #  ANSIBLE_VERBOSITY: 3
   inventory:
     group_vars:
       all:
         ansible_user: devops
+        # Fix: due to "Failed to connect to bus: No such file or directory" when using hostnamectl in docker
+        bootstrap_hostname_set: false
+        # Fix: due to SSH server not being installed
+        bootstrap_harden_sshd_config: false
 verifier:
   name: ansible

--- a/roles/bootstrap/molecule/default/molecule.yml
+++ b/roles/bootstrap/molecule/default/molecule.yml
@@ -32,5 +32,11 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  #env:
+  #  ANSIBLE_VERBOSITY: 3
+  inventory:
+    group_vars:
+      all:
+        ansible_user: devops
 verifier:
   name: ansible

--- a/roles/bootstrap/molecule/default/molecule.yml
+++ b/roles/bootstrap/molecule/default/molecule.yml
@@ -1,0 +1,36 @@
+scenario:
+  name: default
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    # - idempotence
+    - side_effect
+    - verify
+    - cleanup
+    - destroy
+dependency:
+  name: galaxy
+  options:
+    role-file: ../../requirements.yaml
+    requirements-file: ../../requirements.yaml
+driver:
+  name: docker
+platforms:
+  - name: debian12
+    image: "geerlingguy/docker-debian12-ansible:latest"
+    # platform: linux/amd64
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/roles/bootstrap/molecule/default/verify.yml
+++ b/roles/bootstrap/molecule/default/verify.yml
@@ -1,10 +1,9 @@
 - name: Verify
   hosts: all
   tasks:
-    - name: test connection
+    - name: Test connection
       ansible.builtin.ping:
-
-    - name: try the package module
+    - name: Check package
       ansible.builtin.package:
         name: gzip
         state: present

--- a/roles/bootstrap/molecule/default/verify.yml
+++ b/roles/bootstrap/molecule/default/verify.yml
@@ -5,5 +5,5 @@
       ansible.builtin.ping:
     - name: Check package
       ansible.builtin.package:
-        name: gzip
+        name: jq
         state: present

--- a/roles/bootstrap/molecule/default/verify.yml
+++ b/roles/bootstrap/molecule/default/verify.yml
@@ -1,0 +1,10 @@
+- name: Verify
+  hosts: all
+  tasks:
+    - name: test connection
+      ansible.builtin.ping:
+
+    - name: try the package module
+      ansible.builtin.package:
+        name: gzip
+        state: present

--- a/roles/bootstrap/tasks/main.yml
+++ b/roles/bootstrap/tasks/main.yml
@@ -43,12 +43,15 @@
 - name: Set hostname
   ansible.builtin.hostname:
     name: "{{ inventory_hostname }}"
+    use: debian
   register: bootstrap_hostname
+  when: bootstrap_hostname_set
 
 - name: Add self to /etc/hosts
   ansible.builtin.lineinfile:
     dest: /etc/hosts
     line: '{{ ansible_host }} {{ inventory_hostname }}'
+  when: bootstrap_hostname_set
 
 # Keep SSH_AUTH_SOCK when using sudo
 - name: Add self to /etc/hosts
@@ -119,7 +122,12 @@
 - name: Set reboot required
   ansible.builtin.set_fact:
     bootstrap_reboot_required: true
-  when: (bootstrap_reboot_required_file.stat.exists or bootstrap_hostname.changed) and bootstrap_reboot_if_required
+  when: >-
+    bootstrap_reboot_if_required and
+    (
+      bootstrap_reboot_required_file.stat.exists
+      or ( (bootstrap_hostname is defined) and bootstrap_hostname.changed)
+    )
 
 - name: Handle reboot
   when: bootstrap_reboot_required|default(false)

--- a/roles/bootstrap/tasks/main.yml
+++ b/roles/bootstrap/tasks/main.yml
@@ -1,27 +1,6 @@
-- name: Try connection
-  block:
-    - name: Test connection
-      ansible.builtin.wait_for_connection:
-        timeout: "3"
-      register: bootstrap_connect
-      changed_when: false
-  rescue:
-    - name: Conenction message
-      ansible.builtin.debug:
-        msg: Failed to connect, will try to use bootstrap_ansible_user
-  always:
-    - name: Set bootstrap_ansible_user connected
-      ansible.builtin.set_fact:
-        bootstrap_ansible_user: "{{ ansible_user }}"
-      when:
-        - bootstrap_connect is succeeded
-        - ansible_user is defined
-
-    - name: Set bootstrap_ansible_user not connected
-      ansible.builtin.set_fact:
-        bootstrap_ansible_user: "{{ bootstrap_user }}"
-      when:
-        - bootstrap_connect is failed
+- name: Prepare system to be used by ansible
+  ansible.builtin.include_tasks:
+    file: prepare/main.yml
 
 # Create default user
 - name: Ensure default user exists

--- a/roles/bootstrap/tasks/main.yml
+++ b/roles/bootstrap/tasks/main.yml
@@ -43,7 +43,6 @@
 - name: Set hostname
   ansible.builtin.hostname:
     name: "{{ inventory_hostname }}"
-    use: debian
   register: bootstrap_hostname
   when: bootstrap_hostname_set
 

--- a/roles/bootstrap/tasks/prepare/gather_facts.yml
+++ b/roles/bootstrap/tasks/prepare/gather_facts.yml
@@ -1,0 +1,29 @@
+- name: Lookup bootstrap facts
+  become: false
+  ansible.builtin.raw: "cat /etc/os-release"
+  check_mode: false
+  register: bootstrap_facts
+  changed_when: false
+  vars:
+    ansible_user: "{{ bootstrap_user }}"
+
+- name: Set bootstrap facts (I)
+  ansible.builtin.set_fact:
+    bootstrap_distribution: "{{ item }}"
+    bootstrap_distribution_major_version: >-
+      {{ bootstrap_facts.stdout_lines | join(',') | regex_replace(
+        '^.*VERSION_ID=\"(\\d{1,2})(\\.\\d{1,4})*?\".*$','\\1') | default('NA') }}
+  loop: "{{ bootstrap_os_family_map | dict2items | map(attribute='value') | flatten }}"
+  when:
+    - bootstrap_facts.rc == 0
+    - bootstrap_distribution is not defined
+    - bootstrap_facts.stdout is regex('PRETTY_NAME=.'~ bootstrap_search[item] | default(item) ~'.*')
+
+- name: Set bootstrap facts (II)
+  ansible.builtin.set_fact:
+    bootstrap_os_family: "{{ item.key }}"
+  loop: "{{ bootstrap_os_family_map | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  when:
+    - bootstrap_distribution in item.value

--- a/roles/bootstrap/tasks/prepare/main.yml
+++ b/roles/bootstrap/tasks/prepare/main.yml
@@ -49,13 +49,29 @@
     - name: Get my IP address
       ansible.builtin.set_fact:
         _bootstrap_my_ip: "{{ lookup('ansible.builtin.url', 'https://ifconfig.me/ip', split_lines=False) }}"
+      when: bootstrap_connect is failed
 
-    - name: Cleanup failed SSH attempts from auth log to avoid getting banned by systems like fail2ban
+    - name: Check if auth log exists
+      ansible.builtin.stat:
+        path: /var/log/auth.log
+      register: _bootstrap_auth_log_reg
+      when: bootstrap_connect is failed
+
+    - name: Auth log - Cleanup failed SSH attempts from auth log to avoid getting banned by systems like fail2ban
       ansible.builtin.replace:
         path: /var/log/auth.log
         regexp: "{{ item }}"
         replace: ''
-        backup: no
+      when: bootstrap_connect is failed and _bootstrap_auth_log_reg.stat.exists
       loop:
-        - .* Invalid user .* {{ _bootstrap_my_ip | replace('.','\.') }} .*
-        - .* Connection closed by invalid user .* {{ _bootstrap_my_ip | replace('.','\.') }} .*
+        - .* Invalid user .* {{ _bootstrap_my_ip | replace('.', '\.') }} .*
+        - .* Connection closed by invalid user .* {{ _bootstrap_my_ip | replace('.', '\.') }} .*
+
+    - name: No auth log - Probably we need to clean journalctl. Not ideal, but this should be just called once per bootstrap
+      ansible.builtin.command: "{{ item }}"
+      failed_when: false
+      changed_when: true
+      loop:
+        - journalctl --rotate
+        - journalctl --vacuum-time=1s
+      when: bootstrap_connect is failed and not _bootstrap_auth_log_reg.stat.exists

--- a/roles/bootstrap/tasks/prepare/main.yml
+++ b/roles/bootstrap/tasks/prepare/main.yml
@@ -45,3 +45,17 @@
         name: "{{ item }}"
         state: present
       loop: "{{ bootstrap_facts_packages.split() }}"
+
+    - name: Get my IP address
+      ansible.builtin.set_fact:
+        _bootstrap_my_ip: "{{ lookup('ansible.builtin.url', 'https://ifconfig.me/ip', split_lines=False) }}"
+
+    - name: Cleanup failed SSH attempts from auth log to avoid getting banned by systems like fail2ban
+      ansible.builtin.replace:
+        path: /var/log/auth.log
+        regexp: "{{ item }}"
+        replace: ''
+        backup: no
+      loop:
+        - .* Invalid user .* {{ _bootstrap_my_ip | replace('.','\.') }} .*
+        - .* Connection closed by invalid user .* {{ _bootstrap_my_ip | replace('.','\.') }} .*

--- a/roles/bootstrap/tasks/prepare/main.yml
+++ b/roles/bootstrap/tasks/prepare/main.yml
@@ -1,0 +1,47 @@
+- name: Try connection
+  block:
+    - name: Test connection
+      ansible.builtin.wait_for_connection:
+        timeout: "{{ bootstrap_timeout }}"
+      register: bootstrap_connect
+      changed_when: false
+  rescue:
+    - name: Gather facts about the system
+      ansible.builtin.include_tasks:
+        file: gather_facts.yml
+    - name: Install minmal bootstrap packages
+      ansible.builtin.raw: "{{ bootstrap_install.raw }}"
+      register: bootstrap_install_packages
+      changed_when:
+        - (bootstrap_install.stdout_regex in bootstrap_install_packages.stdout and
+           bootstrap_os_family in [ "Alpine", "Archlinux", "Gentoo" ]) or
+          (bootstrap_install.stdout_regex not in bootstrap_install_packages.stdout and
+           bootstrap_os_family in [ "Debian", "RedHat", "Rocky", "Suse" ])
+      vars:
+        ansible_user: "{{ bootstrap_user }}"
+  always:
+    - name: Set bootstrap_ansible_user connected
+      ansible.builtin.set_fact:
+        bootstrap_ansible_user: "{{ ansible_user }}"
+      when:
+        - bootstrap_connect is succeeded
+        - ansible_user is defined
+
+    - name: Set bootstrap_ansible_user not connected
+      ansible.builtin.set_fact:
+        bootstrap_ansible_user: "{{ bootstrap_user }}"
+      when:
+        - bootstrap_connect is failed
+
+- name: Ensure system is prepared
+  vars:
+    ansible_user: "{{ bootstrap_ansible_user | default(omit) }}"
+  block:
+    - name: Gather ansible facts
+      ansible.builtin.setup:
+
+    - name: Install bootstrap packages
+      ansible.builtin.package:
+        name: "{{ item }}"
+        state: present
+      loop: "{{ bootstrap_facts_packages.split() }}"

--- a/roles/bootstrap/vars/main.yml
+++ b/roles/bootstrap/vars/main.yml
@@ -1,7 +1,7 @@
 _bootstrap_packages:
   Alpine: python3 sudo
   Archlinux: python sudo
-  Debian: python3 sudo gnupg python3-apt
+  Debian: python3 sudo gnupg python3-apt python3-distutils python3-setuptools python3-pkg-resources python-apt-common
   Gentoo: python sudo gentoolkit
   RedHat: &redhat_packages python3 sudo
   Rocky: *redhat_packages

--- a/roles/bootstrap/vars/main.yml
+++ b/roles/bootstrap/vars/main.yml
@@ -1,0 +1,70 @@
+_bootstrap_packages:
+  Alpine: python3 sudo
+  Archlinux: python sudo
+  Debian: python3 sudo gnupg python3-apt
+  Gentoo: python sudo gentoolkit
+  RedHat: &redhat_packages python3 sudo
+  Rocky: *redhat_packages
+  Suse: python3 python3-xml sudo
+  Amazon: python sudo
+  CentOS_7: python sudo
+  Debian_8: python sudo gnupg
+  Debian_9: python sudo gnupg
+  RedHat_7: python sudo
+
+# Map the right set of packages, based on gathered bootstrap facts.
+bootstrap_packages: "{{ _bootstrap_packages[bootstrap_distribution ~'_'~ bootstrap_distribution_major_version]|default(
+                     _bootstrap_packages[bootstrap_distribution])|default(
+                     _bootstrap_packages[bootstrap_os_family]) }}"
+
+_bootstrap_install:
+  Alpine:
+    raw: "LANG=C apk update ; apk add {{ bootstrap_packages }}"
+    stdout_regex: 'Installing'
+  Archlinux:
+    raw: "LANG=C pacman -Sy --noconfirm {{ bootstrap_packages }}"
+    stdout_regex: ' installing python'
+  Debian:
+    raw: "LANG=C apt-get update && apt-get install -y {{ bootstrap_packages }}"
+    stdout_regex: ' 0 newly installed'
+  Gentoo:
+    raw: "LANG=C equery l {{ bootstrap_packages }} ||
+          (emaint -a sync ; emerge -qkv {{ bootstrap_packages }} ; echo 'changed')"
+    stdout_regex: 'changed'
+  RedHat:
+    raw: "LANG=C yum -y install {{ bootstrap_packages }}"
+    stdout_regex: 'Nothing'
+  Suse:
+    raw: "LANG=C zypper -n install {{ bootstrap_packages }}"
+    stdout_regex: 'Nothing'
+
+# Map the right install command, based on gathered bootstrap facts.
+bootstrap_install: "{{ _bootstrap_install[bootstrap_distribution ~'_'~ bootstrap_distribution_major_version]|default(
+                    _bootstrap_install[bootstrap_distribution])|default(
+                    _bootstrap_install[bootstrap_os_family]) }}"
+
+# See URL for available OS families and search queries
+# https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/facts/system/distribution.py
+bootstrap_os_family_map:
+  Alpine: [Alpine]
+  Archlinux: [Archlinux, Antergos, Manjaro]
+  Debian: [Debian, Ubuntu, Raspbian, Neon, KDE neon,
+           Linux Mint, SteamOS, Devuan, Kali, Cumulus Linux,
+           'Pop!_OS', Parrot, Pardus GNU/Linux]
+  Gentoo: [Gentoo, Funtoo]
+  RedHat: [RedHat, Fedora, CentOS, Scientific, SLC,
+           Ascendos, CloudLinux, PSBM, Rocky, OracleLinux,
+           OVS, OEL, Amazon, Virtuozzo, XenServer, Alibaba,
+           EulerOS, openEuler, AlmaLinux]
+  Suse: [SLED, openSUSE Tumbleweed, openSUSE Leap,
+         SLES_SAP, SUSE_LINUX, SLES, openSUSE, SuSE]
+
+bootstrap_search:
+  Archlinux: 'Arch Linux'
+  OracleLinux: 'Oracle Linux'
+  RedHat: 'Red Hat'
+
+# Map the right set of packages, based on gathered ansible_facts.
+bootstrap_facts_packages: "{{ _bootstrap_packages[ansible_distribution ~'_'~ ansible_distribution_major_version]|default(
+                           _bootstrap_packages[ansible_distribution])|default(
+                           _bootstrap_packages[ansible_os_family]) }}"

--- a/roles/bootstrap/vars/main.yml
+++ b/roles/bootstrap/vars/main.yml
@@ -25,7 +25,7 @@ _bootstrap_install:
     raw: "LANG=C pacman -Sy --noconfirm {{ bootstrap_packages }}"
     stdout_regex: ' installing python'
   Debian:
-    raw: "LANG=C apt-get update && apt-get install -y {{ bootstrap_packages }}"
+    raw: "LANG=C apt-get update && NEEDRESTART_MODE=a apt-get install -y {{ bootstrap_packages }}"
     stdout_regex: ' 0 newly installed'
   Gentoo:
     raw: "LANG=C equery l {{ bootstrap_packages }} ||

--- a/roles/ethereum_node/molecule/default/molecule.yml
+++ b/roles/ethereum_node/molecule/default/molecule.yml
@@ -38,6 +38,18 @@ provisioner:
         ethereum_node_announced_ip: 127.0.0.1
         docker_daemon_options:
           storage-driver: "vfs"
+        # Fixes for integration tests to be able to run
+        lighthouse_container_command_extra_args:
+        # Fixes: Failed to start beacon node reason: Syncing from genesis is insecure and
+        # incompatible with data availability checks. You should instead perform a checkpoint
+        # sync from a trusted node using the --checkpoint-sync-url option. For a list of public endpoints,
+        #  see: https://eth-clients.github.io/checkpoint-sync-endpoints/
+        # Alternatively, use --allow-insecure-genesis-sync if the risks are understood.",
+          - --allow-insecure-genesis-sync
+        teku_container_command_extra_args:
+         # Fixes: Cannot sync outside of weak subjectivity period.
+         # Consider re-syncing your node using --checkpoint-sync-url or use --ignore-weak-subjectivity-period-enabled to ignore this check
+          - --ignore-weak-subjectivity-period-enabled
     host_vars:
       ethereum_node:
         ethereum_node_cl: ${CONSENSUS_CLIENT:-lighthouse.yml}


### PR DESCRIPTION
Move steps that were used by the `robertdebock.bootstrap` role to the bootstrap role itself.

So this mainly includes, making sure that the system is ready to be managed by ansible, by installing the minimal required packages (e.g. python, sudo ... ) 