### PR TITLE
making more configurible

### DIFF
--- a/roles/cl_bootnode/defaults/main.yaml
+++ b/roles/cl_bootnode/defaults/main.yaml
@@ -5,21 +5,26 @@ cl_bootnode_set_facts: true
 cl_bootnode_container_name: "cl-bootnode"
 cl_bootnode_container_image: "protolambda/eth2-bootnode:cleanup"
 cl_bootnode_container_env: {}
+cl_bootnode_p2p_port: 9010
+cl_bootnode_api_port: 8002
+cl_bootnode_datadir: "/data/cl-bootnode"
 cl_bootnode_container_ports:
-  - "9001:9001"
-  - "9001:9001/udp"
-  - "127.0.0.1:8002:8002"
+  - "{{cl_bootnode_p2p_port}}:{{cl_bootnode_p2p_port}}"
+  - "127.0.0.1:{{cl_bootnode_api_port}}:{{cl_bootnode_api_port}}"
+  - "{{cl_bootnode_p2p_port}}:{{cl_bootnode_p2p_port}}/udp"
+  -
 cl_bootnode_container_volumes:
-  - "/data/cl-bootnode:/data"
+  - "{{cl_bootnode_datadir}}:/data"
+
 cl_bootnode_container_stop_timeout: "30"
 cl_bootnode_container_networks: []
 cl_bootnode_container_command:
   - --color=false
   - --enr-ip={{ ansible_host }}
-  - --enr-udp=9001
+  - --enr-udp={{cl_bootnode_p2p_port}}
   - --level=trace
   - --listen-ip=0.0.0.0
-  - --listen-udp=9001
-  - --api-addr=0.0.0.0:8002
+  - --listen-udp={{cl_bootnode_p2p_port}}
+  - --api-addr=0.0.0.0:{{cl_bootnode_api_port}}
   - --node-db="/data/localnode.db"
   - --priv={{ cl_bootnode_privkey }}

--- a/roles/cl_bootnode/defaults/main.yaml
+++ b/roles/cl_bootnode/defaults/main.yaml
@@ -9,22 +9,22 @@ cl_bootnode_p2p_port: 9010
 cl_bootnode_api_port: 8002
 cl_bootnode_datadir: "/data/cl-bootnode"
 cl_bootnode_container_ports:
-  - "{{cl_bootnode_p2p_port}}:{{cl_bootnode_p2p_port}}"
-  - "127.0.0.1:{{cl_bootnode_api_port}}:{{cl_bootnode_api_port}}"
-  - "{{cl_bootnode_p2p_port}}:{{cl_bootnode_p2p_port}}/udp"
+  - "{{ cl_bootnode_p2p_port }}:{{ cl_bootnode_p2p_port }}"
+  - "127.0.0.1:{{ cl_bootnode_api_port }}:{{ cl_bootnode_api_port }}"
+  - "{{ cl_bootnode_p2p_port }}:{{ cl_bootnode_p2p_port }}/udp"
   -
 cl_bootnode_container_volumes:
-  - "{{cl_bootnode_datadir}}:/data"
+  - "{{ cl_bootnode_datadir }}:/data"
 
 cl_bootnode_container_stop_timeout: "30"
 cl_bootnode_container_networks: []
 cl_bootnode_container_command:
   - --color=false
   - --enr-ip={{ ansible_host }}
-  - --enr-udp={{cl_bootnode_p2p_port}}
+  - --enr-udp={{ cl_bootnode_p2p_port }}
   - --level=trace
   - --listen-ip=0.0.0.0
-  - --listen-udp={{cl_bootnode_p2p_port}}
-  - --api-addr=0.0.0.0:{{cl_bootnode_api_port}}
+  - --listen-udp={{ cl_bootnode_p2p_port }}
+  - --api-addr=0.0.0.0:{{ cl_bootnode_api_port }}
   - --node-db="/data/localnode.db"
   - --priv={{ cl_bootnode_privkey }}

--- a/roles/cl_bootnode/defaults/main.yaml
+++ b/roles/cl_bootnode/defaults/main.yaml
@@ -12,7 +12,6 @@ cl_bootnode_container_ports:
   - "{{ cl_bootnode_p2p_port }}:{{ cl_bootnode_p2p_port }}"
   - "127.0.0.1:{{ cl_bootnode_api_port }}:{{ cl_bootnode_api_port }}"
   - "{{ cl_bootnode_p2p_port }}:{{ cl_bootnode_p2p_port }}/udp"
-  -
 cl_bootnode_container_volumes:
   - "{{ cl_bootnode_datadir }}:/data"
 


### PR DESCRIPTION
`9001` is now taken by `quic`, so moving this range to a different one. Otherwise if cl-bootnode and quic is on the same node, we face an contentious deployment. 
