### PR TITLE
mev_relay: update default env vars - expect dict, not list.

### DIFF
--- a/roles/mev_relay/defaults/main.yml
+++ b/roles/mev_relay/defaults/main.yml
@@ -53,7 +53,7 @@ mev_relay_housekeeper_enabled: true
 mev_relay_housekeeper_datadir: "{{ mev_relay_datadir }}/mev-relay-housekeeper"
 mev_relay_housekeeper_container_name: mev-relay-housekeeper
 mev_relay_housekeeper_container_image: flashbots/mev-boost-relay:latest
-mev_relay_housekeeper_container_env: []
+mev_relay_housekeeper_container_env: {}
 mev_relay_housekeeper_container_ports: []
 mev_relay_housekeeper_container_volumes: []
 mev_relay_housekeeper_container_stop_timeout: "300"
@@ -69,7 +69,7 @@ mev_relay_api_enabled: true
 mev_relay_api_datadir: "{{ mev_relay_datadir }}/mev-relay-api"
 mev_relay_api_container_name: mev-relay-api
 mev_relay_api_container_image: flashbots/mev-boost-relay:latest
-mev_relay_api_container_env: []
+mev_relay_api_container_env: {}
 mev_relay_api_container_ports:
   - "127.0.0.1:{{ mev_relay_api_listening_port }}:{{ mev_relay_api_listening_port }}"
 mev_relay_api_container_volumes: []
@@ -86,7 +86,7 @@ mev_relay_website_enabled: true
 mev_relay_website_datadir: "{{ mev_relay_datadir }}/mev-relay-website"
 mev_relay_website_container_name: mev-relay-website
 mev_relay_website_container_image: flashbots/mev-boost-relay:latest
-mev_relay_website_container_env: []
+mev_relay_website_container_env: {}
 mev_relay_website_container_ports:
   - "127.0.0.1:{{ mev_relay_website_listening_port }}:{{ mev_relay_website_listening_port }}"
 mev_relay_website_container_volumes: []


### PR DESCRIPTION
`env` is a dict. not a list: https://docs.ansible.com/ansible/latest/collections/community/docker/docker_container_module.html#parameter-env 