### PR TITLE
Update docker_compose module to docker_compose_v2 

### DIFF
--- a/roles/beaconchain_explorer_aio/tasks/cleanup.yml
+++ b/roles/beaconchain_explorer_aio/tasks/cleanup.yml
@@ -1,5 +1,5 @@
 - name: Stop services
-  community.docker.docker_compose:
+  community.docker.docker_compose_v2:
     project_src: "{{ beaconchain_explorer_aio_installation_dir }}"
     state: absent
 

--- a/roles/beaconchain_explorer_aio/tasks/setup.yml
+++ b/roles/beaconchain_explorer_aio/tasks/setup.yml
@@ -94,7 +94,7 @@
   loop: "{{ beaconchain_explorer_aio_extra_config_files | dict2items }}"
 
 - name: Create and start database services
-  community.docker.docker_compose:
+  community.docker.docker_compose_v2:
     project_src: "{{ beaconchain_explorer_aio_installation_dir }}"
     services:
       - postgres
@@ -111,7 +111,7 @@
   when: not beaconchain_explorer_aio_bigtable_external_enabled
   block:
     - name: Create and start database service
-      community.docker.docker_compose:
+      community.docker.docker_compose_v2:
         project_src: "{{ beaconchain_explorer_aio_installation_dir }}"
         services:
           - bigtable
@@ -126,7 +126,7 @@
         creates: "{{ beaconchain_explorer_aio_installation_dir }}/bigtable/initialized"
 
 - name: Create remaining explorer services
-  community.docker.docker_compose:
+  community.docker.docker_compose_v2:
     project_src: "{{ beaconchain_explorer_aio_installation_dir }}"
     services:
       - exporter

--- a/roles/xatu_stack/handlers/main.yaml
+++ b/roles/xatu_stack/handlers/main.yaml
@@ -3,5 +3,4 @@
     project_src: "{{ xatu_stack_repo_path }}"
     files:
       - docker-compose.yml
-    state: present
-    restarted: true
+    state: restarted

--- a/roles/xatu_stack/tasks/cleanup.yaml
+++ b/roles/xatu_stack/tasks/cleanup.yaml
@@ -1,5 +1,5 @@
 - name: Remove xatu stack containers
-  community.docker.docker_compose:
+  community.docker.docker_compose_v2:
     project_src: "{{ xatu_stack_repo_path }}"
     files:
       - docker-compose.yml


### PR DESCRIPTION
docker-compose v1 is deprecated and using it will print: `[DEPRECATION WARNING]: community.docker.docker_compose has been deprecated. This module uses docker-compose v1, which is End of Life since July 2022. Please migrate to community.docker.docker_compose_v2. This 
feature will be removed from community.docker in version 4.0.0. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.`. 

This PR updates the ansible module to use docker_compose_v2 instead of the v1. 