### PR TITLE
fix(nimbusel): change data dir permissions to match nimbusel override

### DIFF
--- a/roles/nimbusel/tasks/setup.yaml
+++ b/roles/nimbusel/tasks/setup.yaml
@@ -7,7 +7,7 @@
   ansible.builtin.file:
     path: "{{ nimbusel_datadir }}"
     state: directory
-    mode: "0750"
+    mode: "0700"
     owner: "{{ nimbusel_user }}"
     group: "{{ nimbusel_user }}"
 


### PR DESCRIPTION
Our integration tests have been failing on the `idempotence` step when setting permissions for the nimbusel data dir. 

The reason for this is that nimbusel changes the permissions to 0700 when it starts up. I'm updating the permissions to match that.