### PR TITLE
ethereum_node: ignore errors giving by chown

### DIFF
--- a/roles/arbitrum_node/tasks/main.yaml
+++ b/roles/arbitrum_node/tasks/main.yaml
@@ -8,6 +8,7 @@
 
 - name: Set permissions
   ansible.builtin.command: "chown -R 1000:1000 {{ arbitrum_node_datadir }}" # noqa no-free-form
+  failed_when: false
   changed_when: false
 
 - name: Run arbitrum_node container

--- a/roles/besu/tasks/setup.yaml
+++ b/roles/besu/tasks/setup.yaml
@@ -13,6 +13,7 @@
 
 - name: Set permissions
   ansible.builtin.command: "chown -R {{ besu_user }}:{{ besu_user }} {{ besu_datadir }}" # noqa no-free-form
+  failed_when: false
   changed_when: false
 
 - name: Run besu container

--- a/roles/blobber/tasks/setup.yaml
+++ b/roles/blobber/tasks/setup.yaml
@@ -35,6 +35,7 @@
 
 - name: Set permissions for blobber director
   ansible.builtin.command: "chown -R {{ blobber_user }}:{{ blobber_user }} {{ blobber_validator_remote_key_folder }}" # noqa no-free-form
+  failed_when: false
   changed_when: false
 
 - name: Run blobber container

--- a/roles/charon/tasks/setup.yaml
+++ b/roles/charon/tasks/setup.yaml
@@ -13,6 +13,7 @@
 
 - name: Set permissions
   ansible.builtin.command: "chown -R {{ charon_user }}:{{ charon_user }} {{ charon_datadir }}" # noqa no-free-form
+  failed_when: false
   changed_when: false
 
 - name: Run charon container

--- a/roles/erigon/tasks/setup.yaml
+++ b/roles/erigon/tasks/setup.yaml
@@ -13,6 +13,7 @@
 
 - name: Set permissions
   ansible.builtin.command: "chown -R {{ erigon_user }}:{{ erigon_user }} {{ erigon_datadir }}" # noqa no-free-form
+  failed_when: false
   changed_when: false
 
 - name: Init custom network

--- a/roles/ethereumjs/tasks/setup.yaml
+++ b/roles/ethereumjs/tasks/setup.yaml
@@ -13,6 +13,7 @@
 
 - name: Set permissions
   ansible.builtin.command: "chown -R {{ ethereumjs_user }}:{{ ethereumjs_user }} {{ ethereumjs_datadir }}" # noqa no-free-form
+  failed_when: false
   changed_when: false
 
 - name: Run ethereumjs container

--- a/roles/geth/tasks/setup.yaml
+++ b/roles/geth/tasks/setup.yaml
@@ -13,6 +13,7 @@
 
 - name: Set permissions
   ansible.builtin.command: "chown -R {{ geth_user }}:{{ geth_user }} {{ geth_datadir }}" # noqa no-free-form
+  failed_when: false
   changed_when: false
 
 - name: Init custom network

--- a/roles/grandine/tasks/setup.yaml
+++ b/roles/grandine/tasks/setup.yaml
@@ -13,6 +13,7 @@
 
 - name: Set permissions
   ansible.builtin.command: "chown -R {{ grandine_user }}:{{ grandine_user }} {{ grandine_datadir }}" # noqa no-free-form
+  failed_when: false
   changed_when: false
 
 - name: Create validator data dir
@@ -30,6 +31,7 @@
 
 - name: Set permissions for validator data dir
   ansible.builtin.command: "chown -R {{ grandine_user }}:{{ grandine_user }} {{ grandine_validator_datadir }}" # noqa no-free-form
+  failed_when: false
   changed_when: false
   when: grandine_validator_enabled
 

--- a/roles/lighthouse/tasks/setup.yaml
+++ b/roles/lighthouse/tasks/setup.yaml
@@ -16,6 +16,7 @@
 
     - name: Set permissions
       ansible.builtin.command: "chown -R {{ lighthouse_user }}:{{ lighthouse_user }} {{ lighthouse_datadir }}" # noqa no-free-form
+      failed_when: false
       changed_when: false
 
     - name: Run lighthouse container
@@ -60,6 +61,7 @@
 
     - name: Set permissions for validator data dir
       ansible.builtin.command: "chown -R {{ lighthouse_user }}:{{ lighthouse_user }} {{ lighthouse_validator_datadir }}" # noqa no-free-form
+      failed_when: false
       changed_when: false
 
     - name: Run lighthouse validator container

--- a/roles/lodestar/tasks/setup.yaml
+++ b/roles/lodestar/tasks/setup.yaml
@@ -16,6 +16,7 @@
 
     - name: Set permissions
       ansible.builtin.command: "chown -R {{ lodestar_user }}:{{ lodestar_user }} {{ lodestar_datadir }}" # noqa no-free-form
