### PR TITLE
Update GitHub Actions to use pinned hashes

### DIFF
--- a/.github/workflows/integration.ethereum_node.scheduled.yaml
+++ b/.github/workflows/integration.ethereum_node.scheduled.yaml
@@ -21,7 +21,7 @@ jobs:
         execution: [geth, nethermind, erigon, besu, ethereumjs, reth, nimbusel]
     runs-on: self-hosted-ghr-size-m-x64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           path: ansible_collections/ethpandaops/general
 
@@ -42,7 +42,7 @@ jobs:
     if: cancelled() || failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/integration.ethereum_node.yaml
+++ b/.github/workflows/integration.ethereum_node.yaml
@@ -20,14 +20,14 @@ jobs:
       consensus_clients: ${{ steps.consensus_clients.outputs.changes }}
       execution_clients: ${{ steps.execution_clients.outputs.changes }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: global
         with:
           filters: |
             ethereum_node: roles/ethereum_node/**
             dependencies: requirements.*
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: consensus_clients
         with:
           filters: |
@@ -37,7 +37,7 @@ jobs:
             nimbus: roles/nimbus/**
             prysm: roles/prysm/**
             teku: roles/teku/**
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: execution_clients
         with:
           filters: |
@@ -112,7 +112,7 @@ jobs:
         execution: ${{ fromJSON(needs.vars.outputs.EXECUTION_CLIENTS) }}
     runs-on: self-hosted-ghr-size-s-x64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           path: ansible_collections/ethpandaops/general
 

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -18,8 +18,8 @@ jobs:
     outputs:
       roles: ${{ steps.filter.outputs.changes }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
         with:
           filters: |
@@ -41,7 +41,7 @@ jobs:
         role: ${{ fromJSON(needs.changes.outputs.roles) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           path: ansible_collections/ethpandaops/general
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,7 +17,7 @@ jobs:
   job:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           path: ansible_collections/ethpandaops/general
 


### PR DESCRIPTION
This PR updates GitHub Actions to use pinned commit hashes for better security.