### PR TITLE
Add spamoor to ansible collection

### DIFF
--- a/roles/spamoor/README.md
+++ b/roles/spamoor/README.md
@@ -1,0 +1,38 @@
+# ethpandaops.general.spamoor
+
+This role will run a [spamoor](https://github.com/ethpandaops/spamoor) within a docker container.
+
+## Requirements
+
+You'll need docker on the target system. Make sure to install it upfront.
+
+## Role Variables
+
+Default variables are defined in [defaults/main.yaml](defaults/main.yaml)
+
+## Dependencies
+
+You'll need docker to run this role. One way of installing docker could be via ansible galaxy with the following dependencies set within `requirements.yaml`:
+
+```yaml
+roles:
+- src: geerlingguy.docker
+  version: latest
+- src: geerlingguy.pip
+  version: latest
+```
+
+## Example Playbook
+
+Your playbook could look like this:
+
+```yaml
+- hosts: localhost
+  become: true
+  roles:
+  - role: geerlingguy.docker
+  - role: geerlingguy.pip
+    pip_install_packages:
+    - name: docker
+  - role: ethpandaops.general.spamoor
+```

--- a/roles/spamoor/defaults/main.yaml
+++ b/roles/spamoor/defaults/main.yaml
@@ -1,0 +1,25 @@
+spamoor_user: "spamoor"
+spamoor_cleanup: false # when set to "true" it will remove the container
+
+spamoor_container_name: "spamoor"
+spamoor_container_image: "ethpandaops/spamoor:latest"
+spamoor_container_env: {}
+spamoor_container_ports: []
+spamoor_container_volumes: []
+
+spamoor_container_stop_timeout: "300"
+spamoor_container_networks: []
+
+spamoor_container_command: |
+  {{ spamoor_scenario }}
+  {% for url in spamoor_rpc_urls %}
+  -h={{ url }}
+  {% endfor %}
+  -p={{ spamoor_private_key }}
+  -t={{ spamoor_rpc_throughput }}
+
+spamoor_rpc_urls:
+  - your-execution-node:8545
+spamoor_rpc_throughput: "10"
+spamoor_scenario: "eoatx"
+spamoor_private_key: ""

--- a/roles/spamoor/handlers/main.yaml
+++ b/roles/spamoor/handlers/main.yaml
@@ -1,0 +1,5 @@
+- name: Restart spamoor container
+  community.docker.docker_container:
+    name: "{{ spamoor_container_name }}"
+    state: started
+    restart: true

--- a/roles/spamoor/tasks/cleanup.yaml
+++ b/roles/spamoor/tasks/cleanup.yaml
@@ -1,0 +1,5 @@
+- name: Remove spamoor container
+  community.docker.docker_container:
+    name: "{{ spamoor_container_name }}"
+    state: absent
+  when: spamoor_cleanup

--- a/roles/spamoor/tasks/main.yaml
+++ b/roles/spamoor/tasks/main.yaml
@@ -1,0 +1,7 @@
+- name: Setup spamoor
+  ansible.builtin.import_tasks: setup.yaml
+  when: not spamoor_cleanup
+
+- name: Cleanup spamoor
+  ansible.builtin.import_tasks: cleanup.yaml
+  when: spamoor_cleanup

--- a/roles/spamoor/tasks/setup.yaml
+++ b/roles/spamoor/tasks/setup.yaml
@@ -1,0 +1,26 @@
+- name: Add spamoor user
+  ansible.builtin.user:
+    name: "{{ spamoor_user }}"
+    shell: /bin/nologin
+
+- name: Get spamoor uid
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ spamoor_user }}"
+  register: spamoor_user_getent
+
+
+- name: Run spamoor sentry container
+  community.docker.docker_container:
+    name: "{{ spamoor_container_name }}"
+    image: "{{ spamoor_container_image }}"
+    image_name_mismatch: recreate
+    user: "{{ spamoor_user_getent.ansible_facts.getent_passwd[spamoor_user][1] }}"
+    state: started
+    restart_policy: always
+    stop_timeout: "{{ spamoor_container_stop_timeout }}"
+    ports: "{{ spamoor_container_ports }}"
+    volumes: "{{ spamoor_container_volumes }}"
+    env: "{{ spamoor_container_env }}"
+    networks: "{{ spamoor_container_networks }}"
+    command: "{{ spamoor_container_command }}"


### PR DESCRIPTION
I've noticed that [spamoor](https://github.com/ethpandaops/spamoor) was missing from the ansible collection, so I've added it to the collection.

You can use the following flags to modify the basic behavior of spamoor
```yaml
spamoor_rpc_urls:
  - your-execution-node:8545
spamoor_rpc_throughput: "10"
spamoor_scenario: "eoatx"
spamoor_private_key: ""
```
and also override `spamoor_container_command` to modify other things

Please let me know if there's anything that needs fixing! 😄 
If this can be merged, I'd also like to work on a follow-up pr on adding this role to the devnet templates so that we can use this in devnets in lieu of tx-fuzz. 