### PR TITLE
adding config options to eth_testnet_config

### DIFF
--- a/roles/ethereum_testnet_config/defaults/main.yaml
+++ b/roles/ethereum_testnet_config/defaults/main.yaml
@@ -4,7 +4,7 @@ eth_testnet_config_git_enabled: false # noqa var-naming[no-role-prefix]
 eth_testnet_config_git_repo: https://github.com/ethpandaops/dencun-devnets # noqa var-naming[no-role-prefix]
 eth_testnet_config_git_version: master # noqa var-naming[no-role-prefix]
 eth_testnet_temp_config_dir: /tmp/checkout # noqa var-naming[no-role-prefix]
-eth_testnet_path_in_temp_git_repo: network-configs/devnet-0/metadata # noqa var-naming[no-role-prefix]
+eth_testnet_path_in_temp_git_repo: network-configs/devnet-0/metadata/ # noqa var-naming[no-role-prefix]
 eth_testnet_config_git_update: false # noqa var-naming[no-role-prefix] - Once it's cloned, it wont update anymore, unless this var is changed
 
 eth_testnet_config_local_dir_enabled: false # noqa var-naming[no-role-prefix]

--- a/roles/ethereum_testnet_config/defaults/main.yaml
+++ b/roles/ethereum_testnet_config/defaults/main.yaml
@@ -1,10 +1,10 @@
 eth_testnet_config_dir: /data/ethereum-network-config/metadata # noqa var-naming[no-role-prefix]
 
 eth_testnet_config_git_enabled: false # noqa var-naming[no-role-prefix]
-eth_testnet_config_git_repo: https://github.com/Inphi/eip4844-testnet # noqa var-naming[no-role-prefix]
-eth_testnet_config_git_version: devnet-4 # noqa var-naming[no-role-prefix]
+eth_testnet_config_git_repo: https://github.com/ethpandaops/dencun-devnets # noqa var-naming[no-role-prefix]
+eth_testnet_config_git_version: master # noqa var-naming[no-role-prefix]
 eth_testnet_temp_config_dir: /tmp/checkout # noqa var-naming[no-role-prefix]
-eth_testnet_path_in_temp_git_repo: 4844-testnet/network-configs/devnet-0/metadata # noqa var-naming[no-role-prefix]
+eth_testnet_path_in_temp_git_repo: dencun-devnets/network-configs/devnet-0/metadata # noqa var-naming[no-role-prefix]
 eth_testnet_config_git_update: false # noqa var-naming[no-role-prefix] - Once it's cloned, it wont update anymore, unless this var is changed
 
 eth_testnet_config_local_dir_enabled: false # noqa var-naming[no-role-prefix]

--- a/roles/ethereum_testnet_config/defaults/main.yaml
+++ b/roles/ethereum_testnet_config/defaults/main.yaml
@@ -4,7 +4,7 @@ eth_testnet_config_git_enabled: false # noqa var-naming[no-role-prefix]
 eth_testnet_config_git_repo: https://github.com/ethpandaops/dencun-devnets # noqa var-naming[no-role-prefix]
 eth_testnet_config_git_version: master # noqa var-naming[no-role-prefix]
 eth_testnet_temp_config_dir: /tmp/checkout # noqa var-naming[no-role-prefix]
-eth_testnet_path_in_temp_git_repo: dencun-devnets/network-configs/devnet-0/metadata # noqa var-naming[no-role-prefix]
+eth_testnet_path_in_temp_git_repo: network-configs/devnet-0/metadata # noqa var-naming[no-role-prefix]
 eth_testnet_config_git_update: false # noqa var-naming[no-role-prefix] - Once it's cloned, it wont update anymore, unless this var is changed
 
 eth_testnet_config_local_dir_enabled: false # noqa var-naming[no-role-prefix]

--- a/roles/ethereum_testnet_config/defaults/main.yaml
+++ b/roles/ethereum_testnet_config/defaults/main.yaml
@@ -3,6 +3,8 @@ eth_testnet_config_dir: /data/ethereum-network-config/metadata # noqa var-naming
 eth_testnet_config_git_enabled: false # noqa var-naming[no-role-prefix]
 eth_testnet_config_git_repo: https://github.com/Inphi/eip4844-testnet # noqa var-naming[no-role-prefix]
 eth_testnet_config_git_version: devnet-4 # noqa var-naming[no-role-prefix]
+eth_testnet_temp_config_dir: /tmp/checkout # noqa var-naming[no-role-prefix]
+eth_testnet_path_in_temp_git_repo: 4844-testnet/network-configs/devnet-0/metadata # noqa var-naming[no-role-prefix]
 eth_testnet_config_git_update: false # noqa var-naming[no-role-prefix] - Once it's cloned, it wont update anymore, unless this var is changed
 
 eth_testnet_config_local_dir_enabled: false # noqa var-naming[no-role-prefix]

--- a/roles/ethereum_testnet_config/tasks/main.yaml
+++ b/roles/ethereum_testnet_config/tasks/main.yaml
@@ -20,6 +20,12 @@
   ansible.builtin.command: mv "{{ eth_testnet_temp_config_dir }}/{{ eth_testnet_path_in_temp_git_repo }}" "{{ eth_testnet_config_dir }}" # noqa: no-changed-when
   when: eth_testnet_config_git_enabled
 
+- name: Recursively remove directory
+  ansible.builtin.file:
+    path: /tmp/checkout
+    state: absent
+  when: eth_testnet_config_git_enabled
+
 # Option B: Allow copying over local dir
 - name: Create dest dir
   ansible.builtin.file:

