### PR TITLE
Bump ansible and other dependencies

### DIFF
--- a/.github/workflows/integration.ethereum_node.yaml
+++ b/.github/workflows/integration.ethereum_node.yaml
@@ -32,7 +32,7 @@ jobs:
     needs: changes
     if: >-
       ${{ needs.changes.outputs.ethereum_node == 'true' }} ||
-      ${{ needs.changes.outputs.dependencies == 'true' }} ||
+      ${{ needs.changes.outputs.dependencies == 'true' }}
     concurrency:
       group: >-
         ${{ github.head_ref }}-ethereum-node-${{ matrix.consensus }}-${{ matrix.execution }}

--- a/.github/workflows/integration.ethereum_node.yaml
+++ b/.github/workflows/integration.ethereum_node.yaml
@@ -17,6 +17,7 @@ jobs:
       pull-requests: read
     outputs:
       ethereum_node: ${{ steps.filter.outputs.ethereum_node }}
+      dependencies: ${{ steps.filter.outputs.dependencies }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -24,11 +25,14 @@ jobs:
         with:
           filters: |
             ethereum_node: roles/ethereum_node/**
+            dependencies: requirements.*
 
   # Integration test using molecule
   job:
     needs: changes
-    if: ${{ needs.changes.outputs.ethereum_node == 'true' }}
+    if: >-
+      ${{ needs.changes.outputs.ethereum_node == 'true' }} ||
+      ${{ needs.changes.outputs.dependencies == 'true' }} ||
     concurrency:
       group: >-
         ${{ github.head_ref }}-ethereum-node-${{ matrix.consensus }}-${{ matrix.execution }}

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-shellcheck 0.9.0
-python 3.11.4
+shellcheck 0.10.0
+python 3.12.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-ansible-lint==6.15.0
-ansible==7.5.0
+ansible-lint==24.6.0
+ansible==10.1.0
 molecule-containers==2.0.0
-molecule==5.0.1
-netaddr==0.8.0
-pip==23.1.2
+molecule==24.6.0
+netaddr==1.3.0
+pip==23.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ molecule-containers==2.0.0
 molecule==24.6.0
 netaddr==1.3.0
 pip==23.3.2
+requests==2.31 # Fix for not being able to run 'molecule test' using docker on mac. Issue: https://github.com/docker/docker-py/issues/3256

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ ansible==10.1.0
 molecule-containers==2.0.0
 molecule==24.6.0
 netaddr==1.3.0
-pip==23.3.2
+pip==24.0
 requests==2.31 # Fix for not being able to run 'molecule test' using docker on mac. Issue: https://github.com/docker/docker-py/issues/3256

--- a/roles/beacon_stopper/defaults/main.yaml
+++ b/roles/beacon_stopper/defaults/main.yaml
@@ -1,4 +1,4 @@
 beacon_stopper_datadir: /data/beacon_stopper
-slot_to_stop_at: 0
-url: http://beacon:5052
-ethereum_node_json_rpc_snooper_engine_name: snooper-engine
+slot_to_stop_at: 0 # noqa var-naming[no-role-prefix]
+url: http://beacon:5052 # noqa var-naming[no-role-prefix]
+ethereum_node_json_rpc_snooper_engine_name: snooper-engine # noqa var-naming[no-role-prefix]

--- a/roles/beaconchain_explorer_aio/defaults/main.yml
+++ b/roles/beaconchain_explorer_aio/defaults/main.yml
@@ -84,7 +84,7 @@ beaconchain_explorer_aio_cmd_frontend:
   - /app/explorer
   - -config=/config.yml
 
-beaconchain_frontend_config: |
+beaconchain_frontend_config: | # noqa var-naming[no-role-prefix]
   # All config options can be found in here: https://github.com/gobitfly/eth2-beaconchain-explorer/blob/master/types/config.go
   chain:
     name: sepolia

--- a/roles/erigon/defaults/main.yaml
+++ b/roles/erigon/defaults/main.yaml
@@ -14,7 +14,7 @@ erigon_ports_metrics: 6060
 erigon_ipv6_enabled: false
 
 erigon_container_name: erigon
-erigon_container_image: thorax/erigon:devel
+erigon_container_image: thorax/erigon:latest
 erigon_container_env: {}
 erigon_container_ports_ipv4:
   - "127.0.0.1:{{ erigon_ports_engine }}:{{ erigon_ports_engine }}"

--- a/roles/ethereum_inventory_web/defaults/main.yaml
+++ b/roles/ethereum_inventory_web/defaults/main.yaml
@@ -1,19 +1,19 @@
-eth_inventory_web_dir: /data/eth-inventory-web
+eth_inventory_web_dir: /data/eth-inventory-web # noqa var-naming[no-role-prefix]
 
-eth_inventory_web_container_image: nginx:alpine
-eth_inventory_web_container_name: eth-inventory-web
-eth_inventory_web_container_published_ports: []
-eth_inventory_web_container_restart_policy: always
-eth_inventory_web_container_networks_cli_compatible: true
-eth_inventory_web_container_network_mode: default
-eth_inventory_web_container_networks: []
-eth_inventory_web_container_env: {}
-eth_inventory_web_container_volumes_from: []
-eth_inventory_web_container_volumes:
+eth_inventory_web_container_image: nginx:alpine # noqa var-naming[no-role-prefix]
+eth_inventory_web_container_name: eth-inventory-web # noqa var-naming[no-role-prefix]
+eth_inventory_web_container_published_ports: [] # noqa var-naming[no-role-prefix]
+eth_inventory_web_container_restart_policy: always # noqa var-naming[no-role-prefix]
+eth_inventory_web_container_networks_cli_compatible: true # noqa var-naming[no-role-prefix]
+eth_inventory_web_container_network_mode: default # noqa var-naming[no-role-prefix]
+eth_inventory_web_container_networks: [] # noqa var-naming[no-role-prefix]
+eth_inventory_web_container_env: {} # noqa var-naming[no-role-prefix]
+eth_inventory_web_container_volumes_from: [] # noqa var-naming[no-role-prefix]
+eth_inventory_web_container_volumes: # noqa var-naming[no-role-prefix]
   - "{{ eth_inventory_web_dir }}/content:/usr/share/nginx/html:ro"
   - "{{ eth_inventory_web_dir }}/nginx-conf/default.conf:/etc/nginx/conf.d/default.conf:ro"
 
-eth_inventory_web_content:
+eth_inventory_web_content: # noqa var-naming[no-role-prefix]
   - file: v1/validator-ranges.json
     content: |
       {
@@ -48,7 +48,7 @@ eth_inventory_web_content:
         }
       }
 
-eth_inventory_web_nginx_config: |
+eth_inventory_web_nginx_config: | # noqa var-naming[no-role-prefix]
   server {
       listen       80;
       server_name  localhost;

--- a/roles/ethereum_testnet_config/defaults/main.yaml
+++ b/roles/ethereum_testnet_config/defaults/main.yaml
@@ -1,9 +1,9 @@
-eth_testnet_config_dir: /data/ethereum-network-config
+eth_testnet_config_dir: /data/ethereum-network-config # noqa var-naming[no-role-prefix]
 
-eth_testnet_config_git_enabled: false
-eth_testnet_config_git_repo: https://github.com/Inphi/eip4844-testnet
-eth_testnet_config_git_version: devnet-4
-eth_testnet_config_git_update: false # Once it's cloned, it wont update anymore, unless this var is changed
+eth_testnet_config_git_enabled: false # noqa var-naming[no-role-prefix]
+eth_testnet_config_git_repo: https://github.com/Inphi/eip4844-testnet # noqa var-naming[no-role-prefix]
+eth_testnet_config_git_version: devnet-4 # noqa var-naming[no-role-prefix]
+eth_testnet_config_git_update: false # noqa var-naming[no-role-prefix] - Once it's cloned, it wont update anymore, unless this var is changed
 
-eth_testnet_config_local_dir_enabled: false
-eth_testnet_config_local_dir_src: "files/ethereum-network-config"
+eth_testnet_config_local_dir_enabled: false # noqa var-naming[no-role-prefix]
+eth_testnet_config_local_dir_src: "files/ethereum-network-config" # noqa var-naming[no-role-prefix]

--- a/roles/generate_basic_auth_nginx/defaults/main.yaml
+++ b/roles/generate_basic_auth_nginx/defaults/main.yaml
@@ -1,16 +1,16 @@
 # Basic auth
-gen_basic_auth_nginx_paths:
+gen_basic_auth_nginx_paths: # noqa var-naming[no-role-prefix]
   - "{{ docker_nginx_proxy_datadir }}/htpasswd/{{ ethereum_node_rcp_hostname }}"
   - "{{ docker_nginx_proxy_datadir }}/htpasswd/{{ ethereum_node_beacon_hostname }}"
-gen_basic_auth_nginx_name: "some-user"
-gen_basic_auth_nginx_password: "some-password"
+gen_basic_auth_nginx_name: "some-user" # noqa var-naming[no-role-prefix]
+gen_basic_auth_nginx_password: "some-password" # noqa var-naming[no-role-prefix]
 
 # CORS
-gen_cors_nginx_paths:
+gen_cors_nginx_paths: # noqa var-naming[no-role-prefix]
   - "{{ docker_nginx_proxy_datadir }}/vhost/{{ ethereum_node_rcp_hostname }}_location"
   - "{{ docker_nginx_proxy_datadir }}/vhost/{{ ethereum_node_beacon_hostname }}_location"
 
-gen_cors_nginx_config: |
+gen_cors_nginx_config: | # noqa var-naming[no-role-prefix]
   proxy_hide_header 'Access-Control-Allow-Credentials';
   proxy_hide_header 'Access-Control-Allow-Origin';
   proxy_hide_header 'Access-Control-Allow-Methods';

--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -1,36 +1,37 @@
-devnet_name: 'template'
+devnet_name: 'template' # noqa var-naming[no-role-prefix]
 
-gen_kubernetes_config_default_output_dir: ../kubernetes/{{ ethereum_network_name | replace(devnet_name + "-", '') }}
+gen_kubernetes_config_default_output_dir: ../kubernetes/{{ ethereum_network_name | replace(devnet_name + "-", '') }} # noqa var-naming[no-role-prefix]
 
-default_cl_endpoint: >-
+default_cl_endpoint: >- # noqa var-naming[no-role-prefix]
   http://{{ gen_kubernetes_config_ethereum_node.cl + '-' + gen_kubernetes_config_ethereum_node.el + '-' +
   gen_kubernetes_config_ethereum_node.value + ':' + ethereum_node_cl_ports_http_beacon | string }}
-default_el_endpoint: >-
+default_el_endpoint: >- # noqa var-naming[no-role-prefix]
   http://{{ gen_kubernetes_config_ethereum_node.el + '-' + gen_kubernetes_config_ethereum_node.cl + '-' +
   gen_kubernetes_config_ethereum_node.value + ':' + ethereum_node_el_ports_http_rpc | string }}
-default_el_ws_endpoint: >-
+default_el_ws_endpoint: >- # noqa var-naming[no-role-prefix]
   ws://{{ gen_kubernetes_config_ethereum_node.el + '-' + gen_kubernetes_config_ethereum_node.cl + '-' +
   gen_kubernetes_config_ethereum_node.value + ':' + ethereum_node_el_ports_ws_rpc | string }}
-default_el_auth_endpoint: >-
+default_el_auth_endpoint: >- # noqa var-naming[no-role-prefix]
   http://{{ gen_kubernetes_config_ethereum_node.el + '-' + gen_kubernetes_config_ethereum_node.cl + '-' +
   gen_kubernetes_config_ethereum_node.value + ':' + ethereum_node_el_ports_engine | string }}
 
-gen_kubernetes_config_ethereum_node:
+gen_kubernetes_config_ethereum_node: # noqa var-naming[no-role-prefix]
   el: geth
   cl: teku
   value: "001"
 
-gen_kubernetes_domain: "{{ domain | default('ethpandaops.io') }}"
+gen_kubernetes_domain: "{{ domain | default('ethpandaops.io') }}" # noqa var-naming[no-role-prefix]
 
-gen_kubernetes_config_helm_repositories:
+gen_kubernetes_config_helm_repositories: # noqa var-naming[no-role-prefix]
   - name: ethereum-helm-charts
     url: https://ethpandaops.github.io/ethereum-helm-charts
   - name: blobscan-helm-charts
     url: https://blobscan.github.io/blobscan-helm-charts/
 
-gen_kubernetes_config_ethereum_node_name: "{{ gen_kubernetes_config_ethereum_node.cl }}-{{ gen_kubernetes_config_ethereum_node.el }}-{{ gen_kubernetes_config_ethereum_node.value }}" # noqa yaml[line-length]
+gen_kubernetes_config_ethereum_node_name: >- # noqa var-naming[no-role-prefix] yaml[line-length]
+  {{ gen_kubernetes_config_ethereum_node.cl }}-{{ gen_kubernetes_config_ethereum_node.el }}-{{ gen_kubernetes_config_ethereum_node.value }}
 
-gen_kubernetes_config_helm_charts:
+gen_kubernetes_config_helm_charts: # noqa var-naming[no-role-prefix]
   config:
     valuesTemplatePath: templates/config.yaml.j2
   beacon-metrics-gazer:

--- a/roles/grandine/defaults/main.yaml
+++ b/roles/grandine/defaults/main.yaml
@@ -85,7 +85,7 @@ grandine_container_command_extra_args: []
 # - --network=mainnet
 # - --graffiti=hello-world
 
-checkpoint_sync_url: https://beaconstate.ethstaker.cc
+checkpoint_sync_url: https://beaconstate.ethstaker.cc # noqa var-naming[no-role-prefix]
 grandine_checkpoint_sync_enabled: true
 grandine_container_command_checkpoint_args:
   - --checkpoint-sync-url={{ checkpoint_sync_url }}

--- a/roles/hetzner_vswitch/defaults/main.yaml
+++ b/roles/hetzner_vswitch/defaults/main.yaml
@@ -1,8 +1,8 @@
 ---
-interface_name: enp0s31f6
-vlan_id: 4000
-ip_address: "{{ ansible_host }}"
-netmask: 255.255.255.0
-gateway: 10.0.0.1
-mtu: 1400
-network: 10.0.0.0/16
+interface_name: enp0s31f6 # noqa var-naming[no-role-prefix]
+vlan_id: 4000 # noqa var-naming[no-role-prefix]
+ip_address: "{{ ansible_host }}" # noqa var-naming[no-role-prefix]
+netmask: 255.255.255.0 # noqa var-naming[no-role-prefix]
+gateway: 10.0.0.1 # noqa var-naming[no-role-prefix]
+mtu: 1400 # noqa var-naming[no-role-prefix]
+network: 10.0.0.0/16 # noqa var-naming[no-role-prefix]

--- a/roles/lighthouse/defaults/main.yaml
+++ b/roles/lighthouse/defaults/main.yaml
@@ -90,7 +90,7 @@ lighthouse_container_command: >-
 
 lighthouse_container_command_extra_args: []
 
-checkpoint_sync_url: https://beaconstate.ethstaker.cc
+checkpoint_sync_url: https://beaconstate.ethstaker.cc # noqa var-naming[no-role-prefix]
 lighthouse_checkpoint_sync_enabled: true
 lighthouse_container_command_checkpoint_args:
   - --checkpoint-sync-url={{ checkpoint_sync_url }}

--- a/roles/lodestar/defaults/main.yaml
+++ b/roles/lodestar/defaults/main.yaml
@@ -80,7 +80,7 @@ lodestar_container_command: >-
 
 lodestar_container_command_extra_args: []
 
-checkpoint_sync_url: https://beaconstate.ethstaker.cc
+checkpoint_sync_url: https://beaconstate.ethstaker.cc # noqa var-naming[no-role-prefix]
 lodestar_checkpoint_sync_enabled: true
 lodestar_container_command_checkpoint_args:
   - --checkpointSyncUrl={{ checkpoint_sync_url }}

--- a/roles/nimbus/defaults/main.yaml
+++ b/roles/nimbus/defaults/main.yaml
@@ -24,7 +24,7 @@ nimbus_validator_datadir: /data/nimbus-validator
 ## Checkpoint sync container configuration
 ##
 ################################################################################
-checkpoint_sync_url: https://beaconstate.ethstaker.cc
+checkpoint_sync_url: https://beaconstate.ethstaker.cc # noqa var-naming[no-role-prefix]
 nimbus_checkpoint_container_name: nimbus_checkpoint
 nimbus_checkpoint_container_command:
   - trustedNodeSync

--- a/roles/prysm/defaults/main.yaml
+++ b/roles/prysm/defaults/main.yaml
@@ -72,7 +72,7 @@ prysm_container_command: >-
 
 prysm_container_command_extra_args: []
 
-checkpoint_sync_url: https://beaconstate.ethstaker.cc
+checkpoint_sync_url: https://beaconstate.ethstaker.cc # noqa var-naming[no-role-prefix]
 prysm_checkpoint_sync_enabled: true
 prysm_container_command_checkpoint_args:
   - --checkpoint-sync-url={{ checkpoint_sync_url }}

--- a/roles/reth/defaults/main.yaml
+++ b/roles/reth/defaults/main.yaml
@@ -11,7 +11,7 @@ reth_ports_http_rpc: 8545
 reth_ports_engine: 8551
 reth_ports_metrics: 6060
 
-ret_ipv6_enabled: false
+reth_ipv6_enabled: false
 
 reth_container_name: reth
 reth_container_image: ghcr.io/paradigmxyz/reth
@@ -27,7 +27,7 @@ reth_container_ports_ipv6:
   - "[::]:{{ reth_ports_p2p }}:{{ reth_ports_p2p }}/udp"
 
 reth_container_ports: >-
-  {{ reth_container_ports_ipv4 + (reth_container_ports_ipv6 if ret_ipv6_enabled and ansible_default_ipv6.address is defined else []) }}
+  {{ reth_container_ports_ipv4 + (reth_container_ports_ipv6 if reth_ipv6_enabled and ansible_default_ipv6.address is defined else []) }}
 
 reth_container_volumes:
   - "{{ reth_datadir }}:/data"
@@ -53,7 +53,7 @@ reth_container_command_v6: []
   # - --nat=extip:{{ reth_announced_ipv6 }} # not supported
 
 reth_container_command: >-
-  {{ reth_container_command_default + (reth_container_command_v6 if ret_ipv6_enabled and ansible_default_ipv6.address is defined else []) }}
+  {{ reth_container_command_default + (reth_container_command_v6 if reth_ipv6_enabled and ansible_default_ipv6.address is defined else []) }}
 
 reth_container_command_extra_args: []
 #  - --http.api=eth,net,web3

--- a/roles/teku/defaults/main.yaml
+++ b/roles/teku/defaults/main.yaml
@@ -76,7 +76,7 @@ teku_container_command_extra_args:
 # - --logging=INFO
 # - ---validators-graffiti=hello-world
 
-checkpoint_sync_url: https://beaconstate.ethstaker.cc
+checkpoint_sync_url: https://beaconstate.ethstaker.cc # noqa var-naming[no-role-prefix]
 teku_checkpoint_sync_enabled: true
 teku_container_command_checkpoint_args:
   - --checkpoint-sync-url={{ checkpoint_sync_url }}


### PR DESCRIPTION
Version Upgrades:
- Shellcheck `0.9.0` -> `0.10.0` https://github.com/koalaman/shellcheck/releases
- Python `3.11.4` -> `3.12.4`
- Ansible `7.5.0` -> `10.1.0` ( Which is actually `2.14.x` to `2.17.1` as per https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html) 
- Ansible Lint `6.15.0 to `24.6.0` ( They changed their release numbers and jumped from v6 to v24 https://github.com/ansible/ansible-lint/releases )
- Molecule `5.0.1` to `24.6.0` ( Same as ansible lint, they jumped from v6 to v24 https://github.com/ansible/molecule/releases ) 
- pip `23.1.2` to `23.3.2`
- netaddr `0.8.0` to `1.3.0` ( needed by some ansible modules). 