### PR TITLE
Prysm BN/VC: Add `tty: true`

### DIFF
--- a/roles/prysm/defaults/main.yaml
+++ b/roles/prysm/defaults/main.yaml
@@ -102,7 +102,7 @@ prysm_validator_container_volumes:
 prysm_validator_container_security_opts: []
 prysm_validator_container_stop_timeout: "300"
 prysm_validator_container_networks: []
-prysm_validator_container_tty: true
+prysm_validator_container_tty: false
 prysm_validator_container_entrypoint:
   - /app/cmd/validator/validator
 prysm_validator_container_command:

--- a/roles/prysm/defaults/main.yaml
+++ b/roles/prysm/defaults/main.yaml
@@ -49,6 +49,7 @@ prysm_container_volumes:
 prysm_container_security_opts: []
 prysm_container_stop_timeout: "300"
 prysm_container_networks: []
+prysm_container_tty: true
 prysm_container_entrypoint:
   - /app/cmd/beacon-chain/beacon-chain
 prysm_container_command_default:
@@ -101,6 +102,7 @@ prysm_validator_container_volumes:
 prysm_validator_container_security_opts: []
 prysm_validator_container_stop_timeout: "300"
 prysm_validator_container_networks: []
+prysm_validator_container_tty: true
 prysm_validator_container_entrypoint:
   - /app/cmd/validator/validator
 prysm_validator_container_command:

--- a/roles/prysm/defaults/main.yaml
+++ b/roles/prysm/defaults/main.yaml
@@ -49,7 +49,7 @@ prysm_container_volumes:
 prysm_container_security_opts: []
 prysm_container_stop_timeout: "300"
 prysm_container_networks: []
-prysm_container_tty: true
+prysm_container_tty: false
 prysm_container_entrypoint:
   - /app/cmd/beacon-chain/beacon-chain
 prysm_container_command_default:

--- a/roles/prysm/tasks/setup.yaml
+++ b/roles/prysm/tasks/setup.yaml
@@ -30,7 +30,7 @@
         volumes: "{{ prysm_container_volumes }}"
         env: "{{ prysm_container_env }}"
         networks: "{{ prysm_container_networks }}"
-        tty: true
+        tty: "{{ prysm_container_tty }}"
         entrypoint: "{{ prysm_container_entrypoint }}"
         command: >-
           {{
@@ -71,7 +71,7 @@
         volumes: "{{ prysm_validator_container_volumes }}"
         env: "{{ prysm_validator_container_env }}"
         networks: "{{ prysm_validator_container_networks }}"
-        tty: true
+        tty: "{{ prysm_validator_container_tty }}"
         entrypoint: "{{ prysm_validator_container_entrypoint }}"
         command: >-
           {{

--- a/roles/prysm/tasks/setup.yaml
+++ b/roles/prysm/tasks/setup.yaml
@@ -30,6 +30,7 @@
         volumes: "{{ prysm_container_volumes }}"
         env: "{{ prysm_container_env }}"
         networks: "{{ prysm_container_networks }}"
+        tty: true
         entrypoint: "{{ prysm_container_entrypoint }}"
         command: >-
           {{
@@ -70,6 +71,7 @@
         volumes: "{{ prysm_validator_container_volumes }}"
         env: "{{ prysm_validator_container_env }}"
         networks: "{{ prysm_validator_container_networks }}"
+        tty: true
         entrypoint: "{{ prysm_validator_container_entrypoint }}"
         command: >-
           {{


### PR DESCRIPTION
It will enable pretty logging for Prysm BN/VC.

Before:
![image](https://github.com/user-attachments/assets/181bc473-f9bc-477e-a77e-9ee8c0544148)

After:
![image](https://github.com/user-attachments/assets/5712a0b5-be95-44cc-9011-8f65a496cde7)
