### PR TITLE
add `dns_server` role & update service generator urls

### DIFF
--- a/roles/dns_server/README.md
+++ b/roles/dns_server/README.md
@@ -1,0 +1,43 @@
+# ethpandaops.general.dns_server
+
+Setup [bind9](https://hub.docker.com/r/ubuntu/bind9) dns server and and serve a custom dns zone.
+
+## Requirements
+
+You'll need docker on the target system. Make sure to install it upfront.
+
+## Role Variables
+
+Default variables are defined in [defaults/main.yaml](defaults/main.yaml)
+
+## Dependencies
+
+You'll need docker to run this role. One way of installing docker could be via ansible galaxy with the following dependencies set within `requirements.yaml`:
+
+```yaml
+roles:
+- src: geerlingguy.docker
+  version: 6.0.3
+- src: geerlingguy.pip
+  version: 2.2.0
+```
+
+## Example Playbook
+
+Your playbook could look like this:
+
+```yaml
+- hosts: dns_server
+  become: true
+  roles:
+  # Docker. Required dependency
+  - role: geerlingguy.docker
+    tags: [docker]
+  - role: geerlingguy.pip
+    pip_install_packages:
+    - name: docker
+    tags: [docker]
+  # dns_server
+  - role: dns_server
+    tags: [dns_server]
+```

--- a/roles/dns_server/defaults/main.yml
+++ b/roles/dns_server/defaults/main.yml
@@ -1,0 +1,47 @@
+---
+
+# Set this to true if you want to stop everything and wipe the databases
+dns_server_cleanup_all: false
+
+
+dns_server_uid: 101
+dns_server_zonesdir: "/data/dns_server/zones"
+dns_server_configdir: "/data/dns_server/config"
+dns_server_docker_network_name: shared
+dns_server_docker_networks:
+  - name: "{{ dns_server_docker_network_name }}"
+dns_server_disable_systemd_resolved: false
+
+# dns_server
+dns_server_enabled: true
+dns_server_container_name: dns_server
+dns_server_container_image: ubuntu/bind9:9.18-22.04_beta
+dns_server_container_env: {}
+dns_server_container_ports:
+  - "0.0.0.0:53:53/udp"
+  - "0.0.0.0:53:53/tcp"
+dns_server_container_volumes:
+  - "{{ dns_server_zonesdir }}:/etc/bind/zones"
+  - "{{ dns_server_configdir }}/named.conf:/etc/bind/named.conf"
+dns_server_container_stop_timeout: "600"
+dns_server_container_pull: false
+dns_server_container_networks: "{{ dns_server_docker_networks }}"
+dns_server_container_command: ""
+
+dns_server_config: |
+  options {
+    directory "/etc/bind/zones";
+    dnssec-validation auto;
+    listen-on-v6 { any; };
+    allow-query { 127.0.0.1; 172.16.0.0/12; };
+    allow-transfer { none; };
+  };
+  {% for zone in dns_server_zones %}
+  zone "{{ zone.zone }}" {
+    type master;
+    file "/etc/bind/zones/{{ zone.zone }}";
+    masterfile-format text;
+    allow-query { any; };
+  };
+  {% endfor %}
+dns_server_zones: []

--- a/roles/dns_server/handlers/main.yaml
+++ b/roles/dns_server/handlers/main.yaml
@@ -1,0 +1,9 @@
+- name: Restart systemd-resolved
+  ansible.builtin.systemd:
+    name: systemd-resolved
+    state: restarted
+- name: Restart dns server container
+  community.docker.docker_container:
+    name: "{{ dns_server_container_name }}"
+    state: started
+    restart: true

--- a/roles/dns_server/tasks/cleanup.yml
+++ b/roles/dns_server/tasks/cleanup.yml
@@ -1,0 +1,14 @@
+- name: Stop dns server containers
+  community.docker.docker_container:
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ dns_server_container_name }}"
+
+- name: Delete data directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ dns_server_zonesdir }}"
+    - "{{ dns_server_configdir }}"

--- a/roles/dns_server/tasks/main.yml
+++ b/roles/dns_server/tasks/main.yml
@@ -1,0 +1,7 @@
+- name: Setup dns server
+  ansible.builtin.import_tasks: setup.yml
+  when: not dns_server_cleanup_all
+
+- name: Cleanup dns server
+  ansible.builtin.import_tasks: cleanup.yml
+  when: dns_server_cleanup_all

