### PR TITLE
bootstrap: increase timeout from 10s to 20s when fetching keys

### DIFF
--- a/roles/bootstrap/defaults/main.yml
+++ b/roles/bootstrap/defaults/main.yml
@@ -21,7 +21,7 @@ bootstrap_default_user_authorized_keys: |
   {% endfor %}
   {% for user in bootstrap_default_user_authorized_keys_github %}
   # github:{{ user }}
-  {{ lookup('ethpandaops.general.url_cached', 'https://github.com/' + user + '.keys', split_lines=False) }}
+  {{ lookup('ethpandaops.general.url_cached', 'https://github.com/' + user + '.keys', split_lines=False, timeout=20) }}
   {% endfor %}
 bootstrap_sudoers_file_path: /etc/sudoers
 bootstrap_reboot_if_required: false


### PR DESCRIPTION
Due to :

```
 Error was a <class 'ansible.errors.AnsibleError'>, original message: An unhandled exception occurred while running the lookup plugin 'ethpandaops.general.url_cached'. Error was a <class 'TimeoutError'>, original message: The read operation timed out. The read operation timed out
```