### PR TITLE
Possiblity to run isolated validator client on consensus nodes + CI change detection improvements

### DIFF
--- a/.github/workflows/integration.ethereum_node.yaml
+++ b/.github/workflows/integration.ethereum_node.yaml
@@ -86,7 +86,7 @@ jobs:
       ${{
         needs.changes.outputs.ethereum_node == 'false' &&
         needs.changes.outputs.dependencies == 'false' &&
-        needs.changes_consensus.outputs.clients == 'true'
+        needs.changes_consensus.outputs.clients != '[]'
       }}
     concurrency:
       group: >-

--- a/.github/workflows/integration.ethereum_node.yaml
+++ b/.github/workflows/integration.ethereum_node.yaml
@@ -12,8 +12,7 @@ defaults:
 jobs:
   vars:
     runs-on: ubuntu-latest
-    steps:
-       - run: echo "null"
+    steps: []
     outputs:
       ALL_CONSENSUS_CLIENTS: "['teku', 'prysm', 'lighthouse', 'nimbus', 'lodestar', 'grandine']"
       ALL_EXECUTION_CLIENTS: "['geth', 'nethermind', 'erigon', 'besu', 'ethereumjs', 'reth']"

--- a/.github/workflows/integration.ethereum_node.yaml
+++ b/.github/workflows/integration.ethereum_node.yaml
@@ -122,5 +122,6 @@ jobs:
         run: molecule test
         env:
           PY_COLORS: '1'
+          ANSIBLE_DOCKER_TIMEOUT: '120'
           EXECUTION_CLIENT: ${{ matrix.execution }}
           CONSENSUS_CLIENT: ${{ matrix.consensus }}

--- a/.github/workflows/integration.ethereum_node.yaml
+++ b/.github/workflows/integration.ethereum_node.yaml
@@ -57,8 +57,8 @@ jobs:
         id: vars
         run: |
           echo "Verifying which clients have changes";
-          ALL_CONSENSUS_CLIENTS="['teku', 'prysm', 'lighthouse', 'nimbus', 'lodestar', 'grandine']";
-          ALL_EXECUTION_CLIENTS="['geth', 'nethermind', 'erigon', 'besu', 'ethereumjs', 'reth']";
+          ALL_CONSENSUS_CLIENTS="[teku, prysm, lighthouse, nimbus, lodestar, grandine]";
+          ALL_EXECUTION_CLIENTS="[geth, nethermind, 'erigon, besu, ethereumjs, reth]";
 
           CONSENSUS_CLIENTS="[]";
           EXECUTION_CLIENTS="[]";
@@ -66,19 +66,19 @@ jobs:
           if [[ "${{ needs.changes.outputs.ethereum_node }}" == "true" ]] || \
              [[ "${{ needs.changes.outputs.dependencies }}" == "true" ]] || \
              [[ "${{ needs.changes.outputs.consensus_clients }}" != "[]" && "${{ needs.changes.outputs.execution_clients }}" != "[]" ]]; then
-            echo "Global changes detected - Need to run all clients";
+            echo "- Global changes detected - Need to run all clients";
             CONSENSUS_CLIENTS=$ALL_CONSENSUS_CLIENTS;
             EXECUTION_CLIENTS=$ALL_EXECUTION_CLIENTS;
           elif [[ "${{ needs.changes.outputs.consensus_clients }}" != "[]" ]]; then
             CONSENSUS_CLIENTS="${{ needs.changes.outputs.consensus_clients }}";
             EXECUTION_CLIENTS=$ALL_EXECUTION_CLIENTS;
-            echo "Consensus clients have changed $CONSENSUS_CLIENTS";
+            echo "- Consensus clients have changed $CONSENSUS_CLIENTS";
           elif [[ "${{ needs.changes.outputs.execution_clients }}" != "[]" ]]; then
             EXECUTION_CLIENTS="${{ needs.changes.outputs.execution_clients }}";
             CONSENSUS_CLIENTS=$ALL_CONSENSUS_CLIENTS;
-            echo "Execution clients have changed $EXECUTION_CLIENTS";
+            echo "- Execution clients have changed $EXECUTION_CLIENTS";
           else
-            echo "No changes detected - Skipping";
+            echo "- No changes detected - Skipping";
           fi
 
           echo "Detected changes in consensus clients: $CONSENSUS_CLIENTS";

--- a/.github/workflows/integration.ethereum_node.yaml
+++ b/.github/workflows/integration.ethereum_node.yaml
@@ -10,24 +10,15 @@ defaults:
     working-directory: ansible_collections/ethpandaops/general
 
 jobs:
-  #global_vars:
-  #  runs-on: ubuntu-latest
-  #  steps: []
-  #    - run: echo "Setting vars to be used in other jobs"
-  #      shell: sh
-  #  outputs:
-  #    ALL_CONSENSUS_CLIENTS: "['teku', 'prysm', 'lighthouse', 'nimbus', 'lodestar', 'grandine']"
-  #    ALL_EXECUTION_CLIENTS: "['geth', 'nethermind', 'erigon', 'besu', 'ethereumjs', 'reth']"
-#
-  # Job for change detection
   changes:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
     outputs:
-      ethereum_node: ${{ steps.global.outputs.ethereum_node }}
       dependencies: ${{ steps.global.outputs.dependencies }}
+      ethereum_node: ${{ steps.global.outputs.ethereum_node }}
       consensus_clients: ${{ steps.consensus_clients.outputs.changes }}