--- a/roles/dns_server/tasks/setup.yml
+++ b/roles/dns_server/tasks/setup.yml
@@ -1,0 +1,66 @@
+
+- name: Setup docker network
+  ansible.builtin.include_role:
+    name: ethpandaops.general.docker_network
+  vars:
+    docker_network_name: "{{ dns_server_docker_network_name }}"
+
+- name: Ensure DNSStubListener=no is set in resolved.conf
+  ansible.builtin.lineinfile:
+    path: /etc/systemd/resolved.conf
+    regexp: '^DNSStubListener='
+    line: 'DNSStubListener=no'
+    insertafter: '^\[Resolve\]'
+    create: yes
+    backup: yes
+  when: dns_server_disable_systemd_resolved | bool
+  notify: Restart systemd-resolved
+
+- name: Immediately apply systemd-resolved changes
+  meta: flush_handlers
+  when: dns_server_disable_systemd_resolved | bool
+
+- name: Create directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: "0750"
+    owner: "{{ dns_server_uid }}"
+    group: "{{ dns_server_uid }}"
+  loop:
+    - "{{ dns_server_configdir }}"
+    - "{{ dns_server_zonesdir }}"
+
+- name: Create dns server config file
+  ansible.builtin.copy:
+    content: "{{ dns_server_config }}"
+    dest: "{{ dns_server_configdir }}/named.conf"
+    owner: "{{ dns_server_uid }}"
+    group: "{{ dns_server_uid }}"
+    mode: '0644'
+  notify: Restart dns server container
+
+- name: Create dns server zone file
+  ansible.builtin.copy:
+    content: "{{ item.content }}"
+    dest: "{{ dns_server_zonesdir }}/{{ item.zone }}"
+    owner: "{{ dns_server_uid }}"
+    group: "{{ dns_server_uid }}"
+    mode: '0644'
+  loop: "{{ dns_server_zones }}"
+  notify: Restart dns server container
+
+- name: Setup dns server
+  community.docker.docker_container:
+    name: "{{ dns_server_container_name }}"
+    image: "{{ dns_server_container_image }}"
+    image_name_mismatch: recreate
+    state: 'started'
+    restart_policy: always
+    stop_timeout: "{{ dns_server_container_stop_timeout }}"
+    ports: "{{ dns_server_container_ports }}"
+    volumes: "{{ dns_server_container_volumes }}"
+    env: "{{ dns_server_container_env }}"
+    networks: "{{ dns_server_container_networks }}"
+    pull: "{{ dns_server_container_pull | bool }}"
+    command: "{{ dns_server_container_command }}"

--- a/roles/generate_kubernetes_config/templates/assertoor.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/assertoor.yaml.j2
@@ -44,8 +44,8 @@ assertoor:
   endpoints:
 {% for host in (groups['ethereum_node'] + groups['bootnode']) | sort %}
     - name:  {{ hostvars[host]['inventory_hostname'] }}
-      executionUrl: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@rpc.{{ hostvars[host]['inventory_hostname'] }}.{{ network_subdomain }}
-      consensusUrl: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@bn.{{ hostvars[host]['inventory_hostname'] }}.{{ network_subdomain }}
+      executionUrl: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@rpc.{{ hostvars[host]['inventory_hostname'] }}.{{ network_server_subdomain }}
+      consensusUrl: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@bn.{{ hostvars[host]['inventory_hostname'] }}.{{ network_server_subdomain }}
 {% endfor %}
 
   validatorNamesInventory: https://config.{{ network_subdomain }}/api/v1/nodes/validator-ranges

--- a/roles/generate_kubernetes_config/templates/checkpointz.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/checkpointz.yaml.j2
@@ -52,7 +52,7 @@ checkpointz:
 {% for host in (groups['ethereum_node'] + groups['bootnode']) | sort %}
 {% if ((hostvars[host]['inventory_hostname'] | string)[-2:]) == "-1" %}
         - name: {{ hostvars[host]['inventory_hostname'] }}
-          address: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@bn.{{ hostvars[host]['inventory_hostname'] }}.{{ network_subdomain }}
+          address: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@bn.{{ hostvars[host]['inventory_hostname'] }}.{{ network_server_subdomain }}
           dataProvider: true
 {% endif %}
 {% endfor %}

--- a/roles/generate_kubernetes_config/templates/dora.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/dora.yaml.j2
@@ -67,7 +67,7 @@ dora:
     archive: true
     priority: 1
 {% for host in (groups['ethereum_node'] + groups['bootnode']) | sort %}
-  - url: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@bn.{{ hostvars[host]['inventory_hostname'] }}.{{ network_subdomain }}
+  - url: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@bn.{{ hostvars[host]['inventory_hostname'] }}.{{ network_server_subdomain }}
     name: {{ hostvars[host]['inventory_hostname'] }}
     priority: -1
 {% if 'lighthouse' in hostvars[host]['inventory_hostname'] %}
@@ -81,7 +81,7 @@ dora:
     archive: true
     priority: 1
 {% for host in (groups['ethereum_node'] + groups['bootnode']) | sort %}
-  - url: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@rpc.{{ hostvars[host]['inventory_hostname'] }}.{{ network_subdomain }}
+  - url: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@rpc.{{ hostvars[host]['inventory_hostname'] }}.{{ network_server_subdomain }}
     name: {{ hostvars[host]['inventory_hostname'] }}
     priority: -1
     archive: false

--- a/roles/generate_kubernetes_config/templates/dugtrio.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/dugtrio.yaml.j2
@@ -33,6 +33,6 @@ dugtrio:
   - url: {{ default_cl_endpoint }}
     name: rpc-{{ gen_kubernetes_config_ethereum_node_name }}
 {% for host in (groups['ethereum_node'] + groups['bootnode']) | sort %}
