### PR TITLE
fix SSL error on config upstreams

### DIFF
--- a/roles/generate_kubernetes_config/files/ingress.config.yaml.tpl
+++ b/roles/generate_kubernetes_config/files/ingress.config.yaml.tpl
@@ -27,6 +27,9 @@ metadata:
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     nginx.ingress.kubernetes.io/upstream-vhost: "{{ .upstream }}"
     nginx.ingress.kubernetes.io/rewrite-target: "{{ .target }}"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_ssl_name {{ .upstream }};
+      proxy_ssl_server_name on;
 spec:
   rules:
   - host: "config.{{ $.Values.domain }}"


### PR DESCRIPTION
Fix for `ingress-nginx-public-controller-678c58d9d6-8p8vj controller 2024-10-21T10:41:45.462803094+02:00 2024/10/21 08:41:45 [crit] 165#165: *18127 SSL_do_handshake() failed (SSL: error:0A000458:SSL routines::tlsv1 unrecognized name:SSL alert number 112) while SSL handshaking to upstream, client: 185.71.112.107, server: config.pectra-devnet-4.ethpandaops.io, request: "GET /api/v1/nodes/validator-ranges HTTP/1.1", upstream: "https://209.38.212.82:443/meta/api/v1/validator-ranges.json", host: "config.pectra-devnet-4.ethpandaops.io"`

`proxy_ssl_name=`
> Allows overriding the server name used to [verify](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_verify) the certificate of the proxied HTTPS server and to be [passed through SNI](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_server_name) when establishing a connection with the proxied HTTPS server.

> By default, the host part of the [proxy_pass](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass) URL is used.

`proxy_ssl_server_name=on`
> Enables or disables passing of the server name through [TLS Server Name Indication extension](http://en.wikipedia.org/wiki/Server_Name_Indication) (SNI, RFC 6066) when establishing a connection with the proxied HTTPS server.