--- a/roles/ethereum_testnet_config/tasks/main.yaml
+++ b/roles/ethereum_testnet_config/tasks/main.yaml
@@ -13,11 +13,14 @@
     repo: "{{ eth_testnet_config_git_repo }}"
     dest: "{{ eth_testnet_temp_config_dir }}"
     version: "{{ eth_testnet_config_git_version }}"
-    update: yes
+    update: true
   when: eth_testnet_config_git_enabled
 
-- name: Move files to destination
-  ansible.builtin.command: mv "{{ eth_testnet_temp_config_dir }}/{{ eth_testnet_path_in_temp_git_repo }}" "{{ eth_testnet_config_dir }}" # noqa: no-changed-when
+- name: Synchronize two directories on one remote host.
+  ansible.posix.synchronize:
+    src: "{{ eth_testnet_temp_config_dir }}/{{ eth_testnet_path_in_temp_git_repo }}"
+    dest: "{{ eth_testnet_config_dir }}"
+  delegate_to: "{{ inventory_hostname }}"
   when: eth_testnet_config_git_enabled
 
 - name: Recursively remove directory

--- a/roles/ethereum_testnet_config/tasks/main.yaml
+++ b/roles/ethereum_testnet_config/tasks/main.yaml
@@ -16,7 +16,7 @@
   when: eth_testnet_config_git_enabled
 
 - name: Move files to destination
-  ansible.builtin.command: mv "{{ eth_testnet_temp_config_dir }}/{{ eth_testnet_path_in_temp_git_repo }}" "{{ eth_testnet_config_dir }}"
+  ansible.builtin.command: mv "{{ eth_testnet_temp_config_dir }}/{{ eth_testnet_path_in_temp_git_repo }}" "{{ eth_testnet_config_dir }}" # noqa: no-changed-when
   when: eth_testnet_config_git_enabled
 
 # Option B: Allow copying over local dir

--- a/roles/ethereum_testnet_config/tasks/main.yaml
+++ b/roles/ethereum_testnet_config/tasks/main.yaml
@@ -17,6 +17,13 @@
     force: true
   when: eth_testnet_config_git_enabled
 
+- name: Create dest dir
+  ansible.builtin.file:
+    path: "{{ eth_testnet_config_dir }}"
+    state: directory
+    recurse: true
+  when: eth_testnet_config_git_enabled
+
 - name: Synchronize two directories on one remote host.
   ansible.posix.synchronize:
     src: "{{ eth_testnet_temp_config_dir }}/{{ eth_testnet_path_in_temp_git_repo }}"

--- a/roles/ethereum_testnet_config/tasks/main.yaml
+++ b/roles/ethereum_testnet_config/tasks/main.yaml
@@ -14,6 +14,7 @@
     dest: "{{ eth_testnet_temp_config_dir }}"
     version: "{{ eth_testnet_config_git_version }}"
     update: true
+    force: true
   when: eth_testnet_config_git_enabled
 
 - name: Synchronize two directories on one remote host.

--- a/roles/ethereum_testnet_config/tasks/main.yaml
+++ b/roles/ethereum_testnet_config/tasks/main.yaml
@@ -22,7 +22,7 @@
 
 - name: Recursively remove directory
   ansible.builtin.file:
-    path: /tmp/checkout
+    path: "{{ eth_testnet_temp_config_dir }}"
     state: absent
   when: eth_testnet_config_git_enabled
 

--- a/roles/ethereum_testnet_config/tasks/main.yaml
+++ b/roles/ethereum_testnet_config/tasks/main.yaml
@@ -13,6 +13,7 @@
     repo: "{{ eth_testnet_config_git_repo }}"
     dest: "{{ eth_testnet_temp_config_dir }}"
     version: "{{ eth_testnet_config_git_version }}"
+    update: yes
   when: eth_testnet_config_git_enabled
 
 - name: Move files to destination

--- a/roles/ethereum_testnet_config/tasks/main.yaml
+++ b/roles/ethereum_testnet_config/tasks/main.yaml
@@ -16,7 +16,7 @@
   when: eth_testnet_config_git_enabled
 
 - name: Move files to destination
-  command: mv "{{ eth_testnet_temp_config_dir }}/{{ eth_testnet_path_in_temp_git_repo }}" "{{ eth_testnet_config_dir }}"
+  ansible.builtin.command: mv "{{ eth_testnet_temp_config_dir }}/{{ eth_testnet_path_in_temp_git_repo }}" "{{ eth_testnet_config_dir }}"
   when: eth_testnet_config_git_enabled
 
 # Option B: Allow copying over local dir

--- a/roles/ethereum_testnet_config/tasks/main.yaml
+++ b/roles/ethereum_testnet_config/tasks/main.yaml
@@ -11,8 +11,12 @@
 - name: Git checkout config
   ansible.builtin.git:
     repo: "{{ eth_testnet_config_git_repo }}"
-    dest: "{{ eth_testnet_config_dir }}"
+    dest: "{{ eth_testnet_temp_config_dir }}"
     version: "{{ eth_testnet_config_git_version }}"
+  when: eth_testnet_config_git_enabled
+
+- name: Move files to destination
+  command: mv "{{ eth_testnet_temp_config_dir }}/{{ eth_testnet_path_in_temp_git_repo }}" "{{ eth_testnet_config_dir }}"
   when: eth_testnet_config_git_enabled
 
 # Option B: Allow copying over local dir


### PR DESCRIPTION
this is needed as the repo cloned doesn't always contain the files needed by the node at its root. this change allows us to clone the repo to a temp location and then move the required files to the needed destination.