### PR TITLE
fix(ethereum_node_fact_discovery): use devp2p to get enode instead of bootnode binary

### DIFF
--- a/roles/ethereum_node_fact_discovery/tasks/execution_layer.yaml
+++ b/roles/ethereum_node_fact_discovery/tasks/execution_layer.yaml
@@ -12,7 +12,8 @@
 
     - name: Turn EL nodekey into enode
       ansible.builtin.command: >-
-        docker run -t --rm ethereum/client-go:alltools-latest sh -c 'devp2p key to-enode <(echo "{{ ethereum_node_fact_discovery_el_nodekey.stdout }}")  | cut -d'@' -f1 | cut -d'/' -f3'
+        docker run -t --rm ethereum/client-go:alltools-latest
+        sh -c 'devp2p key to-enode <(echo "{{ ethereum_node_fact_discovery_el_nodekey.stdout }}")  | cut -d'@' -f1 | cut -d'/' -f3'
       vars:
         ansible_connection: local
       delegate_to: 127.0.0.1

--- a/roles/ethereum_node_fact_discovery/tasks/execution_layer.yaml
+++ b/roles/ethereum_node_fact_discovery/tasks/execution_layer.yaml
@@ -12,7 +12,7 @@
 
     - name: Turn EL nodekey into enode
       ansible.builtin.command: >-
-        docker run -t --rm ethereum/client-go:alltools-latest bootnode -writeaddress -nodekeyhex {{ ethereum_node_fact_discovery_el_nodekey.stdout }}
+        docker run -t --rm ethereum/client-go:alltools-latest sh -c 'devp2p key to-enode <(echo "{{ ethereum_node_fact_discovery_el_nodekey.stdout }}")  | cut -d'@' -f1 | cut -d'/' -f3'
       vars:
         ansible_connection: local
       delegate_to: 127.0.0.1


### PR DESCRIPTION
The bootnode binary has been removed