### PR TITLE
docker_cleanup: limit default pruning to images only and make it configurable

### DIFF
--- a/roles/docker_cleanup/defaults/main.yaml
+++ b/roles/docker_cleanup/defaults/main.yaml
@@ -1,3 +1,4 @@
 docker_cleanup_cron_name: docker-clean-up
 docker_cleanup_schedule: ["0", "0", "*", "*", "*"] # Cron format https://en.wikipedia.org/wiki/Cron
                                                    # Defaults to 00h00 every day
+docker_cleanup_command: "docker image prune -f"

--- a/roles/docker_cleanup/tasks/main.yaml
+++ b/roles/docker_cleanup/tasks/main.yaml
@@ -7,4 +7,4 @@
       day: "{{ docker_cleanup_schedule[2] }}"
       month: "{{ docker_cleanup_schedule[3] }}"
       weekday: "{{ docker_cleanup_schedule[4] }}"
-      job: "{{ docker_cleanup_command}}"
+      job: "{{ docker_cleanup_command }}"

--- a/roles/docker_cleanup/tasks/main.yaml
+++ b/roles/docker_cleanup/tasks/main.yaml
@@ -7,4 +7,4 @@
       day: "{{ docker_cleanup_schedule[2] }}"
       month: "{{ docker_cleanup_schedule[3] }}"
       weekday: "{{ docker_cleanup_schedule[4] }}"
-      job: "docker system prune -f &>/dev/null"
+      job: "{{ docker_cleanup_command}}"


### PR DESCRIPTION
The problem is that `docker system prune` will cleanup:
       - all stopped containers
        - all networks not used by at least one container
        - all dangling images
        - unused build cache
        
I don't think that we want it to cleanup stopped docker containers by default. This affected me on certain machines. 

Having the default policy just to prune images, should be enough.