-  - url: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@bn.{{ hostvars[host]['inventory_hostname'] }}.{{ network_subdomain }}
+  - url: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@bn.{{ hostvars[host]['inventory_hostname'] }}.{{ network_server_subdomain }}
     name: {{ hostvars[host]['inventory_hostname'] }}
 {% endfor %}

--- a/roles/generate_kubernetes_config/templates/erpc.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/erpc.yaml.j2
@@ -133,5 +133,5 @@ erpc:
             - "trace_block"
         upstreams:
 {% for host in (groups['ethereum_node'] + groups['bootnode']) | sort %}
-          - endpoint: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@rpc.{{ hostvars[host]['inventory_hostname'] }}.{{ network_subdomain }}
+          - endpoint: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@rpc.{{ hostvars[host]['inventory_hostname'] }}.{{ network_server_subdomain }}
 {% endfor %}

--- a/roles/generate_kubernetes_config/templates/forkmon.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/forkmon.yaml.j2
@@ -21,7 +21,7 @@ forkmon:
   - addr: {{ default_el_endpoint }}
     name: rpc-{{ gen_kubernetes_config_ethereum_node_name }}
 {% for host in (groups['ethereum_node'] + groups['bootnode']) | sort %}
-  - addr: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@rpc.{{ hostvars[host]['inventory_hostname'] }}.{{ network_subdomain }}
+  - addr: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@rpc.{{ hostvars[host]['inventory_hostname'] }}.{{ network_server_subdomain }}
     name: {{ hostvars[host]['inventory_hostname'] }}
 {% endfor %}
 {% raw %}

--- a/roles/generate_kubernetes_config/templates/forky.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/forky.yaml.j2
@@ -77,7 +77,7 @@ forky:
         - name: {{ hostvars[host]['inventory_hostname'] }}
           type: "beacon_node"
           config:
-            address: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@bn.{{ hostvars[host]['inventory_hostname'] }}.{{ network_subdomain }}
+            address: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@bn.{{ hostvars[host]['inventory_hostname'] }}.{{ network_server_subdomain }}
             polling_interval: "12s"
 {% endif %}
 {% endfor %}

--- a/roles/generate_kubernetes_config/templates/spamoor.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/spamoor.yaml.j2
@@ -43,5 +43,5 @@ spamoor:
   # Rpc
   - "{{ default_el_endpoint }}"
 {% for host in (groups['ethereum_node'] + groups['bootnode']) | sort %}
-  - "https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@rpc.{{ hostvars[host]['inventory_hostname'] }}.{{ network_subdomain }}"
+  - "https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@rpc.{{ hostvars[host]['inventory_hostname'] }}.{{ network_server_subdomain }}"
 {% endfor %}

--- a/roles/generate_kubernetes_config/templates/tracoor.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/tracoor.yaml.j2
@@ -92,9 +92,9 @@ tracoor-single:
         ethereum:
           overrideNetworkName: {{ ethereum_network_name }}
           beacon:
-            nodeAddress: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@bn.{{ hostvars[host]['inventory_hostname'] }}.{{ network_subdomain }}
+            nodeAddress: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@bn.{{ hostvars[host]['inventory_hostname'] }}.{{ network_server_subdomain }}
           execution:
-            nodeAddress: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@rpc.{{ hostvars[host]['inventory_hostname'] }}.{{ network_subdomain }}
+            nodeAddress: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@rpc.{{ hostvars[host]['inventory_hostname'] }}.{{ network_server_subdomain }}
             traceDisableMemory: true
             traceDisableStack: true
             traceDisableStorage: true

--- a/roles/generate_kubernetes_config/templates/xatu-cannon.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/xatu-cannon.yaml.j2
@@ -95,7 +95,7 @@ xatu-cannon:
       enabled: false
     ethereum:
 {% if groups['bootnode'] | length > 0 %}
-      beaconNodeAddress: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@bn.{{ hostvars[groups['bootnode'][0]]['inventory_hostname'] }}.{{ network_subdomain }}
+      beaconNodeAddress: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@bn.{{ hostvars[groups['bootnode'][0]]['inventory_hostname'] }}.{{ network_server_subdomain }}
 {% endif %}
       overrideNetworkName: {{ ethereum_network_name }}
       beaconNodeHeaders: {}


### PR DESCRIPTION
This PR adds a simple dns server role that is capable of running a dockerized bind9 server with a list of zone files.

In addition to the dns_server role, this PR contains a breaking change, as the `generate_kubernetes_config` role uses the newly defined global variable `network_server_subdomain`.
For existing devnets that use cloudlflare records for all nodes, this can be defined as:
```yaml
network_server_subdomain: "{{ network_subdomain }}"
```

for future devnets using the dns server, this will be defined as:
```yaml
network_server_subdomain: "srv.{{ network_subdomain }}"
```

rel PR to template-devnet: 