### PR TITLE
generate_kubernetes_config: enable additional sensitive peer infos on dora

### DIFF
--- a/roles/generate_kubernetes_config/templates/dora.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/dora.yaml.j2
@@ -30,6 +30,8 @@ dora:
   extraEnv:
    - name: FRONTEND_PPROF
      value: "true"
+   - name: FRONTEND_SHOW_SENSITIVE_PEER_INFOS
+     value: "true"
    
   postgresql:
     name: "dora-postgresql"


### PR DESCRIPTION
Feature from https://github.com/ethpandaops/dora/pull/117 