### PR TITLE
Add mev-rs role

### DIFF
--- a/.github/workflows/integration.ethereum_node.yaml
+++ b/.github/workflows/integration.ethereum_node.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           filters: |
             ethereum_node: roles/ethereum_node/**
-          #  dependencies: requirements.*
+            dependencies: requirements.*
 
   # Integration test using molecule
   job:

--- a/.github/workflows/integration.ethereum_node.yaml
+++ b/.github/workflows/integration.ethereum_node.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           filters: |
             ethereum_node: roles/ethereum_node/**
-            dependencies: requirements.*
+          #  dependencies: requirements.*
 
   # Integration test using molecule
   job:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -25,6 +25,7 @@ jobs:
           filters: |
             blockscout: roles/blockscout/**
             bootstrap: roles/bootstrap/**
+            mev_boost: roles/mev_boost/**
             mev_rs: roles/mev_rs/**
 
   # Integration test using molecule

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -25,7 +25,7 @@ jobs:
           filters: |
             blockscout: roles/blockscout/**
             bootstrap: roles/bootstrap/**
-            mev-rs: roles/mev_rs/**
+            mev_rs: roles/mev_rs/**
 
   # Integration test using molecule
   job:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -25,6 +25,7 @@ jobs:
           filters: |
             blockscout: roles/blockscout/**
             bootstrap: roles/bootstrap/**
+            mev-rs: roles/mev_rs/**
 
   # Integration test using molecule
   job:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A collection of reusable ansible components used by the EthPandaOps team.
 - [goomy](roles/goomy)
 - [mev_boost](roles/mev_boost)
 - [mev_relay](roles/mev_relay)
+- [mev_rs](roles/mev_rs)
 - [powfaucet](roles/powfaucet)
 - [snapshotter](roles/snapshotter)
 - [xatu_sentry](roles/xatu_sentry)

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,10 +1,10 @@
 collections:
   - name: community.docker
-    version: ">=3.0.2,<4.0.0"
+    version: "3.12.1"
   - name: ansible.posix
-    version: ">=1.4.0,<2.0.0"
+    version: "1.5.4"
   - name: community.general
-    version: ">=6.0.0,<7.0.0"
+    version: "6.6.9"
 
 roles:
   - name: geerlingguy.docker

--- a/roles/ethereum_node/defaults/main.yaml
+++ b/roles/ethereum_node/defaults/main.yaml
@@ -46,8 +46,13 @@ ethereum_node_blobber_enabled: false
 ethereum_node_blobber_name: blobber
 ethereum_node_blobber_port: 20000
 
-# Mev boost
-ethereum_node_mev_boost_enabled: false
+# External block builder
+ethereum_node_external_builder_enabled: "{{ ethereum_node_mev_boost_enabled | default(false) }}"
+#                                           ^ Var used for backward compatability
+ethereum_node_external_builder_type: mev_boost # Valid options: mev_boost, mev_rs, custom
+ethereum_node_external_builder_container_name: external-block-builder
+ethereum_node_external_builder_server_port: 18550
+ethereum_node_external_builder_endpoint: "http://{{ ethereum_node_external_builder_container_name }}:{{ ethereum_node_external_builder_server_port }}"
 
 # Mev mock relay builder
 ethereum_node_mev_mock_relay_builder_enabled: false

--- a/roles/ethereum_node/molecule/default/molecule.yml
+++ b/roles/ethereum_node/molecule/default/molecule.yml
@@ -54,7 +54,10 @@ provisioner:
           - --ignore-weak-subjectivity-period-enabled
     host_vars:
       ethereum_node:
-        ethereum_node_cl: ${CONSENSUS_CLIENT:-lighthouse.yml}
-        ethereum_node_el: ${EXECUTION_CLIENT:-geth.yml}
+        ethereum_node_cl: ${CONSENSUS_CLIENT:-lighthouse}
+        ethereum_node_el: ${EXECUTION_CLIENT:-geth}
+        # Add additional vars here if you're manually testing a feature:
+        # ethereum_node_external_builder_enabled: true
+        # ethereum_node_external_builder_type: mev_boost
 verifier:
   name: ansible

--- a/roles/ethereum_node/tasks/addons/external_block_builder.yaml
+++ b/roles/ethereum_node/tasks/addons/external_block_builder.yaml
@@ -1,0 +1,49 @@
+- name: Setup external block builder
+  when: ethereum_node_external_builder_enabled
+  block:
+    - name: Setup mev_boost
+      ansible.builtin.include_role:
+        name: ethpandaops.general.mev_boost
+      vars:
+        mev_boost_container_networks: "{{ ethereum_node_docker_networks }}"
+        mev_boost_container_name: "{{ ethereum_node_external_builder_container_name }}"
+        mev_boost_server_port: "{{ ethereum_node_external_builder_server_port }}"
+      when: ethereum_node_external_builder_type == "mev_boost"
+
+    - name: Setup mev_rs
+      ansible.builtin.include_role:
+        name: ethpandaops.general.mev_rs
+      vars:
+        mev_rs_container_networks: "{{ ethereum_node_docker_networks }}"
+        mev_rs_container_name: "{{ ethereum_node_external_builder_container_name }}"
+        mev_rs_server_port: "{{ ethereum_node_external_builder_server_port }}"
+      when: ethereum_node_external_builder_type == "mev_rs"
+
+    - name: Inform that the external block builder is enabled
+      ansible.builtin.debug:
+        msg: >-
+          External block builder '{{ ethereum_node_external_builder_type }}' is enabled.
+          The consensus layer nodes will use the following endpoint: '{{ ethereum_node_external_builder_endpoint }}'.
+
+- name: Cleanup external block builder
+  when: not ethereum_node_external_builder_enabled
+  block:
+    - name: Cleanup mev_boost
+      ansible.builtin.include_role:
+        name: ethpandaops.general.mev_boost
+      vars:
+        mev_boost_container_name: "{{ ethereum_node_external_builder_container_name }}"
+        mev_boost_cleanup: true
+      when: >-
+        ethereum_node_external_builder_type == "mev_boost" or
+        ethereum_node_external_builder_type == "custom"
+
+    - name: Cleanup mev_rs
+      ansible.builtin.include_role:
+        name: ethpandaops.general.mev_rs
+      vars:
+        mev_rs_container_name: "{{ ethereum_node_external_builder_container_name }}"
+        mev_rs_cleanup: true
+      when: >-
+        ethereum_node_external_builder_type == "mev_rs" or
+        ethereum_node_external_builder_type == "custom"

--- a/roles/ethereum_node/tasks/main.yaml
+++ b/roles/ethereum_node/tasks/main.yaml
@@ -11,12 +11,8 @@
   ansible.builtin.import_tasks: cleanup.yaml
   when: not ethereum_node_skip_cleanup
 
-- name: Setup mev_boost
-  ansible.builtin.include_role:
-    name: ethpandaops.general.mev_boost
-  vars:
-    mev_boost_container_networks: "{{ ethereum_node_docker_networks }}"
-  when: ethereum_node_mev_boost_enabled
+- name: Setup external block builder
+  ansible.builtin.import_tasks: addons/external_block_builder.yaml
 
 - name: Setup mev_mock_relay_builder
   ansible.builtin.include_role:

--- a/roles/ethereum_node/tasks/setup_cl.yaml
+++ b/roles/ethereum_node/tasks/setup_cl.yaml
@@ -16,7 +16,8 @@
     lighthouse_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     lighthouse_validator_container_networks: "{{ ethereum_node_docker_networks }}"
     lighthouse_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
-    lighthouse_mev_boost_enabled: "{{ ethereum_node_mev_boost_enabled }}"
+    lighthouse_mev_boost_enabled: "{{ ethereum_node_external_builder_enabled }}"
+    lighthouse_mev_boost_endpoint: "{{ ethereum_node_external_builder_endpoint }}"
     lighthouse_checkpoint_sync_enabled: "{{ ethereum_node_cl_checkpoint_sync_enabled }}"
     lighthouse_ipv6_enabled: "{{ ethereum_node_ipv6_enabled }}"
 
@@ -36,7 +37,8 @@
     teku_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     teku_validator_container_networks: "{{ ethereum_node_docker_networks }}"
     teku_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
-    teku_mev_boost_enabled: "{{ ethereum_node_mev_boost_enabled }}"
+    teku_mev_boost_enabled: "{{ ethereum_node_external_builder_enabled }}"
+    teku_mev_boost_endpoint: "{{ ethereum_node_external_builder_endpoint }}"
     teku_checkpoint_sync_enabled: "{{ ethereum_node_cl_checkpoint_sync_enabled }}"
     teku_ipv6_enabled: "{{ ethereum_node_ipv6_enabled }}"
 
@@ -57,7 +59,8 @@
     prysm_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     prysm_validator_container_networks: "{{ ethereum_node_docker_networks }}"
     prysm_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
-    prysm_mev_boost_enabled: "{{ ethereum_node_mev_boost_enabled }}"
+    prysm_mev_boost_enabled: "{{ ethereum_node_external_builder_enabled }}"
+    prysm_mev_boost_endpoint: "{{ ethereum_node_external_builder_endpoint }}"
     prysm_checkpoint_sync_enabled: "{{ ethereum_node_cl_checkpoint_sync_enabled }}"
     prysm_ipv6_enabled: "{{ ethereum_node_ipv6_enabled }}"
 
@@ -78,7 +81,8 @@
     lodestar_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     lodestar_validator_container_networks: "{{ ethereum_node_docker_networks }}"
     lodestar_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
-    lodestar_mev_boost_enabled: "{{ ethereum_node_mev_boost_enabled }}"
+    lodestar_mev_boost_enabled: "{{ ethereum_node_external_builder_enabled }}"
+    lodestar_mev_boost_endpoint: "{{ ethereum_node_external_builder_endpoint }}"
     lodestar_checkpoint_sync_enabled: "{{ ethereum_node_cl_checkpoint_sync_enabled }}"
     lodestar_ipv6_enabled: "{{ ethereum_node_ipv6_enabled }}"
 
@@ -98,7 +102,8 @@
     nimbus_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     nimbus_validator_container_networks: "{{ ethereum_node_docker_networks }}"
     nimbus_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
-    nimbus_mev_boost_enabled: "{{ ethereum_node_mev_boost_enabled }}"
+    nimbus_mev_boost_enabled: "{{ ethereum_node_external_builder_enabled }}"
+    nimbus_mev_boost_endpoint: "{{ ethereum_node_external_builder_endpoint }}"
     nimbus_checkpoint_sync_enabled: "{{ ethereum_node_cl_checkpoint_sync_enabled }}"
     nimbus_ipv6_enabled: "{{ ethereum_node_ipv6_enabled }}"
 
@@ -118,6 +123,7 @@
     grandine_execution_engine_endpoint: "{{ ethereum_node_execution_engine_endpoint }}"
     grandine_validator_enabled: "{{ ethereum_node_cl_validator_enabled }}"
     grandine_validator_fee_recipient: "{{ ethereum_node_cl_validator_fee_recipient }}"
-    grandine_mev_boost_enabled: "{{ ethereum_node_mev_boost_enabled }}"
+    grandine_mev_boost_enabled: "{{ ethereum_node_external_builder_enabled }}"
+    grandine_mev_boost_endpoint: "{{ ethereum_node_external_builder_endpoint }}"
     grandine_checkpoint_sync_enabled: "{{ ethereum_node_cl_checkpoint_sync_enabled }}"
     grandine_ipv6_enabled: "{{ ethereum_node_ipv6_enabled }}"

--- a/roles/ethereum_node/vars/main.yaml
+++ b/roles/ethereum_node/vars/main.yaml
@@ -14,6 +14,10 @@ ethereum_node_supported_cl:
   - nimbus
   - grandine
 
+ethereum_node_supported_external_builders:
+  - mev_boost
+  - mev_rs
+
 ethereum_node_docker_networks:
   - name: "{{ ethereum_node_docker_network_name }}"
 

--- a/roles/mev_boost/defaults/main.yml
+++ b/roles/mev_boost/defaults/main.yml
@@ -19,6 +19,9 @@ mev_boost_container_stop_timeout: "300"
 mev_boost_container_networks: "{{ mev_boost_docker_networks }}"
 mev_boost_container_volumes: []
 mev_boost_container_command:
+  - -addr=0.0.0.0:{{ mev_boost_server_port }}
+  - -sepolia
   - -relay-check
+  - -relays=https://0x845bd072b7cd566f02faeb0a4033ce9399e42839ced64e8b2adcfc859ed1e8e1a5a293336a49feac6d9a5edb779be53a@boost-relay-sepolia.flashbots.net
 
 mev_boost_container_command_extra_args: []

--- a/roles/mev_boost/molecule/default/converge.yml
+++ b/roles/mev_boost/molecule/default/converge.yml
@@ -1,0 +1,35 @@
+- name: Converge
+  hosts: all
+  become: true
+  pre_tasks:
+    - name: Update apt cache
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 3600
+  tasks:
+    - name: Setup
+      block:
+        - name: Install docker
+          ansible.builtin.import_role:
+            name: geerlingguy.docker
+        - name: Install pip and docker pkg
+          ansible.builtin.import_role:
+            name: geerlingguy.pip
+          vars:
+            pip_install_packages:
+              - name: docker
+        - name: Run mev rs
+          ansible.builtin.import_role:
+            name: mev_boost
+      always:
+        - name: Get logs
+          ansible.builtin.command:
+            cmd: docker logs {{ mev_boost_container_name }}
+          changed_when: false
+          register: container_logs
+        - name: Show logs
+          ansible.builtin.debug:
+            var: "{{ item }}"
+          loop:
+            - container_logs.stdout
+            - container_logs.stderr

--- a/roles/mev_boost/molecule/default/molecule.yml
+++ b/roles/mev_boost/molecule/default/molecule.yml
@@ -1,0 +1,32 @@
+scenario:
+  name: default
+dependency:
+  name: galaxy
+  options:
+    role-file: ../../requirements.yaml
+    requirements-file: ../../requirements.yaml
+driver:
+  name: docker
+platforms:
+  - name: debian12
+    image: "geerlingguy/docker-debian12-ansible:latest"
+    # platform: linux/amd64
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  # env:
+    # ANSIBLE_VERBOSITY: 3
+  inventory:
+    group_vars:
+      all:
+        docker_daemon_options:
+          storage-driver: "vfs"
+        # Role specific variables
+        mev_boost_container_name: mev-boost
+verifier:
+  name: ansible

--- a/roles/mev_boost/molecule/default/verify.yml
+++ b/roles/mev_boost/molecule/default/verify.yml
@@ -1,0 +1,19 @@
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Wait and let the container start
+      ansible.builtin.pause:
+        seconds: 5
+    - name: Get infos from container
+      community.docker.docker_container_info:
+        name: "{{ mev_boost_container_name }}"
+      register: result_container
+    - name: Show infos
+      ansible.builtin.debug:
+        var: "{{ item }}"
+      loop:
+        - result_container
+    - name: Assert results
+      ansible.builtin.assert:
+        that:
+          - "result_container.container.State.Running == true"

--- a/roles/mev_rs/README.md
+++ b/roles/mev_rs/README.md
@@ -1,0 +1,38 @@
+# ethpandaops.general.mev_rs
+
+This role will run [mev-rs](https://github.com/ralexstokes/mev-rs) within a docker container.
+
+## Requirements
+
+You'll need docker on the target system. Make sure to install it upfront.
+
+## Role Variables
+
+Default variables are defined in [defaults/main.yaml](defaults/main.yaml)
+
+## Dependencies
+
+You'll need docker to run this role. One way of installing docker could be via ansible galaxy with the following dependencies set within `requirements.yaml`:
+
+```yaml
+roles:
+- src: geerlingguy.docker
+  version: latest
+- src: geerlingguy.pip
+  version: latest
+```
+
+## Example Playbook
+
+Your playbook could look like this:
+
+```yaml
+- hosts: localhost
+  become: true
+  roles:
+  - role: geerlingguy.docker
+  - role: geerlingguy.pip
+    pip_install_packages:
+    - name: docker
+  - role: ethpandaops.general.mev_rs
+```

--- a/roles/mev_rs/defaults/main.yml
+++ b/roles/mev_rs/defaults/main.yml
@@ -10,7 +10,7 @@ mev_rs_docker_networks:
 ##
 ################################################################################
 mev_rs_container_name: mev-rs
-mev_rs_container_image: ethpandaops/mev-rs:main
+mev_rs_container_image: ethpandaops/mev-rs:v0.4.0-alpha.6
 mev_rs_container_env: {}
 mev_rs_server_port: 18550
 mev_rs_container_ports:

--- a/roles/mev_rs/defaults/main.yml
+++ b/roles/mev_rs/defaults/main.yml
@@ -1,0 +1,39 @@
+mev_rs_user: mev_rs
+mev_rs_datadir: "/data/mev-rs"
+mev_rs_cleanup: false # when set to "true" it will remove the container(s)
+mev_rs_docker_network_name: shared
+mev_rs_docker_networks:
+  - name: "{{ mev_rs_docker_network_name }}"
+################################################################################
+##
+## mev_rs container configuration
+##
+################################################################################
+mev_rs_container_name: mev-rs
+mev_rs_container_image: ethpandaops/mev-rs:main
+mev_rs_container_env: {}
+mev_rs_server_port: 18550
+mev_rs_container_ports:
+  - "127.0.0.1:{{ mev_rs_server_port }}:{{ mev_rs_server_port }}"
+mev_rs_container_stop_timeout: "300"
+mev_rs_container_networks: "{{ mev_rs_docker_networks }}"
+mev_rs_container_volumes:
+  - "{{ mev_rs_datadir }}/config:/config"
+
+# Available subcommands are: 'boost', 'relay', 'build'
+mev_rs_container_command:
+  - boost
+  - /config/config.toml
+
+mev_rs_container_command_extra_args: []
+
+# Configuration file. Example from: https://github.com/ralexstokes/mev-rs/blob/main/example.config.toml
+mev_rs_config: |
+  network = "sepolia"
+
+  [boost]
+  host = "0.0.0.0"
+  port = {{ mev_rs_server_port }}
+  relays = [
+      "https://0x845bd072b7cd566f02faeb0a4033ce9399e42839ced64e8b2adcfc859ed1e8e1a5a293336a49feac6d9a5edb779be53a@boost-relay-sepolia.flashbots.net",
+  ]

--- a/roles/mev_rs/molecule/default/converge.yml
+++ b/roles/mev_rs/molecule/default/converge.yml
@@ -1,0 +1,35 @@
+- name: Converge
+  hosts: all
+  become: true
+  pre_tasks:
+    - name: Update apt cache
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 3600
+  tasks:
+    - name: Setup
+      block:
+        - name: Install docker
+          ansible.builtin.import_role:
+            name: geerlingguy.docker
+        - name: Install pip and docker pkg
+          ansible.builtin.import_role:
+            name: geerlingguy.pip
+          vars:
+            pip_install_packages:
+              - name: docker
+        - name: Run mev rs
+          ansible.builtin.import_role:
+            name: mev_rs
+      always:
+        - name: Get logs
+          ansible.builtin.command:
+            cmd: docker logs {{ mev_rs_container_name }}
+          changed_when: false
+          register: container_logs
+        - name: Show logs
+          ansible.builtin.debug:
+            var: "{{ item }}"
+          loop:
+            - container_logs.stdout
+            - container_logs.stderr

--- a/roles/mev_rs/molecule/default/molecule.yml
+++ b/roles/mev_rs/molecule/default/molecule.yml
@@ -1,0 +1,32 @@
+scenario:
+  name: default
+dependency:
+  name: galaxy
+  options:
+    role-file: ../../requirements.yaml
+    requirements-file: ../../requirements.yaml
+driver:
+  name: docker
+platforms:
+  - name: debian12
+    image: "geerlingguy/docker-debian12-ansible:latest"
+    # platform: linux/amd64
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  # env:
+    # ANSIBLE_VERBOSITY: 3
+  inventory:
+    group_vars:
+      all:
+        docker_daemon_options:
+          storage-driver: "vfs"
+        # Role specific variables
+        mev_rs_container_name: mev-rs
+verifier:
+  name: ansible

--- a/roles/mev_rs/molecule/default/verify.yml
+++ b/roles/mev_rs/molecule/default/verify.yml
@@ -1,0 +1,19 @@
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Wait and let the container start
+      ansible.builtin.pause:
+        seconds: 5
+    - name: Get infos from container
+      community.docker.docker_container_info:
+        name: "{{ mev_rs_container_name }}"
+      register: result_container
+    - name: Show infos
+      ansible.builtin.debug:
+        var: "{{ item }}"
+      loop:
+        - result_container
+    - name: Assert results
+      ansible.builtin.assert:
+        that:
+          - "result_container.container.State.Running == true"

--- a/roles/mev_rs/tasks/cleanup.yaml
+++ b/roles/mev_rs/tasks/cleanup.yaml
@@ -1,0 +1,5 @@
+- name: Remove mev_rs container
+  community.docker.docker_container:
+    name: "{{ mev_rs_container_name }}"
+    state: absent
+  when: mev_rs_cleanup

--- a/roles/mev_rs/tasks/main.yml
+++ b/roles/mev_rs/tasks/main.yml
@@ -1,0 +1,6 @@
+- name: Setup mev_rs
+  ansible.builtin.import_tasks: setup.yaml
+  when: not mev_rs_cleanup
+
+- name: Cleanup mev_rs
+  ansible.builtin.import_tasks: cleanup.yaml

--- a/roles/mev_rs/tasks/setup.yaml
+++ b/roles/mev_rs/tasks/setup.yaml
@@ -1,0 +1,44 @@
+- name: Add mev_rs user
+  ansible.builtin.user:
+    name: "{{ mev_rs_user }}"
+  register: mev_rs_user_meta
+
+- name: Setup docker network
+  ansible.builtin.include_role:
+    name: ethpandaops.general.docker_network
+  vars:
+    docker_network_name: "{{ mev_rs_docker_network_name }}"
+
+- name: Create directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: "0750"
+    owner: "{{ mev_rs_user }}"
+    group: "{{ mev_rs_user }}"
+  loop:
+    - "{{ mev_rs_datadir }}"
+    - "{{ mev_rs_datadir }}/config"
+
+- name: Create mev-rs config file
+  ansible.builtin.copy:
+    content: "{{ mev_rs_config }}"
+    dest: "{{ mev_rs_datadir }}/config/config.toml"
+    owner: "{{ mev_rs_user }}"
+    group: "{{ mev_rs_user }}"
+    mode: '0640'
+
+- name: Run mev_rs container
+  community.docker.docker_container:
+    name: "{{ mev_rs_container_name }}"
+    image: "{{ mev_rs_container_image }}"
+    image_name_mismatch: recreate
+    state: started
+    restart_policy: always
+    stop_timeout: "{{ mev_rs_container_stop_timeout }}"
+    volumes: "{{ mev_rs_container_volumes }}"
+    env: "{{ mev_rs_container_env }}"
+    networks: "{{ mev_rs_container_networks }}"
+    ports: "{{ mev_rs_container_ports }}"
+    command: "{{ mev_rs_container_command + mev_rs_container_command_extra_args }} "
+    user: "{{ mev_rs_user_meta.uid }}"

--- a/roles/nethermind/defaults/main.yaml
+++ b/roles/nethermind/defaults/main.yaml
@@ -52,7 +52,7 @@ nethermind_container_command_default:
   - --JsonRpc.EngineHost=0.0.0.0
   - --JsonRpc.EnginePort={{ nethermind_ports_engine }}
   - --Metrics.Enabled=true
-  - --Metrics.NodeName={{ ethereum_network_name }}-{{ inventory_hostname }}
+  - --Metrics.NodeName={{ ethereum_network_name | default("unknown") }}-{{ inventory_hostname }}
   - --Metrics.ExposePort={{ nethermind_ports_metrics }}
   - --Metrics.ExposeHost=0.0.0.0
 


### PR DESCRIPTION
Solves: https://github.com/ethpandaops/ansible-collection-general/issues/221 

Changes in this PR:
- Added `mev_rs` role with a simple molecule test (Run container, verify it started, print logs).
- Added the same molecule test to `mev_boost`.
- Changed the `ethereum_node` role so that you can choose between `mev_boost` and `mev_rs` as the external block builder. It's also possible to provide `custom`. When using a custom builder, you need to provide your own endpoint.