### PR TITLE
Enable Teku's rest api docs by default

### DIFF
--- a/roles/teku/defaults/main.yaml
+++ b/roles/teku/defaults/main.yaml
@@ -60,6 +60,7 @@ teku_container_command_default:
   - --rest-api-interface=0.0.0.0
   - --rest-api-port={{ teku_ports_http_beacon }}
   - --rest-api-host-allowlist=*
+  - --rest-api-docs-enabled
   - --ee-endpoint={{ teku_execution_engine_endpoint }}
   - --ee-jwt-secret-file=/execution-auth.jwt
 


### PR DESCRIPTION
Will enable swagger ui on /swagger-ui/ url for Teku