### PR TITLE
fix: ansible-lint CI failing

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -16,5 +16,5 @@ runs:
 
     - name: Run setup
       shell: bash
-      run: ./setup.sh
+      run: make setup
       working-directory: ansible_collections/ethpandaops/general

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,11 +23,5 @@ jobs:
 
       - uses: ./ansible_collections/ethpandaops/general/.github/actions/setup
 
-      - name: Lint roles
-        run: ansible-lint roles
-
-      - name: Lint playbooks
-        run: ansible-lint playbooks
-
-      - name: Sanity test
-        run: ansible-test sanity
+      - name: Lint
+        run: make lint

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Vendored ansible collections and roles
 vendor/
 
+# Ansible cache
+.ansible/
+
 # Test outputs from ansible-test
 tests/output/
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: lint lint-roles lint-playbooks sanity setup
+
+setup:
+	./setup.sh
+
+lint: lint-roles lint-playbooks sanity
+
+lint-roles:
+	ansible-lint roles
+
+lint-playbooks:
+	ansible-lint playbooks
+
+sanity:
+	ansible-test sanity --exclude .ansible/

--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ lint-playbooks:
 	ansible-lint playbooks
 
 sanity:
-	ansible-test sanity --exclude .ansible/
+	ansible-test sanity

--- a/README.md
+++ b/README.md
@@ -110,14 +110,16 @@ git clone git@github.com:ethpandaops/ansible-collection-general.git ansible_coll
 
 If you want to test and develop on this ansible collection you'll need some tools. We're using [`asdf`](https://asdf-vm.com/) to commit to certain [versions](.tool-versions) of those tools. Some additional python specific tools are defined in the [`requirements.txt`](requirements.txt).
 
-Make sure you have `asdf` installed and then you can run the `./setup.sh` script which will install all required tools.
+Make sure you have `asdf` installed and then you can run the `./setup.sh` script which will install all required tools. Alternatively you can run `make setup` which will do the same thing.
 
 For linting and sanity checks you can run the following commands:
 
 ```sh
 ansible-lint
-ansible-test sanity
+ansible-test sanity --exclude .ansible/
 ```
+
+Alternatively you can run `make lint` which will run the linting and sanity checks.
 
 Some roles have [molecule](https://ansible.readthedocs.io/projects/molecule/) tests inside. You can check this if a role has a `molecule` directory within. To run molecule ona given role you can do the following:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ ansible==10.1.0
 molecule-containers==2.0.0
 molecule==24.6.0
 netaddr==1.3.0
-pip==25.0
+pip==25.0.1
 requests==2.31 # Fix for not being able to run 'molecule test' using docker on mac. Issue: https://github.com/docker/docker-py/issues/3256


### PR DESCRIPTION
The problem with the most recent linting runs was that:

1. `ansible-lint` created a `.ansible` directory locally where it cached some stuff (roles/collections...)
2. `ansible-test sanity` also checked that `.ansible` directory.

This PR adds `.ansible` to gitignore and also excludes it from the sanity test command.
Additionaly, I've moved some commands to a Makefile to make it easier to run the whole lint job by just running `make lint`. 