+      failed_when: false
       changed_when: false
 
     - name: Run lodestar container
@@ -60,6 +61,7 @@
 
     - name: Set permissions for validator data dir
       ansible.builtin.command: "chown -R {{ lodestar_user }}:{{ lodestar_user }} {{ lodestar_validator_datadir }}" # noqa no-free-form
+      failed_when: false
       changed_when: false
 
     - name: Run lodestar validator container

--- a/roles/mev_flood/tasks/setup.yaml
+++ b/roles/mev_flood/tasks/setup.yaml
@@ -21,6 +21,7 @@
 
 - name: Set permissions
   ansible.builtin.command: "chown -R {{ mev_flood_user }}:{{ mev_flood_user }} {{ mev_flood_datadir }}" # noqa no-free-form
+  failed_when: false
   changed_when: false
 
 - name: Run mev_flood container

--- a/roles/nethermind/tasks/setup.yaml
+++ b/roles/nethermind/tasks/setup.yaml
@@ -16,6 +16,7 @@
 
 - name: Set permissions
   ansible.builtin.command: "chown -R {{ nethermind_user }}:{{ nethermind_user }} {{ nethermind_datadir }}" # noqa no-free-form
+  failed_when: false
   changed_when: false
 
 - name: Run nethermind container

--- a/roles/nimbus/tasks/setup.yaml
+++ b/roles/nimbus/tasks/setup.yaml
@@ -13,6 +13,7 @@
 
 - name: Set permissions
   ansible.builtin.command: "chown -R {{ nimbus_user }}:{{ nimbus_user }} {{ nimbus_datadir }}" # noqa no-free-form
+  failed_when: false
   changed_when: false
 
 - name: Create validator data dir
@@ -30,6 +31,7 @@
 
 - name: Set permissions for validator data dir
   ansible.builtin.command: "chown -R {{ nimbus_user }}:{{ nimbus_user }} {{ nimbus_validator_datadir }}" # noqa no-free-form
+  failed_when: false
   changed_when: false
   when: nimbus_validator_enabled
 

--- a/roles/nimbusel/tasks/setup.yaml
+++ b/roles/nimbusel/tasks/setup.yaml
@@ -13,6 +13,7 @@
 
 - name: Set permissions
   ansible.builtin.command: "chown -R {{ nimbusel_user }}:{{ nimbusel_user }} {{ nimbusel_datadir }}" # noqa no-free-form
+  failed_when: false
   changed_when: false
 
 - name: Run nimbusel container

--- a/roles/prysm/tasks/setup.yaml
+++ b/roles/prysm/tasks/setup.yaml
@@ -16,6 +16,7 @@
 
     - name: Set permissions
       ansible.builtin.command: "chown -R {{ prysm_user }}:{{ prysm_user }} {{ prysm_datadir }}" # noqa no-free-form
+      failed_when: false
       changed_when: false
 
     - name: Run prysm container
@@ -57,6 +58,7 @@
 
     - name: Set permissions for validator data dir
       ansible.builtin.command: "chown -R {{ prysm_user }}:{{ prysm_user }} {{ prysm_validator_datadir }}" # noqa no-free-form
+      failed_when: false
       changed_when: false
 
     - name: Run prysm validator container

--- a/roles/reth/tasks/setup.yaml
+++ b/roles/reth/tasks/setup.yaml
@@ -13,6 +13,7 @@
 
 - name: Set permissions
   ansible.builtin.command: "chown -R {{ reth_user }}:{{ reth_user }} {{ reth_datadir }}" # noqa no-free-form
+  failed_when: false
   changed_when: false
 
 - name: Create rbuilder config file

--- a/roles/teku/tasks/setup.yaml
+++ b/roles/teku/tasks/setup.yaml
@@ -13,6 +13,7 @@
 
 - name: Set permissions
   ansible.builtin.command: "chown -R {{ teku_user }}:{{ teku_user }} {{ teku_datadir }}" # noqa no-free-form
+  failed_when: false
   changed_when: false
 
 - name: Create validator data dir
@@ -30,6 +31,7 @@
 
 - name: Set permissions for validator data dir
   ansible.builtin.command: "chown -R {{ teku_user }}:{{ teku_user }} {{ teku_validator_datadir }}" # noqa no-free-form
+  failed_when: false
   changed_when: false
   when: teku_validator_enabled
 


### PR DESCRIPTION
fixes https://github.com/ethpandaops/ansible-collection-general/issues/379 

Sometimes files get deleted by the running apps and chown will throw some errors. We can safely ignore those. 