### PR TITLE
fix: metadata not needed everywhere

### DIFF
--- a/roles/generate_kubernetes_config/templates/ethereum-node.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/ethereum-node.yaml.j2
@@ -127,21 +127,21 @@
             GENESIS_URI=https://config.{{ network_subdomain }}/el/genesis.json;
             BESU_GENESIS_URI=https://config.{{ network_subdomain }}/el/besu.json;
             ENODES_URI=https://config.{{ network_subdomain }}/el/enodes.txt;
-            mkdir -p /data/network-config/metadata;
+            mkdir -p /data/network-config;
             if ! [ -f /data/network_config_init_done ];
             then
               apk update && apk add curl jq;
-              wget -O /data/network-config/metadata/chainspec.json $CHAINSPEC_URI;
-              wget -O /data/network-config/metadata/genesis.json $GENESIS_URI;
-              wget -O /data/network-config/metadata/besu.json $BESU_GENESIS_URI;
-              wget -O /data/network-config/metadata/enodes.txt $ENODES_URI;
+              wget -O /data/network-config/chainspec.json $CHAINSPEC_URI;
+              wget -O /data/network-config/genesis.json $GENESIS_URI;
+              wget -O /data/network-config/besu.json $BESU_GENESIS_URI;
+              wget -O /data/network-config/enodes.txt $ENODES_URI;
               cat /data/network-config/genesis.json | jq -r '.config.chainId' > /data/network-config/chainid.txt;
               touch /data/network_config_init_done;
               echo "network config init done";
             else
               echo "network config already present";
             fi;
-            echo "bootnode init done: $(cat /data/network-config/metadata/enodes.txt)";
+            echo "bootnode init done: $(cat /data/network-config/enodes.txt)";
         volumeMounts:
           - name: storage
             mountPath: "/data"
@@ -158,11 +158,7 @@
           - >
             if ! [ -f /data/genesis_init_done ];
             then
-{%- if gen_kubernetes_config_ethereum_node.el in ['geth'] +%}
-              {{ gen_kubernetes_config_ethereum_node.el }} init --state.scheme=path --datadir /data /data/network-config/metadata/genesis.json;
-{%- else +%}
-              {{ gen_kubernetes_config_ethereum_node.el }} init --datadir /data /data/network-config/metadata/genesis.json;
-{%- endif +%}
+              {{ gen_kubernetes_config_ethereum_node.el }} init --datadir /data /data/network-config/genesis.json;
               touch /data/genesis_init_done;
               echo "genesis init done";
             else
@@ -218,22 +214,22 @@
           DEPOSIT_CONTRACT_BLOCK_HASH_URI=https://config.{{ network_subdomain }}/cl/deposit_contract_block_hash.txt;
           GENESIS_CONFIG_URI=https://config.{{ network_subdomain }}/cl/config.yaml;
           GENESIS_SSZ_URI=https://config.{{ network_subdomain }}/cl/genesis.ssz;
-          mkdir -p /data/network-config/metadata;
-          curl -s https://config.{{ network_subdomain }}/api/v1/nodes/inventory | jq -r '.ethereum_pairs[] | .consensus.enr' > /data/network-config/metadata/bootstrap_nodes.txt;
-          if ! [ -f /data/network-config/metadata/genesis.ssz ];
+          mkdir -p /data/network-config;
+          curl -s https://config.{{ network_subdomain }}/api/v1/nodes/inventory | jq -r '.ethereum_pairs[] | .consensus.enr' > /data/network-config/bootstrap_nodes.txt;
+          if ! [ -f /data/network-config/genesis.ssz ];
           then
-            wget -O /data/network-config/metadata/deposit_contract.txt $DEPOSIT_CONTRACT_URI;
-            wget -O /data/network-config/metadata/deposit_contract_block.txt $DEPOSIT_CONTRACT_BLOCK_URI;
-            wget -O /data/network-config/metadata/deposit_contract_block_hash.txt $DEPOSIT_CONTRACT_BLOCK_HASH_URI;
-            wget -O /data/network-config/metadata/config.yaml $GENESIS_CONFIG_URI;
-            wget -O /data/network-config/metadata/genesis.ssz $GENESIS_SSZ_URI;
+            wget -O /data/network-config/deposit_contract.txt $DEPOSIT_CONTRACT_URI;
+            wget -O /data/network-config/deposit_contract_block.txt $DEPOSIT_CONTRACT_BLOCK_URI;
+            wget -O /data/network-config/deposit_contract_block_hash.txt $DEPOSIT_CONTRACT_BLOCK_HASH_URI;
+            wget -O /data/network-config/config.yaml $GENESIS_CONFIG_URI;
+            wget -O /data/network-config/genesis.ssz $GENESIS_SSZ_URI;
             echo "genesis init done";
           else
             echo "genesis exists. skipping...";
           fi;
-          (tr '\n' ',' < /data/network-config/metadata/bootstrap_nodes.txt | sed 's/[^,]*/"&"/g') > /data/network-config/metadata/bootstrap_nodes2.txt;
-          mv /data/network-config/metadata/bootstrap_nodes2.txt /data/network-config/metadata/bootstrap_nodes.txt;
-          echo "bootnode init done: $(cat /data/network-config/metadata/bootstrap_nodes.txt)";
+          (tr '\n' ',' < /data/network-config/bootstrap_nodes.txt | sed 's/[^,]*/"&"/g') > /data/network-config/bootstrap_nodes2.txt;
+          mv /data/network-config/bootstrap_nodes2.txt /data/network-config/bootstrap_nodes.txt;
+          echo "bootnode init done: $(cat /data/network-config/bootstrap_nodes.txt)";
       volumeMounts:
         - name: storage
           mountPath: "/data"


### PR DESCRIPTION
We didn't change any of the paths for metadata inside the containers. So this metadata change broke all the kube nodes stuff. 