### PR TITLE
downgrade asdf

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -11,6 +11,8 @@ runs:
 
     - name: Install asdf
       uses: asdf-vm/actions/setup@v3
+      with:
+        asdf_branch: v0.15.0
 
     - name: Run setup
       shell: bash


### PR DESCRIPTION
The newest asdf version 0.16.0 is rewritten in go and requires some new setup. I'll stick to 0.15.0 until we decide to update this across our stack. 