+      execution_clients: ${{ steps.execution_clients.outputs.changes }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -46,6 +37,16 @@ jobs:
             nimbus: roles/nimbus/**
             prysm: roles/prysm/**
             teku: roles/teku/**
+      - uses: dorny/paths-filter@v3
+        id: execution_clients
+        with:
+          filters: |
+            geth: roles/geth/**
+            nethermind: roles/nethermind/**
+            erigon: roles/erigon/**
+            besu: roles/besu/**
+            ethereumjs: roles/ethereumjs/**
+            reth: roles/reth/**
 
   vars:
     runs-on: ubuntu-latest
@@ -55,19 +56,38 @@ jobs:
         working-directory: .
         id: vars
         run: |
-          echo "ALL_CONSENSUS_CLIENTS=['teku', 'prysm', 'lighthouse', 'nimbus', 'lodestar', 'grandine']" >> $GITHUB_ENV
-          echo "ALL_EXECUTION_CLIENTS=['geth', 'nethermind', 'erigon', 'besu', 'ethereumjs', 'reth']" >> $GITHUB_ENV
+          ALL_CONSENSUS_CLIENTS="['teku', 'prysm', 'lighthouse', 'nimbus', 'lodestar', 'grandine']";
+          ALL_EXECUTION_CLIENTS="['geth', 'nethermind', 'erigon', 'besu', 'ethereumjs', 'reth']";
+
+          CONSENSUS_CLIENTS="[]";
+          EXECUTION_CLIENTS="[]";
+
+          if [[ "${{ needs.changes.outputs.ethereum_node }}" == "true" ]] || \
+             [[ "${{ needs.changes.outputs.dependencies }}" == "true" ]] || \
+             [[ "${{ needs.changes.outputs.consensus_clients }}" != "[]" && "${{ needs.changes.outputs.execution_clients }}" != "[]" ]]; then
+            CONSENSUS_CLIENTS=$ALL_CONSENSUS_CLIENTS;
+            EXECUTION_CLIENTS=$ALL_EXECUTION_CLIENTS;
+          elif [[ "${{ needs.changes.outputs.consensus_clients }}" != "[]" ]]; then
+            CONSENSUS_CLIENTS="${{ needs.changes.outputs.consensus_clients }}";
+            EXECUTION_CLIENTS=$ALL_EXECUTION_CLIENTS;
+          elif [[ "${{ needs.changes.outputs.execution_clients }}" != "[]" ]]; then
+            EXECUTION_CLIENTS="${{ needs.changes.outputs.execution_clients }}";
+            CONSENSUS_CLIENTS=$ALL_CONSENSUS_CLIENTS;
+          fi
+
+          echo "CONSENSUS_CLIENTS=$CONSENSUS_CLIENTS" >> $GITHUB_ENV
+          echo "EXECUTION_CLIENTS=$EXECUTION_CLIENTS" >> $GITHUB_ENV
+
     outputs:
-      ALL_CONSENSUS_CLIENTS: ${{ env.ALL_CONSENSUS_CLIENTS }}
-      ALL_EXECUTION_CLIENTS: ${{ env.ALL_EXECUTION_CLIENTS }}
+      CONSENSUS_CLIENTS: ${{ env.CONSENSUS_CLIENTS }}
+      EXECUTION_CLIENTS: ${{ env.EXECUTION_CLIENTS }}
 
-  # Integration test using molecule ( all pairs )
-  all-clients:
+  test:
     needs: [changes,vars]
     if: >-
       ${{
-        needs.changes.outputs.ethereum_node == 'true' ||
-        needs.changes.outputs.dependencies == 'true'
+        needs.vars.outputs.EXECUTION_CLIENTS != '[]' &&
+        needs.vars.outputs.CONSENSUS_CLIENTS != '[]'
       }}
     concurrency:
       group: >-
@@ -76,42 +96,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        consensus: ${{ fromJSON(needs.vars.outputs.ALL_CONSENSUS_CLIENTS) }}
-        execution: ${{ fromJSON(needs.vars.outputs.ALL_EXECUTION_CLIENTS) }}
-    runs-on: self-hosted-ghr-size-s-x64
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          path: ansible_collections/ethpandaops/general
-
-      - uses: ./ansible_collections/ethpandaops/general/.github/actions/setup
-
-      - name: Run molecule
-        working-directory: ansible_collections/ethpandaops/general/roles/ethereum_node
-        run: molecule test
-        env:
-          PY_COLORS: '1'
-          EXECUTION_CLIENT: ${{ matrix.execution }}
-          CONSENSUS_CLIENT: ${{ matrix.consensus }}
-
-  # Integration test using molecule ( consensus layer )
-  consensus-clients:
-    needs: [changes,vars]
-    if: >-
-      ${{
-        needs.changes.outputs.ethereum_node == 'false' &&
-        needs.changes.outputs.dependencies == 'false' &&
-        needs.changes.outputs.consensus_clients != '[]'
-      }}
-    concurrency:
-      group: >-
-        ${{ github.head_ref }}-ethereum-node-${{ matrix.consensus }}-${{ matrix.execution }}
-      cancel-in-progress: true
-    strategy:
-      fail-fast: false
-      matrix:
-        consensus: ${{ fromJSON(needs.changes.outputs.consensus_clients) }}
-        execution: ${{ fromJSON(needs.vars.outputs.ALL_EXECUTION_CLIENTS) }}
+        consensus: ${{ fromJSON(needs.vars.outputs.CONSENSUS_CLIENTS) }}
+        execution: ${{ fromJSON(needs.vars.outputs.EXECUTION_CLIENTS) }}
     runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/integration.ethereum_node.yaml
+++ b/.github/workflows/integration.ethereum_node.yaml
@@ -94,7 +94,7 @@ jobs:
       EXECUTION_CLIENTS: ${{ env.EXECUTION_CLIENTS }}
 
   test:
-    needs: [changes,vars]
+    needs: [changes, vars]
     if: >-
       ${{
         needs.vars.outputs.EXECUTION_CLIENTS != '[]' &&

--- a/.github/workflows/integration.ethereum_node.yaml
+++ b/.github/workflows/integration.ethereum_node.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+env:
+  ALL_CONSENSUS_CLIENTS: "['teku', 'prysm', 'lighthouse', 'nimbus', 'lodestar', 'grandine']"
+  ALL_EXECUTION_CLIENTS: "['geth', 'nethermind', 'erigon', 'besu', 'ethereumjs', 'reth']"
+
 defaults:
   run:
     working-directory: ansible_collections/ethpandaops/general
@@ -39,6 +43,7 @@ jobs:
         id: filter
         with:
           filters: |
+            grandine: roles/grandine/**
             lighthouse: roles/lighthouse/**
             lodestar: roles/lodestar/**
             nimbus: roles/nimbus/**
@@ -61,8 +66,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        consensus: [teku, prysm, lighthouse, nimbus, lodestar, grandine]
-        execution: [geth, nethermind, erigon, besu, ethereumjs, reth]
+        consensus: ${{ fromJSON(env.ALL_CONSENSUS_CLIENTS) }}
+        execution: ${{ fromJSON(env.ALL_EXECUTION_CLIENTS) }}
     runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@v4
@@ -96,7 +101,7 @@ jobs:
       fail-fast: false
       matrix:
         consensus: ${{ fromJSON(needs.changes_consensus.outputs.clients) }}
-        execution: [geth, nethermind, erigon, besu, ethereumjs, reth]
+        execution: ${{ fromJSON(env.ALL_EXECUTION_CLIENTS) }}
     runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/integration.ethereum_node.yaml
+++ b/.github/workflows/integration.ethereum_node.yaml
@@ -56,6 +56,7 @@ jobs:
         working-directory: .
         id: vars
         run: |
+          echo "Verifying which clients have changes";
           ALL_CONSENSUS_CLIENTS="['teku', 'prysm', 'lighthouse', 'nimbus', 'lodestar', 'grandine']";
           ALL_EXECUTION_CLIENTS="['geth', 'nethermind', 'erigon', 'besu', 'ethereumjs', 'reth']";
 
@@ -65,15 +66,23 @@ jobs:
           if [[ "${{ needs.changes.outputs.ethereum_node }}" == "true" ]] || \
              [[ "${{ needs.changes.outputs.dependencies }}" == "true" ]] || \
              [[ "${{ needs.changes.outputs.consensus_clients }}" != "[]" && "${{ needs.changes.outputs.execution_clients }}" != "[]" ]]; then
+            echo "Global changes detected - Need to run all clients";
             CONSENSUS_CLIENTS=$ALL_CONSENSUS_CLIENTS;
             EXECUTION_CLIENTS=$ALL_EXECUTION_CLIENTS;
           elif [[ "${{ needs.changes.outputs.consensus_clients }}" != "[]" ]]; then
             CONSENSUS_CLIENTS="${{ needs.changes.outputs.consensus_clients }}";
             EXECUTION_CLIENTS=$ALL_EXECUTION_CLIENTS;
+            echo "Consensus clients have changed $CONSENSUS_CLIENTS";
           elif [[ "${{ needs.changes.outputs.execution_clients }}" != "[]" ]]; then
             EXECUTION_CLIENTS="${{ needs.changes.outputs.execution_clients }}";
             CONSENSUS_CLIENTS=$ALL_CONSENSUS_CLIENTS;
+            echo "Execution clients have changed $EXECUTION_CLIENTS";
+          else
+            echo "No changes detected - Skipping";
           fi
+
+          echo "Detected changes in consensus clients: $CONSENSUS_CLIENTS";
+          echo "Detected changes in execution clients: $EXECUTION_CLIENTS";
 
           echo "CONSENSUS_CLIENTS=$CONSENSUS_CLIENTS" >> $GITHUB_ENV
           echo "EXECUTION_CLIENTS=$EXECUTION_CLIENTS" >> $GITHUB_ENV

--- a/.github/workflows/integration.ethereum_node.yaml
+++ b/.github/workflows/integration.ethereum_node.yaml
@@ -13,6 +13,8 @@ jobs:
   vars:
     runs-on: ubuntu-latest
     steps: []
+      - run: echo "Setting vars to be used in other jobs"
+        shell: sh
     outputs:
       ALL_CONSENSUS_CLIENTS: "['teku', 'prysm', 'lighthouse', 'nimbus', 'lodestar', 'grandine']"
       ALL_EXECUTION_CLIENTS: "['geth', 'nethermind', 'erigon', 'besu', 'ethereumjs', 'reth']"

--- a/.github/workflows/integration.ethereum_node.yaml
+++ b/.github/workflows/integration.ethereum_node.yaml
@@ -56,9 +56,9 @@ jobs:
         working-directory: .
         id: vars
         run: |
-          echo "Verifying which clients have changes";
+          echo "Verifying which client roles have changed...";
           ALL_CONSENSUS_CLIENTS="[teku, prysm, lighthouse, nimbus, lodestar, grandine]";
-          ALL_EXECUTION_CLIENTS="[geth, nethermind, 'erigon, besu, ethereumjs, reth]";
+          ALL_EXECUTION_CLIENTS="[geth, nethermind, erigon, besu, ethereumjs, reth]";
 
           CONSENSUS_CLIENTS="[]";
           EXECUTION_CLIENTS="[]";
@@ -66,23 +66,25 @@ jobs:
           if [[ "${{ needs.changes.outputs.ethereum_node }}" == "true" ]] || \
              [[ "${{ needs.changes.outputs.dependencies }}" == "true" ]] || \
              [[ "${{ needs.changes.outputs.consensus_clients }}" != "[]" && "${{ needs.changes.outputs.execution_clients }}" != "[]" ]]; then
-            echo "- Global changes detected - Need to run all clients";
+            echo "Global changes detected - Need to run all clients";
             CONSENSUS_CLIENTS=$ALL_CONSENSUS_CLIENTS;
             EXECUTION_CLIENTS=$ALL_EXECUTION_CLIENTS;
           elif [[ "${{ needs.changes.outputs.consensus_clients }}" != "[]" ]]; then
             CONSENSUS_CLIENTS="${{ needs.changes.outputs.consensus_clients }}";
             EXECUTION_CLIENTS=$ALL_EXECUTION_CLIENTS;
-            echo "- Consensus clients have changed $CONSENSUS_CLIENTS";
+            echo "Consensus clients have changed $CONSENSUS_CLIENTS";
           elif [[ "${{ needs.changes.outputs.execution_clients }}" != "[]" ]]; then
             EXECUTION_CLIENTS="${{ needs.changes.outputs.execution_clients }}";
             CONSENSUS_CLIENTS=$ALL_CONSENSUS_CLIENTS;
-            echo "- Execution clients have changed $EXECUTION_CLIENTS";
+            echo "Execution clients have changed $EXECUTION_CLIENTS";
           else
-            echo "- No changes detected - Skipping";
+            echo "No changes detected - Skipping";
           fi
 
-          echo "Detected changes in consensus clients: $CONSENSUS_CLIENTS";
-          echo "Detected changes in execution clients: $EXECUTION_CLIENTS";
+          echo "=========================================";
+          echo "The following matrix will be executed:";
+          echo "CONSENSUS_CLIENTS: $CONSENSUS_CLIENTS";
+          echo "EXECUTION_CLIENTS: $EXECUTION_CLIENTS";
 
           echo "CONSENSUS_CLIENTS=$CONSENSUS_CLIENTS" >> $GITHUB_ENV
           echo "EXECUTION_CLIENTS=$EXECUTION_CLIENTS" >> $GITHUB_ENV

--- a/.github/workflows/integration.ethereum_node.yaml
+++ b/.github/workflows/integration.ethereum_node.yaml
@@ -70,11 +70,11 @@ jobs:
             CONSENSUS_CLIENTS=$ALL_CONSENSUS_CLIENTS;
             EXECUTION_CLIENTS=$ALL_EXECUTION_CLIENTS;
           elif [[ "${{ needs.changes.outputs.consensus_clients }}" != "[]" ]]; then
-            CONSENSUS_CLIENTS="${{ needs.changes.outputs.consensus_clients }}";
+            CONSENSUS_CLIENTS="${{ toJSON(needs.changes.outputs.consensus_clients) }}";
             EXECUTION_CLIENTS=$ALL_EXECUTION_CLIENTS;
             echo "Consensus clients have changed $CONSENSUS_CLIENTS";
           elif [[ "${{ needs.changes.outputs.execution_clients }}" != "[]" ]]; then
-            EXECUTION_CLIENTS="${{ needs.changes.outputs.execution_clients }}";
+            EXECUTION_CLIENTS="${{ toJSON(needs.changes.outputs.execution_clients) }}";
             CONSENSUS_CLIENTS=$ALL_CONSENSUS_CLIENTS;
             echo "Execution clients have changed $EXECUTION_CLIENTS";
           else
@@ -83,8 +83,8 @@ jobs:
 
           echo "=========================================";
           echo "The following matrix will be executed:";
-          echo "CONSENSUS_CLIENTS: $CONSENSUS_CLIENTS";
-          echo "EXECUTION_CLIENTS: $EXECUTION_CLIENTS";
+          echo "CONSENSUS_CLIENTS=$CONSENSUS_CLIENTS";
+          echo "EXECUTION_CLIENTS=$EXECUTION_CLIENTS";
 
           echo "CONSENSUS_CLIENTS=$CONSENSUS_CLIENTS" >> $GITHUB_ENV
           echo "EXECUTION_CLIENTS=$EXECUTION_CLIENTS" >> $GITHUB_ENV

--- a/.github/workflows/integration.ethereum_node.yaml
+++ b/.github/workflows/integration.ethereum_node.yaml
@@ -10,15 +10,15 @@ defaults:
     working-directory: ansible_collections/ethpandaops/general
 
 jobs:
-  global_vars:
-    runs-on: ubuntu-latest
-    steps: []
-      - run: echo "Setting vars to be used in other jobs"
-        shell: sh
-    outputs:
-      ALL_CONSENSUS_CLIENTS: "['teku', 'prysm', 'lighthouse', 'nimbus', 'lodestar', 'grandine']"
-      ALL_EXECUTION_CLIENTS: "['geth', 'nethermind', 'erigon', 'besu', 'ethereumjs', 'reth']"
-
+  #global_vars:
+  #  runs-on: ubuntu-latest
+  #  steps: []
+  #    - run: echo "Setting vars to be used in other jobs"
+  #      shell: sh
+  #  outputs:
+  #    ALL_CONSENSUS_CLIENTS: "['teku', 'prysm', 'lighthouse', 'nimbus', 'lodestar', 'grandine']"
+  #    ALL_EXECUTION_CLIENTS: "['geth', 'nethermind', 'erigon', 'besu', 'ethereumjs', 'reth']"
+#
   # Job for change detection
   changes:
     needs: global_vars
@@ -48,9 +48,22 @@ jobs:
             prysm: roles/prysm/**
             teku: roles/teku/**
 
+  vars:
+    runs-on: ubuntu-latest
+    needs: changes
+    steps:
+      - name: Set variables
+        id: vars
+        run: |
+          echo "ALL_CONSENSUS_CLIENTS=['teku', 'prysm', 'lighthouse', 'nimbus', 'lodestar', 'grandine']" >> $GITHUB_ENV
+          echo "ALL_EXECUTION_CLIENTS=['geth', 'nethermind', 'erigon', 'besu', 'ethereumjs', 'reth']" >> $GITHUB_ENV
+    outputs:
+      ALL_CONSENSUS_CLIENTS: ${{ env.ALL_CONSENSUS_CLIENTS }}
+      ALL_EXECUTION_CLIENTS: ${{ env.ALL_EXECUTION_CLIENTS }}
+
   # Integration test using molecule ( all pairs )
   all-clients:
-    needs: changes
+    needs: [changes,vars]
     if: >-
       ${{
         needs.changes.outputs.ethereum_node == 'true' ||
@@ -63,8 +76,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        consensus: ${{ fromJSON(needs.global_vars.outputs.ALL_CONSENSUS_CLIENTS) }}
-        execution: ${{ fromJSON(needs.global_vars.outputs.ALL_EXECUTION_CLIENTS) }}
+        consensus: ${{ fromJSON(needs.vars.outputs.ALL_CONSENSUS_CLIENTS) }}
+        execution: ${{ fromJSON(needs.vars.outputs.ALL_EXECUTION_CLIENTS) }}
     runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@v4
@@ -98,7 +111,7 @@ jobs:
       fail-fast: false
       matrix:
         consensus: ${{ fromJSON(needs.changes.outputs.consensus_clients) }}
-        execution: ${{ fromJSON(needs.global_vars.outputs.ALL_EXECUTION_CLIENTS) }}
+        execution: ${{ fromJSON(needs.vars.outputs.ALL_EXECUTION_CLIENTS) }}
     runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/integration.ethereum_node.yaml
+++ b/.github/workflows/integration.ethereum_node.yaml
@@ -10,7 +10,7 @@ defaults:
     working-directory: ansible_collections/ethpandaops/general
 
 jobs:
-  # Job for change detection
+  # Job for change detection ( ethereum_node, dependencies )
   changes:
     runs-on: ubuntu-latest
     permissions:
@@ -26,9 +26,28 @@ jobs:
           filters: |
             ethereum_node: roles/ethereum_node/**
             dependencies: requirements.*
+  # Job for change detection ( consensus layer clients )
+  changes_consensus:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      clients: ${{ steps.filter.outputs.changes }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            lighthouse: roles/lighthouse/**
+            lodestar: roles/lodestar/**
+            nimbus: roles/nimbus/**
+            prysm: roles/prysm/**
+            teku: roles/teku/**
 
-  # Integration test using molecule
-  job:
+
+  # Integration test using molecule ( all pairs )
+  all-clients:
     needs: changes
     if: >-
       ${{
@@ -43,6 +62,40 @@ jobs:
       fail-fast: false
       matrix:
         consensus: [teku, prysm, lighthouse, nimbus, lodestar, grandine]
+        execution: [geth, nethermind, erigon, besu, ethereumjs, reth]
+    runs-on: self-hosted-ghr-size-s-x64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: ansible_collections/ethpandaops/general
+
+      - uses: ./ansible_collections/ethpandaops/general/.github/actions/setup
+
+      - name: Run molecule
+        working-directory: ansible_collections/ethpandaops/general/roles/ethereum_node
+        run: molecule test
+        env:
+          PY_COLORS: '1'
+          EXECUTION_CLIENT: ${{ matrix.execution }}
+          CONSENSUS_CLIENT: ${{ matrix.consensus }}
+
+  # Integration test using molecule ( consensus layer )
+  consensus-clients:
+    needs: changes
+    if: >-
+      ${{
+        needs.changes.outputs.ethereum_node == 'false' &&
+        needs.changes.outputs.dependencies == 'false' &&
+        needs.changes_consensus.outputs.clients == 'true'
+      }}
+    concurrency:
+      group: >-
+        ${{ github.head_ref }}-ethereum-node-${{ matrix.consensus }}-${{ matrix.execution }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        consensus: ${{ fromJSON(needs.changes_consensus.outputs.clients) }}
         execution: [geth, nethermind, erigon, besu, ethereumjs, reth]
     runs-on: self-hosted-ghr-size-s-x64
     steps:

--- a/.github/workflows/integration.ethereum_node.yaml
+++ b/.github/workflows/integration.ethereum_node.yaml
@@ -21,7 +21,6 @@ jobs:
 #
   # Job for change detection
   changes:
-    needs: global_vars
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/.github/workflows/integration.ethereum_node.yaml
+++ b/.github/workflows/integration.ethereum_node.yaml
@@ -57,8 +57,8 @@ jobs:
         id: vars
         run: |
           echo "Verifying which client roles have changed...";
-          ALL_CONSENSUS_CLIENTS="[teku, prysm, lighthouse, nimbus, lodestar, grandine]";
-          ALL_EXECUTION_CLIENTS="[geth, nethermind, erigon, besu, ethereumjs, reth]";
+          ALL_CONSENSUS_CLIENTS='["teku", "prysm", "lighthouse", "nimbus", "lodestar", "grandine"]';
+          ALL_EXECUTION_CLIENTS='["geth", "nethermind", "erigon", "besu", "ethereumjs", "reth"]';
 
           CONSENSUS_CLIENTS="[]";
           EXECUTION_CLIENTS="[]";

--- a/.github/workflows/integration.ethereum_node.yaml
+++ b/.github/workflows/integration.ethereum_node.yaml
@@ -53,6 +53,7 @@ jobs:
     steps:
       - name: Set variables
         id: vars
+        shell: sh
         run: |
           echo "ALL_CONSENSUS_CLIENTS=['teku', 'prysm', 'lighthouse', 'nimbus', 'lodestar', 'grandine']" >> $GITHUB_ENV
           echo "ALL_EXECUTION_CLIENTS=['geth', 'nethermind', 'erigon', 'besu', 'ethereumjs', 'reth']" >> $GITHUB_ENV
@@ -95,7 +96,7 @@ jobs:
 
   # Integration test using molecule ( consensus layer )
   consensus-clients:
-    needs: changes
+    needs: [changes,vars]
     if: >-
       ${{
         needs.changes.outputs.ethereum_node == 'false' &&

--- a/.github/workflows/integration.ethereum_node.yaml
+++ b/.github/workflows/integration.ethereum_node.yaml
@@ -10,7 +10,7 @@ defaults:
     working-directory: ansible_collections/ethpandaops/general
 
 jobs:
-  vars:
+  global_vars:
     runs-on: ubuntu-latest
     steps: []
       - run: echo "Setting vars to be used in other jobs"
@@ -21,6 +21,7 @@ jobs:
 
   # Job for change detection
   changes:
+    needs: global_vars
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -62,8 +63,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        consensus: ${{ fromJSON(needs.vars.outputs.ALL_CONSENSUS_CLIENTS) }}
-        execution: ${{ fromJSON(needs.vars.outputs.ALL_EXECUTION_CLIENTS) }}
+        consensus: ${{ fromJSON(needs.global_vars.outputs.ALL_CONSENSUS_CLIENTS) }}
+        execution: ${{ fromJSON(needs.global_vars.outputs.ALL_EXECUTION_CLIENTS) }}
     runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@v4
@@ -97,7 +98,7 @@ jobs:
       fail-fast: false
       matrix:
         consensus: ${{ fromJSON(needs.changes.outputs.consensus_clients) }}
-        execution: ${{ fromJSON(needs.vars.outputs.ALL_EXECUTION_CLIENTS) }}
+        execution: ${{ fromJSON(needs.global_vars.outputs.ALL_EXECUTION_CLIENTS) }}
     runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/integration.ethereum_node.yaml
+++ b/.github/workflows/integration.ethereum_node.yaml
@@ -5,42 +5,38 @@ on:
     branches:
       - master
 
-env:
-  ALL_CONSENSUS_CLIENTS: "['teku', 'prysm', 'lighthouse', 'nimbus', 'lodestar', 'grandine']"
-  ALL_EXECUTION_CLIENTS: "['geth', 'nethermind', 'erigon', 'besu', 'ethereumjs', 'reth']"
-
 defaults:
   run:
     working-directory: ansible_collections/ethpandaops/general
 
 jobs:
-  # Job for change detection ( ethereum_node, dependencies )
+  vars:
+    runs-on: ubuntu-latest
+    steps:
+       - run: echo "null"
+    outputs:
+      ALL_CONSENSUS_CLIENTS: "['teku', 'prysm', 'lighthouse', 'nimbus', 'lodestar', 'grandine']"
+      ALL_EXECUTION_CLIENTS: "['geth', 'nethermind', 'erigon', 'besu', 'ethereumjs', 'reth']"
+
+  # Job for change detection
   changes:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
     outputs:
-      ethereum_node: ${{ steps.filter.outputs.ethereum_node }}
-      dependencies: ${{ steps.filter.outputs.dependencies }}
+      ethereum_node: ${{ steps.global.outputs.ethereum_node }}
+      dependencies: ${{ steps.global.outputs.dependencies }}
+      consensus_clients: ${{ steps.consensus_clients.outputs.changes }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
-        id: filter
+        id: global
         with:
           filters: |
             ethereum_node: roles/ethereum_node/**
             dependencies: requirements.*
-  # Job for change detection ( consensus layer clients )
-  changes_consensus:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      clients: ${{ steps.filter.outputs.changes }}
-    steps:
-      - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
-        id: filter
+        id: consensus_clients
         with:
           filters: |
             grandine: roles/grandine/**
@@ -49,7 +45,6 @@ jobs:
             nimbus: roles/nimbus/**
             prysm: roles/prysm/**
             teku: roles/teku/**
-
 
   # Integration test using molecule ( all pairs )
   all-clients:
@@ -66,8 +61,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        consensus: ${{ fromJSON(env.ALL_CONSENSUS_CLIENTS) }}
-        execution: ${{ fromJSON(env.ALL_EXECUTION_CLIENTS) }}
+        consensus: ${{ fromJSON(needs.vars.outputs.ALL_CONSENSUS_CLIENTS) }}
+        execution: ${{ fromJSON(needs.vars.outputs.ALL_EXECUTION_CLIENTS) }}
     runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@v4
@@ -91,7 +86,7 @@ jobs:
       ${{
         needs.changes.outputs.ethereum_node == 'false' &&
         needs.changes.outputs.dependencies == 'false' &&
-        needs.changes_consensus.outputs.clients != '[]'
+        needs.changes.outputs.consensus_clients != '[]'
       }}
     concurrency:
       group: >-
@@ -100,8 +95,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        consensus: ${{ fromJSON(needs.changes_consensus.outputs.clients) }}
-        execution: ${{ fromJSON(env.ALL_EXECUTION_CLIENTS) }}
+        consensus: ${{ fromJSON(needs.changes.outputs.consensus_clients) }}
+        execution: ${{ fromJSON(needs.vars.outputs.ALL_EXECUTION_CLIENTS) }}
     runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/integration.ethereum_node.yaml
+++ b/.github/workflows/integration.ethereum_node.yaml
@@ -52,8 +52,8 @@ jobs:
     needs: changes
     steps:
       - name: Set variables
+        working-directory: .
         id: vars
-        shell: sh
         run: |
           echo "ALL_CONSENSUS_CLIENTS=['teku', 'prysm', 'lighthouse', 'nimbus', 'lodestar', 'grandine']" >> $GITHUB_ENV
           echo "ALL_EXECUTION_CLIENTS=['geth', 'nethermind', 'erigon', 'besu', 'ethereumjs', 'reth']" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ A collection of reusable ansible components used by the EthPandaOps team.
 - [ethereumjs](roles/ethereumjs)
 - [geth](roles/geth)
 - [nethermind](roles/nethermind)
+- [reth](roles/reth)
 
 ### Ethereum consensus clients
+- [grandine](roles/grandine)
 - [lighthouse](roles/lighthouse)
 - [lodestar](roles/lodestar)
 - [nimbus](roles/nimbus)

--- a/roles/lighthouse/defaults/main.yaml
+++ b/roles/lighthouse/defaults/main.yaml
@@ -1,3 +1,4 @@
+lighthouse_enabled: true
 lighthouse_user: lighthouse
 lighthouse_datadir: /data/lighthouse
 lighthouse_auth_jwt_path: /data/execution-auth.secret

--- a/roles/lighthouse/meta/main.yaml
+++ b/roles/lighthouse/meta/main.yaml
@@ -1,3 +1,4 @@
+allow_duplicates: true
 dependencies:
   - role: ethpandaops.general.ethereum_auth_jwt
     vars:

--- a/roles/lighthouse/tasks/cleanup.yaml
+++ b/roles/lighthouse/tasks/cleanup.yaml
@@ -2,7 +2,7 @@
   community.docker.docker_container:
     name: "{{ lighthouse_container_name }}"
     state: absent
-  when: lighthouse_cleanup
+  when: lighthouse_cleanup or (not lighthouse_enabled)
 
 - name: Remove lighthouse validator container
   community.docker.docker_container:

--- a/roles/lighthouse/tasks/setup.yaml
+++ b/roles/lighthouse/tasks/setup.yaml
@@ -3,80 +3,84 @@
     name: "{{ lighthouse_user }}"
   register: lighthouse_user_meta
 
-- name: Create data dir
-  ansible.builtin.file:
-    path: "{{ lighthouse_datadir }}"
-    state: directory
-    mode: "0750"
-    owner: "{{ lighthouse_user }}"
-    group: "{{ lighthouse_user }}"
+- name: Configure lighthouse beacon client
+  when: lighthouse_enabled
+  block:
+    - name: Create data dir
+      ansible.builtin.file:
+        path: "{{ lighthouse_datadir }}"
+        state: directory
+        mode: "0750"
+        owner: "{{ lighthouse_user }}"
+        group: "{{ lighthouse_user }}"
 
-- name: Set permissions
-  ansible.builtin.command: "chown -R {{ lighthouse_user }}:{{ lighthouse_user }} {{ lighthouse_datadir }}" # noqa no-free-form
-  changed_when: false
+    - name: Set permissions
+      ansible.builtin.command: "chown -R {{ lighthouse_user }}:{{ lighthouse_user }} {{ lighthouse_datadir }}" # noqa no-free-form
+      changed_when: false
 
-- name: Run lighthouse container
-  community.docker.docker_container:
-    name: "{{ lighthouse_container_name }}"
-    image: "{{ lighthouse_container_image }}"
-    image_name_mismatch: recreate
-    state: started
-    restart_policy: always
-    stop_timeout: "{{ lighthouse_container_stop_timeout }}"
-    ports: "{{ lighthouse_container_ports }}"
-    volumes: "{{ lighthouse_container_volumes }}"
-    env: "{{ lighthouse_container_env }}"
-    networks: "{{ lighthouse_container_networks }}"
-    entrypoint: "{{ lighthouse_container_entrypoint | default(omit) }}"
-    command: >-
-      {{
-        lighthouse_container_command +
-        lighthouse_container_command_extra_args +
-        (lighthouse_checkpoint_sync_enabled | ternary(lighthouse_container_command_checkpoint_args, [])) +
-        (lighthouse_mev_boost_enabled | ternary(lighthouse_mev_boost_beacon_command, []))
-      }}
-    user: "{{ lighthouse_user_meta.uid }}"
-    pull: "{{ lighthouse_container_pull | bool }}"
-    security_opts: "{{ lighthouse_container_security_opts }}"
+    - name: Run lighthouse container
+      community.docker.docker_container:
+        name: "{{ lighthouse_container_name }}"
+        image: "{{ lighthouse_container_image }}"
+        image_name_mismatch: recreate
+        state: started
+        restart_policy: always
+        stop_timeout: "{{ lighthouse_container_stop_timeout }}"
+        ports: "{{ lighthouse_container_ports }}"
+        volumes: "{{ lighthouse_container_volumes }}"
+        env: "{{ lighthouse_container_env }}"
+        networks: "{{ lighthouse_container_networks }}"
+        entrypoint: "{{ lighthouse_container_entrypoint | default(omit) }}"
+        command: >-
+          {{
+            lighthouse_container_command +
+            lighthouse_container_command_extra_args +
+            (lighthouse_checkpoint_sync_enabled | ternary(lighthouse_container_command_checkpoint_args, [])) +
+            (lighthouse_mev_boost_enabled | ternary(lighthouse_mev_boost_beacon_command, []))
+          }}
+        user: "{{ lighthouse_user_meta.uid }}"
+        pull: "{{ lighthouse_container_pull | bool }}"
+        security_opts: "{{ lighthouse_container_security_opts }}"
 
-- name: Create validator data dir
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: directory
-    mode: "0750"
-    owner: "{{ lighthouse_user }}"
-    group: "{{ lighthouse_user }}"
-  loop:
-    - "{{ lighthouse_validator_datadir }}"
-    - "{{ lighthouse_validator_datadir }}/keys"
-    - "{{ lighthouse_validator_datadir }}/secrets"
+
+- name: Configure lighthouse validator client
   when: lighthouse_validator_enabled
+  block:
+    - name: Create validator data dir
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: "0750"
+        owner: "{{ lighthouse_user }}"
+        group: "{{ lighthouse_user }}"
+      loop:
+        - "{{ lighthouse_validator_datadir }}"
+        - "{{ lighthouse_validator_datadir }}/keys"
+        - "{{ lighthouse_validator_datadir }}/secrets"
 
-- name: Set permissions for validator data dir
-  ansible.builtin.command: "chown -R {{ lighthouse_user }}:{{ lighthouse_user }} {{ lighthouse_validator_datadir }}" # noqa no-free-form
-  changed_when: false
-  when: lighthouse_validator_enabled
+    - name: Set permissions for validator data dir
+      ansible.builtin.command: "chown -R {{ lighthouse_user }}:{{ lighthouse_user }} {{ lighthouse_validator_datadir }}" # noqa no-free-form
+      changed_when: false
 
-- name: Run lighthouse validator container
-  community.docker.docker_container:
-    name: "{{ lighthouse_validator_container_name }}"
-    image: "{{ lighthouse_validator_container_image }}"
-    image_name_mismatch: recreate
-    state: started
-    restart_policy: always
-    stop_timeout: "{{ lighthouse_validator_container_stop_timeout }}"
-    ports: "{{ lighthouse_validator_container_ports }}"
-    volumes: "{{ lighthouse_validator_container_volumes }}"
-    env: "{{ lighthouse_validator_container_env }}"
-    networks: "{{ lighthouse_validator_container_networks }}"
-    entrypoint: "{{ lighthouse_validator_container_entrypoint | default(omit) }}"
-    command: >-
-      {{
-        lighthouse_validator_container_command +
-        lighthouse_validator_container_command_extra_args +
-        (lighthouse_mev_boost_enabled | ternary(lighthouse_mev_boost_validator_command, []))
-      }}
-    user: "{{ lighthouse_user_meta.uid }}"
-    pull: "{{ lighthouse_container_pull | bool }}"
-    security_opts: "{{ lighthouse_validator_container_security_opts }}"
-  when: lighthouse_validator_enabled
+    - name: Run lighthouse validator container
+      community.docker.docker_container:
+        name: "{{ lighthouse_validator_container_name }}"
+        image: "{{ lighthouse_validator_container_image }}"
+        image_name_mismatch: recreate
+        state: started
+        restart_policy: always
+        stop_timeout: "{{ lighthouse_validator_container_stop_timeout }}"
+        ports: "{{ lighthouse_validator_container_ports }}"
+        volumes: "{{ lighthouse_validator_container_volumes }}"
+        env: "{{ lighthouse_validator_container_env }}"
+        networks: "{{ lighthouse_validator_container_networks }}"
+        entrypoint: "{{ lighthouse_validator_container_entrypoint | default(omit) }}"
+        command: >-
+          {{
+            lighthouse_validator_container_command +
+            lighthouse_validator_container_command_extra_args +
+            (lighthouse_mev_boost_enabled | ternary(lighthouse_mev_boost_validator_command, []))
+          }}
+        user: "{{ lighthouse_user_meta.uid }}"
+        pull: "{{ lighthouse_container_pull | bool }}"
+        security_opts: "{{ lighthouse_validator_container_security_opts }}"

--- a/roles/lodestar/defaults/main.yaml
+++ b/roles/lodestar/defaults/main.yaml
@@ -1,3 +1,4 @@
+lodestar_enabled: true
 lodestar_user: lodestar
 lodestar_datadir: /data/lodestar
 lodestar_auth_jwt_path: /data/execution-auth.secret

--- a/roles/lodestar/meta/main.yaml
+++ b/roles/lodestar/meta/main.yaml
@@ -1,3 +1,4 @@
+allow_duplicates: true
 dependencies:
   - role: ethpandaops.general.ethereum_auth_jwt
     vars:

--- a/roles/lodestar/tasks/cleanup.yaml
+++ b/roles/lodestar/tasks/cleanup.yaml
@@ -2,7 +2,7 @@
   community.docker.docker_container:
     name: "{{ lodestar_container_name }}"
     state: absent
-  when: lodestar_cleanup
+  when: lodestar_cleanup or (not lodestar_enabled)
 
 - name: Remove lodestar validator container
   community.docker.docker_container:

--- a/roles/lodestar/tasks/setup.yaml
+++ b/roles/lodestar/tasks/setup.yaml
@@ -3,80 +3,84 @@
     name: "{{ lodestar_user }}"
   register: lodestar_user_meta
 
-- name: Create data dir
-  ansible.builtin.file:
-    path: "{{ lodestar_datadir }}"
-    state: directory
-    mode: "0750"
-    owner: "{{ lodestar_user }}"
-    group: "{{ lodestar_user }}"
+- name: Configure lodestar beacon client
+  when: lodestar_enabled
+  block:
+    - name: Create data dir
+      ansible.builtin.file:
+        path: "{{ lodestar_datadir }}"
+        state: directory
+        mode: "0750"
+        owner: "{{ lodestar_user }}"
+        group: "{{ lodestar_user }}"
 
-- name: Set permissions
-  ansible.builtin.command: "chown -R {{ lodestar_user }}:{{ lodestar_user }} {{ lodestar_datadir }}" # noqa no-free-form
-  changed_when: false
+    - name: Set permissions
+      ansible.builtin.command: "chown -R {{ lodestar_user }}:{{ lodestar_user }} {{ lodestar_datadir }}" # noqa no-free-form
+      changed_when: false
 
-- name: Run lodestar container
-  community.docker.docker_container:
-    name: "{{ lodestar_container_name }}"
-    image: "{{ lodestar_container_image }}"
-    image_name_mismatch: recreate
-    state: started
-    restart_policy: always
-    stop_timeout: "{{ lodestar_container_stop_timeout }}"
-    ports: "{{ lodestar_container_ports }}"
-    volumes: "{{ lodestar_container_volumes }}"
-    env: "{{ lodestar_container_env }}"
-    networks: "{{ lodestar_container_networks }}"
-    entrypoint: "{{ lodestar_container_entrypoint | default(omit) }}"
-    command: >-
-      {{
-        lodestar_container_command +
-        lodestar_container_command_extra_args +
-        (lodestar_checkpoint_sync_enabled | ternary(lodestar_container_command_checkpoint_args, [])) +
-        (lodestar_mev_boost_enabled | ternary(lodestar_mev_boost_beacon_command, []))
-      }}
-    user: "{{ lodestar_user_meta.uid }}"
-    pull: "{{ lodestar_container_pull | bool }}"
-    security_opts: "{{ lodestar_container_security_opts }}"
+    - name: Run lodestar container
+      community.docker.docker_container:
+        name: "{{ lodestar_container_name }}"
+        image: "{{ lodestar_container_image }}"
+        image_name_mismatch: recreate
+        state: started
+        restart_policy: always
+        stop_timeout: "{{ lodestar_container_stop_timeout }}"
+        ports: "{{ lodestar_container_ports }}"
+        volumes: "{{ lodestar_container_volumes }}"
+        env: "{{ lodestar_container_env }}"
+        networks: "{{ lodestar_container_networks }}"
+        entrypoint: "{{ lodestar_container_entrypoint | default(omit) }}"
+        command: >-
+          {{
+            lodestar_container_command +
+            lodestar_container_command_extra_args +
+            (lodestar_checkpoint_sync_enabled | ternary(lodestar_container_command_checkpoint_args, [])) +
+            (lodestar_mev_boost_enabled | ternary(lodestar_mev_boost_beacon_command, []))
+          }}
+        user: "{{ lodestar_user_meta.uid }}"
+        pull: "{{ lodestar_container_pull | bool }}"
+        security_opts: "{{ lodestar_container_security_opts }}"
 
-- name: Create validator data dir
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: directory
-    mode: "0750"
-    owner: "{{ lodestar_user }}"
-    group: "{{ lodestar_user }}"
-  loop:
-    - "{{ lodestar_validator_datadir }}"
-    - "{{ lodestar_validator_datadir }}/keys"
-    - "{{ lodestar_validator_datadir }}/secrets"
+
+- name: Configure lodestar validator client
   when: lodestar_validator_enabled
+  block:
+    - name: Create validator data dir
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: "0750"
+        owner: "{{ lodestar_user }}"
+        group: "{{ lodestar_user }}"
+      loop:
+        - "{{ lodestar_validator_datadir }}"
+        - "{{ lodestar_validator_datadir }}/keys"
+        - "{{ lodestar_validator_datadir }}/secrets"
 
-- name: Set permissions for validator data dir
-  ansible.builtin.command: "chown -R {{ lodestar_user }}:{{ lodestar_user }} {{ lodestar_validator_datadir }}" # noqa no-free-form
-  changed_when: false
-  when: lodestar_validator_enabled
+    - name: Set permissions for validator data dir
+      ansible.builtin.command: "chown -R {{ lodestar_user }}:{{ lodestar_user }} {{ lodestar_validator_datadir }}" # noqa no-free-form
+      changed_when: false
 
-- name: Run lodestar validator container
-  community.docker.docker_container:
-    name: "{{ lodestar_validator_container_name }}"
-    image: "{{ lodestar_validator_container_image }}"
-    image_name_mismatch: recreate
-    state: started
-    restart_policy: always
-    stop_timeout: "{{ lodestar_validator_container_stop_timeout }}"
-    ports: "{{ lodestar_validator_container_ports }}"
-    volumes: "{{ lodestar_validator_container_volumes }}"
-    env: "{{ lodestar_validator_container_env }}"
-    networks: "{{ lodestar_validator_container_networks }}"
-    entrypoint: "{{ lodestar_validator_container_entrypoint | default(omit) }}"
-    command: >-
-      {{
-        lodestar_validator_container_command +
-        lodestar_validator_container_command_extra_args +
-        (lodestar_mev_boost_enabled | ternary(lodestar_mev_boost_validator_command, []))
-      }}
-    user: "{{ lodestar_user_meta.uid }}"
-    pull: "{{ lodestar_container_pull | bool }}"
-    security_opts: "{{ lodestar_validator_container_security_opts }}"
-  when: lodestar_validator_enabled
+    - name: Run lodestar validator container
+      community.docker.docker_container:
+        name: "{{ lodestar_validator_container_name }}"
+        image: "{{ lodestar_validator_container_image }}"
+        image_name_mismatch: recreate
+        state: started
+        restart_policy: always
+        stop_timeout: "{{ lodestar_validator_container_stop_timeout }}"
+        ports: "{{ lodestar_validator_container_ports }}"
+        volumes: "{{ lodestar_validator_container_volumes }}"
+        env: "{{ lodestar_validator_container_env }}"
+        networks: "{{ lodestar_validator_container_networks }}"
+        entrypoint: "{{ lodestar_validator_container_entrypoint | default(omit) }}"
+        command: >-
+          {{
+            lodestar_validator_container_command +
+            lodestar_validator_container_command_extra_args +
+            (lodestar_mev_boost_enabled | ternary(lodestar_mev_boost_validator_command, []))
+          }}
+        user: "{{ lodestar_user_meta.uid }}"
+        pull: "{{ lodestar_container_pull | bool }}"
+        security_opts: "{{ lodestar_validator_container_security_opts }}"

--- a/roles/nimbus/defaults/main.yaml
+++ b/roles/nimbus/defaults/main.yaml
@@ -1,7 +1,9 @@
+nimbus_enabled: true
 nimbus_user: nimbus
 nimbus_datadir: /data/nimbus
 nimbus_auth_jwt_path: /data/execution-auth.secret
 nimbus_execution_engine_endpoint: http://geth:8551
+nimbus_beacon_endpoint: "http://{{ nimbus_container_name }}:{{ nimbus_ports_http_beacon }}"
 nimbus_announced_ip: "{{ ansible_host }}"
 nimbus_announced_ipv6: "{{ ansible_default_ipv6.address if nimbus_ipv6_enabled and ansible_default_ipv6.address is defined else '' }}"
 nimbus_mev_boost_endpoint: "http://mev-boost:18550"
@@ -76,6 +78,8 @@ nimbus_container_command_default:
   - --rest-allow-origin=*
   - --web3-url={{ nimbus_execution_engine_endpoint }}
   - --jwt-secret=/execution-auth.jwt
+
+nimbus_container_command_metrics:
   - --metrics
   - --metrics-port={{ nimbus_ports_metrics }}
   - --metrics-address=0.0.0.0
@@ -84,7 +88,11 @@ nimbus_container_command_v6: []
   # - --nat=extip:{{ nimbus_announced_ipv6 }} # not supported yet
 
 nimbus_container_command: >-
-  {{ nimbus_container_command_default + (nimbus_container_command_v6 if nimbus_ipv6_enabled and ansible_default_ipv6.address is defined else []) }}
+  {{
+    nimbus_container_command_default +
+    nimbus_container_command_metrics +
+    (nimbus_container_command_v6 if nimbus_ipv6_enabled and ansible_default_ipv6.address is defined else [])
+  }}
 
 nimbus_container_command_extra_args: []
   # - --graffiti=hello-world
@@ -94,12 +102,23 @@ nimbus_container_command_extra_args: []
 ## Validator specific configuration
 ##
 ################################################################################
-nimbus_container_validator_args:
+nimbus_validator_container_image: statusim/nimbus-validator-client:amd64-latest
+nimbus_validator_container_name: "{{ nimbus_container_name }}-validator"
+nimbus_validator_container_args:
   - --validators-dir=/validator-data/keys
   - --secrets-dir=/validator-data/secrets
   - --suggested-fee-recipient={{ nimbus_validator_fee_recipient }}
-nimbus_container_validator_volumes:
+nimbus_validator_container_volumes:
   - "{{ nimbus_validator_datadir }}:/validator-data"
+nimbus_validator_container_command: >-
+  {{
+    [
+      "--beacon-node=" + nimbus_beacon_endpoint
+    ] +
+    nimbus_validator_container_args +
+    nimbus_container_command_metrics +
+    nimbus_container_command_extra_args
+  }}
 
 # Default image pull policy
 nimbus_container_pull: false
@@ -113,5 +132,3 @@ nimbus_mev_boost_enabled: false
 nimbus_mev_boost_beacon_command:
   - --payload-builder=true
   - --payload-builder-url={{ nimbus_mev_boost_endpoint }}
-
-nimbus_mev_boost_validator_command: []

--- a/roles/nimbus/defaults/main.yaml
+++ b/roles/nimbus/defaults/main.yaml
@@ -43,7 +43,7 @@ nimbus_checkpoint_autoremove_enabled: false
 ##
 ################################################################################
 nimbus_container_name: nimbus
-nimbus_container_image: statusim/nimbus-eth2:amd64-latest
+nimbus_container_image: statusim/nimbus-eth2:multiarch-latest
 nimbus_container_env: {}
 nimbus_container_ports_ipv4:
   - "127.0.0.1:{{ nimbus_ports_http_beacon }}:{{ nimbus_ports_http_beacon }}"
@@ -102,7 +102,7 @@ nimbus_container_command_extra_args: []
 ## Validator specific configuration
 ##
 ################################################################################
-nimbus_validator_container_image: statusim/nimbus-validator-client:amd64-latest
+nimbus_validator_container_image: statusim/nimbus-validator-client:multiarch-latest
 nimbus_validator_container_name: "{{ nimbus_container_name }}-validator"
 nimbus_validator_container_args:
   - --validators-dir=/validator-data/keys

--- a/roles/nimbus/tasks/cleanup.yaml
+++ b/roles/nimbus/tasks/cleanup.yaml
@@ -2,4 +2,10 @@
   community.docker.docker_container:
     name: "{{ nimbus_container_name }}"
     state: absent
-  when: nimbus_cleanup
+  when: nimbus_cleanup or (not nimbus_enabled)
+
+- name: Remove nimbus validator container
+  community.docker.docker_container:
+    name: "{{ nimbus_validator_container_name }}"
+    state: absent
+  when: nimbus_cleanup or nimbus_enabled

--- a/roles/nimbus/tasks/main.yaml
+++ b/roles/nimbus/tasks/main.yaml
@@ -1,7 +1,6 @@
+- name: Cleanup nimbus
+  ansible.builtin.import_tasks: cleanup.yaml
+
 - name: Setup nimbus
   ansible.builtin.import_tasks: setup.yaml
   when: not nimbus_cleanup
-
-- name: Cleanup nimbus
-  ansible.builtin.import_tasks: cleanup.yaml
-  when: nimbus_cleanup

--- a/roles/nimbus/tasks/setup.yaml
+++ b/roles/nimbus/tasks/setup.yaml
@@ -34,7 +34,7 @@
   when: nimbus_validator_enabled
 
 - name: Checkpoint sync nimbus node
-  when: nimbus_checkpoint_sync_enabled
+  when: nimbus_enabled and nimbus_checkpoint_sync_enabled
   community.docker.docker_container:
     name: "{{ nimbus_checkpoint_container_name }}"
     image: "{{ nimbus_container_image }}"
@@ -52,6 +52,7 @@
     security_opts: "{{ nimbus_container_security_opts }}"
 
 - name: Run nimbus container
+  when: nimbus_enabled
   community.docker.docker_container:
     name: "{{ nimbus_container_name }}"
     image: "{{ nimbus_container_image }}"
@@ -63,7 +64,7 @@
     volumes: >-
       {{
         nimbus_validator_enabled | ternary(
-          nimbus_container_volumes + nimbus_container_validator_volumes,
+          nimbus_container_volumes + nimbus_validator_container_volumes,
           nimbus_container_volumes
         )
       }}
@@ -73,11 +74,30 @@
     command: >-
       {{
         nimbus_validator_enabled | ternary(
-          nimbus_container_command + nimbus_container_validator_args + nimbus_container_command_extra_args +
+          nimbus_container_command + nimbus_validator_container_args + nimbus_container_command_extra_args +
           (nimbus_mev_boost_enabled | ternary(nimbus_mev_boost_beacon_command, [])),
           nimbus_container_command + nimbus_container_command_extra_args,
         )
       }}
+    user: "{{ nimbus_user_meta.uid }}"
+    pull: "{{ nimbus_container_pull | bool }}"
+    security_opts: "{{ nimbus_container_security_opts }}"
+
+- name: Run nimbus validator container
+  when: nimbus_validator_enabled and (not nimbus_enabled)
+  community.docker.docker_container:
+    name: "{{ nimbus_validator_container_name }}"
+    image: "{{ nimbus_validator_container_image }}"
+    image_name_mismatch: recreate
+    state: started
+    restart_policy: always
+    stop_timeout: "{{ nimbus_container_stop_timeout }}"
+    ports: []
+    volumes: "{{ nimbus_validator_container_volumes }}"
+    env: "{{ nimbus_container_env }}"
+    networks: "{{ nimbus_container_networks }}"
+    entrypoint: "{{ nimbus_container_entrypoint | default(omit) }}"
+    command: "{{ nimbus_validator_container_command }}"
     user: "{{ nimbus_user_meta.uid }}"
     pull: "{{ nimbus_container_pull | bool }}"
     security_opts: "{{ nimbus_container_security_opts }}"

--- a/roles/prysm/defaults/main.yaml
+++ b/roles/prysm/defaults/main.yaml
@@ -1,3 +1,4 @@
+prysm_enabled: true
 prysm_user: prysm
 prysm_datadir: /data/prysm
 prysm_auth_jwt_path: /data/execution-auth.secret

--- a/roles/prysm/meta/main.yaml
+++ b/roles/prysm/meta/main.yaml
@@ -1,3 +1,4 @@
+allow_duplicates: true
 dependencies:
   - role: ethpandaops.general.ethereum_auth_jwt
     vars:

--- a/roles/prysm/tasks/cleanup.yaml
+++ b/roles/prysm/tasks/cleanup.yaml
@@ -2,7 +2,7 @@
   community.docker.docker_container:
     name: "{{ prysm_container_name }}"
     state: absent
-  when: prysm_cleanup
+  when: prysm_cleanup or (not prysm_enabled)
 
 - name: Remove prysm validator container
   community.docker.docker_container:

--- a/roles/prysm/tasks/setup.yaml
+++ b/roles/prysm/tasks/setup.yaml
@@ -3,76 +3,80 @@
     name: "{{ prysm_user }}"
   register: prysm_user_meta
 
-- name: Create data dir
-  ansible.builtin.file:
-    path: "{{ prysm_datadir }}"
-    state: directory
-    mode: "0750"
-    owner: "{{ prysm_user }}"
-    group: "{{ prysm_user }}"
+- name: Configure prysm beacon client
+  when: prysm_enabled
+  block:
+    - name: Create data dir
+      ansible.builtin.file:
+        path: "{{ prysm_datadir }}"
+        state: directory
+        mode: "0750"
+        owner: "{{ prysm_user }}"
+        group: "{{ prysm_user }}"
 
-- name: Set permissions
-  ansible.builtin.command: "chown -R {{ prysm_user }}:{{ prysm_user }} {{ prysm_datadir }}" # noqa no-free-form
-  changed_when: false
+    - name: Set permissions
+      ansible.builtin.command: "chown -R {{ prysm_user }}:{{ prysm_user }} {{ prysm_datadir }}" # noqa no-free-form
+      changed_when: false
 
-- name: Run prysm container
-  community.docker.docker_container:
-    name: "{{ prysm_container_name }}"
-    image: "{{ prysm_container_image }}"
-    image_name_mismatch: recreate
-    state: started
-    restart_policy: always
-    stop_timeout: "{{ prysm_container_stop_timeout }}"
-    ports: "{{ prysm_container_ports }}"
-    volumes: "{{ prysm_container_volumes }}"
-    env: "{{ prysm_container_env }}"
-    networks: "{{ prysm_container_networks }}"
-    entrypoint: "{{ prysm_container_entrypoint }}"
-    command: >-
-      {{
-        prysm_container_command +
-        prysm_container_command_extra_args +
-        (prysm_checkpoint_sync_enabled | ternary(prysm_container_command_checkpoint_args, [])) +
-        (prysm_mev_boost_enabled | ternary(prysm_mev_boost_beacon_command, []))
-      }}
-    user: "{{ prysm_user_meta.uid }}"
-    pull: "{{ prysm_container_pull | bool }}"
-    security_opts: "{{ prysm_container_security_opts }}"
+    - name: Run prysm container
+      community.docker.docker_container:
+        name: "{{ prysm_container_name }}"
+        image: "{{ prysm_container_image }}"
+        image_name_mismatch: recreate
+        state: started
+        restart_policy: always
+        stop_timeout: "{{ prysm_container_stop_timeout }}"
+        ports: "{{ prysm_container_ports }}"
+        volumes: "{{ prysm_container_volumes }}"
+        env: "{{ prysm_container_env }}"
+        networks: "{{ prysm_container_networks }}"
+        entrypoint: "{{ prysm_container_entrypoint }}"
+        command: >-
+          {{
+            prysm_container_command +
+            prysm_container_command_extra_args +
+            (prysm_checkpoint_sync_enabled | ternary(prysm_container_command_checkpoint_args, [])) +
+            (prysm_mev_boost_enabled | ternary(prysm_mev_boost_beacon_command, []))
+          }}
+        user: "{{ prysm_user_meta.uid }}"
+        pull: "{{ prysm_container_pull | bool }}"
+        security_opts: "{{ prysm_container_security_opts }}"
 
-- name: Create validator data dir
-  ansible.builtin.file:
-    path: "{{ prysm_validator_datadir }}"
-    state: directory
-    mode: "0750"
-    owner: "{{ prysm_user }}"
-    group: "{{ prysm_user }}"
+
+- name: Configure prysm beacon client
   when: prysm_validator_enabled
+  block:
+    - name: Create validator data dir
+      ansible.builtin.file:
+        path: "{{ prysm_validator_datadir }}"
+        state: directory
+        mode: "0750"
+        owner: "{{ prysm_user }}"
+        group: "{{ prysm_user }}"
 
-- name: Set permissions for validator data dir
-  ansible.builtin.command: "chown -R {{ prysm_user }}:{{ prysm_user }} {{ prysm_validator_datadir }}" # noqa no-free-form
-  changed_when: false
-  when: prysm_validator_enabled
+    - name: Set permissions for validator data dir
+      ansible.builtin.command: "chown -R {{ prysm_user }}:{{ prysm_user }} {{ prysm_validator_datadir }}" # noqa no-free-form
+      changed_when: false
 
-- name: Run prysm validator container
-  community.docker.docker_container:
-    name: "{{ prysm_validator_container_name }}"
-    image: "{{ prysm_validator_container_image }}"
-    image_name_mismatch: recreate
-    state: started
-    restart_policy: always
-    stop_timeout: "{{ prysm_validator_container_stop_timeout }}"
-    ports: "{{ prysm_validator_container_ports }}"
-    volumes: "{{ prysm_validator_container_volumes }}"
-    env: "{{ prysm_validator_container_env }}"
-    networks: "{{ prysm_validator_container_networks }}"
-    entrypoint: "{{ prysm_validator_container_entrypoint }}"
-    command: >-
-      {{
-        prysm_validator_container_command +
-        prysm_validator_container_command_extra_args +
-        (prysm_mev_boost_enabled | ternary(prysm_mev_boost_validator_command, []))
-      }}
-    user: "{{ prysm_user_meta.uid }}"
-    pull: "{{ prysm_container_pull | bool }}"
-    security_opts: "{{ prysm_validator_container_security_opts }}"
-  when: prysm_validator_enabled
+    - name: Run prysm validator container
+      community.docker.docker_container:
+        name: "{{ prysm_validator_container_name }}"
+        image: "{{ prysm_validator_container_image }}"
+        image_name_mismatch: recreate
+        state: started
+        restart_policy: always
+        stop_timeout: "{{ prysm_validator_container_stop_timeout }}"
+        ports: "{{ prysm_validator_container_ports }}"
+        volumes: "{{ prysm_validator_container_volumes }}"
+        env: "{{ prysm_validator_container_env }}"
+        networks: "{{ prysm_validator_container_networks }}"
+        entrypoint: "{{ prysm_validator_container_entrypoint }}"
+        command: >-
+          {{
+            prysm_validator_container_command +
+            prysm_validator_container_command_extra_args +
+            (prysm_mev_boost_enabled | ternary(prysm_mev_boost_validator_command, []))
+          }}
+        user: "{{ prysm_user_meta.uid }}"
+        pull: "{{ prysm_container_pull | bool }}"
+        security_opts: "{{ prysm_validator_container_security_opts }}"

--- a/roles/teku/defaults/main.yaml
+++ b/roles/teku/defaults/main.yaml
@@ -95,6 +95,7 @@ teku_container_command_checkpoint_args:
 ##
 ################################################################################
 teku_validator_container_image: "{{ teku_container_image }}"
+teku_validator_container_name: "{{ teku_container_name }}-validator"
 teku_validator_container_args:
   - --validator-keys=/validator-data/keys:/validator-data/secrets
   - --validators-proposer-default-fee-recipient={{ teku_validator_fee_recipient }}

--- a/roles/teku/defaults/main.yaml
+++ b/roles/teku/defaults/main.yaml
@@ -3,6 +3,7 @@ teku_user: teku
 teku_datadir: /data/teku
 teku_auth_jwt_path: /data/execution-auth.secret
 teku_execution_engine_endpoint: http://geth:8551
+teku_beacon_endpoint: "http://{{ teku_container_name }}:{{ teku_ports_http_beacon }}"
 teku_announced_ip: "{{ ansible_host }}"
 teku_announced_ipv6: "{{ ansible_default_ipv6.address if teku_ipv6_enabled and ansible_default_ipv6.address is defined else '' }}"
 teku_mev_boost_endpoint: "http://mev-boost:18550"
@@ -99,6 +100,13 @@ teku_container_validator_args:
   - --validators-keystore-locking-enabled=false
 teku_container_validator_volumes:
   - "{{ teku_validator_datadir }}:/validator-data"
+teku_container_validator_command: >-
+  {{
+    ["validator-client", "--beacon-node-api-endpoint=" + teku_beacon_endpoint ] +
+    teku_container_validator_args +
+    teku_container_command_metrics +
+    teku_container_command_extra_args
+  }}
 
 # Default image pull policy
 teku_container_pull: false

--- a/roles/teku/defaults/main.yaml
+++ b/roles/teku/defaults/main.yaml
@@ -73,9 +73,9 @@ teku_container_command_v6: []
 
 teku_container_command: >-
   {{
-  teku_container_command_default +
-  teku_container_command_metrics +
-  (teku_container_command_v6 if teku_ipv6_enabled and ansible_default_ipv6.address is defined else [])
+    teku_container_command_default +
+    teku_container_command_metrics +
+    (teku_container_command_v6 if teku_ipv6_enabled and ansible_default_ipv6.address is defined else [])
   }}
 
 teku_container_command_extra_args:
@@ -102,7 +102,11 @@ teku_container_validator_volumes:
   - "{{ teku_validator_datadir }}:/validator-data"
 teku_container_validator_command: >-
   {{
-    ["validator-client", "--beacon-node-api-endpoint=" + teku_beacon_endpoint ] +
+    [
+      "validator-client",
+      "--beacon-node-api-endpoint=" + teku_beacon_endpoint,
+      "--data-path=/validator-data"
+    ] +
     teku_container_validator_args +
     teku_container_command_metrics +
     teku_container_command_extra_args

--- a/roles/teku/defaults/main.yaml
+++ b/roles/teku/defaults/main.yaml
@@ -94,20 +94,21 @@ teku_container_command_checkpoint_args:
 ## Validator specific configuration
 ##
 ################################################################################
-teku_container_validator_args:
+
+teku_validator_container_args:
   - --validator-keys=/validator-data/keys:/validator-data/secrets
   - --validators-proposer-default-fee-recipient={{ teku_validator_fee_recipient }}
   - --validators-keystore-locking-enabled=false
-teku_container_validator_volumes:
+teku_validator_container_volumes:
   - "{{ teku_validator_datadir }}:/validator-data"
-teku_container_validator_command: >-
+teku_validator_container_command: >-
   {{
     [
       "validator-client",
       "--beacon-node-api-endpoint=" + teku_beacon_endpoint,
       "--data-path=/validator-data"
     ] +
-    teku_container_validator_args +
+    teku_validator_container_args +
     teku_container_command_metrics +
     teku_container_command_extra_args
   }}

--- a/roles/teku/defaults/main.yaml
+++ b/roles/teku/defaults/main.yaml
@@ -1,3 +1,4 @@
+teku_enabled: true
 teku_user: teku
 teku_datadir: /data/teku
 teku_auth_jwt_path: /data/execution-auth.secret
@@ -59,6 +60,8 @@ teku_container_command_default:
   - --rest-api-host-allowlist=*
   - --ee-endpoint={{ teku_execution_engine_endpoint }}
   - --ee-jwt-secret-file=/execution-auth.jwt
+
+teku_container_command_metrics:
   - --metrics-enabled=true
   - --metrics-interface=0.0.0.0
   - --metrics-port={{ teku_ports_metrics }}
@@ -68,7 +71,11 @@ teku_container_command_v6: []
 # - --p2p-advertised-ipv6={{ teku_announced_ipv6 }} # not supported yet
 
 teku_container_command: >-
-  {{ teku_container_command_default + (teku_container_command_v6 if teku_ipv6_enabled and ansible_default_ipv6.address is defined else []) }}
+  {{
+  teku_container_command_default +
+  teku_container_command_metrics +
+  (teku_container_command_v6 if teku_ipv6_enabled and ansible_default_ipv6.address is defined else [])
+  }}
 
 teku_container_command_extra_args:
   - --data-storage-mode=PRUNE

--- a/roles/teku/defaults/main.yaml
+++ b/roles/teku/defaults/main.yaml
@@ -94,7 +94,7 @@ teku_container_command_checkpoint_args:
 ## Validator specific configuration
 ##
 ################################################################################
-
+teku_validator_container_image: "{{ teku_container_image }}"
 teku_validator_container_args:
   - --validator-keys=/validator-data/keys:/validator-data/secrets
   - --validators-proposer-default-fee-recipient={{ teku_validator_fee_recipient }}

--- a/roles/teku/tasks/cleanup.yaml
+++ b/roles/teku/tasks/cleanup.yaml
@@ -8,4 +8,4 @@
   community.docker.docker_container:
     name: "{{ teku_container_name }}-validator"
     state: absent
-  when: teku_cleanup or (not teku_validator_enabled)
+  when: teku_cleanup or teku_enabled

--- a/roles/teku/tasks/cleanup.yaml
+++ b/roles/teku/tasks/cleanup.yaml
@@ -6,6 +6,6 @@
 
 - name: Remove teku validator container
   community.docker.docker_container:
-    name: "{{ teku_container_name }}-validator"
+    name: "{{ teku_validator_container_name }}"
     state: absent
   when: teku_cleanup or teku_enabled

--- a/roles/teku/tasks/cleanup.yaml
+++ b/roles/teku/tasks/cleanup.yaml
@@ -2,4 +2,10 @@
   community.docker.docker_container:
     name: "{{ teku_container_name }}"
     state: absent
-  when: teku_cleanup
+  when: teku_cleanup or (not teku_enabled)
+
+- name: Remove teku validator container
+  community.docker.docker_container:
+    name: "{{ teku_container_name }}-validator"
+    state: absent
+  when: teku_cleanup or (not teku_validator_enabled)

--- a/roles/teku/tasks/main.yaml
+++ b/roles/teku/tasks/main.yaml
@@ -1,10 +1,9 @@
 - name: Validate inputs
   ansible.builtin.import_tasks: validations.yaml
 
+- name: Cleanup teku
+  ansible.builtin.import_tasks: cleanup.yaml
+
 - name: Setup teku
   ansible.builtin.import_tasks: setup.yaml
   when: not teku_cleanup
-
-- name: Cleanup teku
-  ansible.builtin.import_tasks: cleanup.yaml
-  when: teku_cleanup

--- a/roles/teku/tasks/setup.yaml
+++ b/roles/teku/tasks/setup.yaml
@@ -34,6 +34,7 @@
   when: teku_validator_enabled
 
 - name: Run teku container
+  when: teku_enabled
   community.docker.docker_container:
     name: "{{ teku_container_name }}"
     image: "{{ teku_container_image }}"
@@ -56,6 +57,30 @@
           teku_container_command_extra_args + teku_container_command_checkpoint_args,
           teku_container_command_extra_args
         ))
+      }}
+    user: "{{ teku_user_meta.uid }}"
+    pull: "{{ teku_container_pull | bool }}"
+    security_opts: "{{ teku_container_security_opts }}"
+
+- name: Run teku validator container
+  when: teku_validator_enabled and (not teku_enabled)
+  community.docker.docker_container:
+    name: "{{ teku_container_name }}-validator"
+    image: "{{ teku_container_image }}"
+    image_name_mismatch: recreate
+    state: started
+    restart_policy: always
+    stop_timeout: "{{ teku_container_stop_timeout }}"
+    ports: []
+    volumes: "{{ teku_container_validator_volumes }}"
+    env: "{{ teku_container_env }}"
+    networks: "{{ teku_container_networks }}"
+    entrypoint: "{{ teku_container_entrypoint | default(omit) }}"
+    command: >-
+      {{
+        ["validator-client"] +
+        teku_container_validator_args +
+        teku_container_command_metrics
       }}
     user: "{{ teku_user_meta.uid }}"
     pull: "{{ teku_container_pull | bool }}"

--- a/roles/teku/tasks/setup.yaml
+++ b/roles/teku/tasks/setup.yaml
@@ -66,7 +66,7 @@
   when: teku_validator_enabled and (not teku_enabled)
   community.docker.docker_container:
     name: "{{ teku_container_name }}-validator"
-    image: "{{ teku_container_image }}"
+    image: "{{ teku_validator_container_image }}"
     image_name_mismatch: recreate
     state: started
     restart_policy: always

--- a/roles/teku/tasks/setup.yaml
+++ b/roles/teku/tasks/setup.yaml
@@ -43,14 +43,14 @@
     restart_policy: always
     stop_timeout: "{{ teku_container_stop_timeout }}"
     ports: "{{ teku_container_ports }}"
-    volumes: "{{ teku_container_volumes + (teku_validator_enabled | ternary(teku_container_validator_volumes, [])) }}"
+    volumes: "{{ teku_container_volumes + (teku_validator_enabled | ternary(teku_validator_container_volumes, [])) }}"
     env: "{{ teku_container_env }}"
     networks: "{{ teku_container_networks }}"
     entrypoint: "{{ teku_container_entrypoint | default(omit) }}"
     command: >-
       {{
         teku_container_command +
-        (teku_validator_enabled | ternary(teku_container_validator_args +
+        (teku_validator_enabled | ternary(teku_validator_container_args +
           (teku_mev_boost_enabled | ternary(teku_mev_boost_beacon_command,[])),
         [])) +
         (teku_checkpoint_sync_enabled | ternary(
@@ -72,11 +72,11 @@
     restart_policy: always
     stop_timeout: "{{ teku_container_stop_timeout }}"
     ports: []
-    volumes: "{{ teku_container_validator_volumes }}"
+    volumes: "{{ teku_validator_container_volumes }}"
     env: "{{ teku_container_env }}"
     networks: "{{ teku_container_networks }}"
     entrypoint: "{{ teku_container_entrypoint | default(omit) }}"
-    command: "{{ teku_container_validator_command }}"
+    command: "{{ teku_validator_container_command }}"
     user: "{{ teku_user_meta.uid }}"
     pull: "{{ teku_container_pull | bool }}"
     security_opts: "{{ teku_container_security_opts }}"

--- a/roles/teku/tasks/setup.yaml
+++ b/roles/teku/tasks/setup.yaml
@@ -65,7 +65,7 @@
 - name: Run teku validator container
   when: teku_validator_enabled and (not teku_enabled)
   community.docker.docker_container:
-    name: "{{ teku_container_name }}-validator"
+    name: "{{ teku_validator_container_name }}"
     image: "{{ teku_validator_container_image }}"
     image_name_mismatch: recreate
     state: started

--- a/roles/teku/tasks/setup.yaml
+++ b/roles/teku/tasks/setup.yaml
@@ -80,7 +80,8 @@
       {{
         ["validator-client"] +
         teku_container_validator_args +
-        teku_container_command_metrics
+        teku_container_command_metrics +
+        teku_container_command_extra_args
       }}
     user: "{{ teku_user_meta.uid }}"
     pull: "{{ teku_container_pull | bool }}"

--- a/roles/teku/tasks/setup.yaml
+++ b/roles/teku/tasks/setup.yaml
@@ -76,13 +76,7 @@
     env: "{{ teku_container_env }}"
     networks: "{{ teku_container_networks }}"
     entrypoint: "{{ teku_container_entrypoint | default(omit) }}"
-    command: >-
-      {{
-        ["validator-client"] +
-        teku_container_validator_args +
-        teku_container_command_metrics +
-        teku_container_command_extra_args
-      }}
+    command: "{{ teku_container_validator_command }}"
     user: "{{ teku_user_meta.uid }}"
     pull: "{{ teku_container_pull | bool }}"
     security_opts: "{{ teku_container_security_opts }}"


### PR DESCRIPTION
This feature is useful when we just want to run the validator client. 

e.g. On the lighthouse role, we can now achieve this by doing:

```yaml
lighthouse_enabled: false
lighthouse_validator_enabled: true
```

Additionally, I've updated the github workflow to run the `ethereum_node` molecule tests whenever it detects a change on a CL/EL role. It will only run tests against a role that has changed. E.g. If you change the lighthouse role, it will run the test with lighthouse + all the EL pairs. 