### PR TITLE
generate_kubernetes_config: fix upper port limit

### DIFF
--- a/roles/generate_kubernetes_config/templates/ethereum-node.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/ethereum-node.yaml.j2
@@ -180,7 +180,7 @@
     mode: "beacon"
     p2pNodePort:
       enabled: true
-      port: {{ (33000 | random(start=32000, seed=ethereum_genesis_network_seed)) }}
+      port: {{ (32767 | random(start=32000, seed=ethereum_genesis_network_seed)) }}
     podLabels:
       network: {{ ethereum_network_name }}
       testnet: {{ ethereum_network_name }}


### PR DESCRIPTION
Due to Service "teku-geth-001-p2p-0" is invalid: spec.ports[0].nodePort: Invalid value: 32918: provided port is not in the valid range. The range of valid ports is 30000-32767 (retried 5 times)