### PR TITLE
Remove extra colon in dora helm chart values

### DIFF
--- a/roles/generate_kubernetes_config/templates/dora.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/dora.yaml.j2
@@ -32,7 +32,7 @@ dora:
       value: "true"
     - name: FRONTEND_SHOW_SENSITIVE_PEER_INFOS
       value: "true"
-    - name: API_ENABLED:
+    - name: API_ENABLED
       value: "true"
     - name: API_CORS_ORIGINS
       value: "*"


### PR DESCRIPTION
There PR removes an extra colon at the `API_ENABLED` env var of dora helm chart which causes issue when using the chart. 