### PR TITLE
fix(ethereum_node): fix condition for docker login in molecule tests

### DIFF
--- a/roles/ethereum_node/molecule/default/converge.yml
+++ b/roles/ethereum_node/molecule/default/converge.yml
@@ -24,7 +24,9 @@
           community.docker.docker_login:
             username: "{{ DOCKERHUB_USERNAME }}"
             password: "{{ DOCKERHUB_PASSWORD }}"
-          when: DOCKERHUB_USERNAME != '' and DOCKERHUB_PASSWORD != ''
+          when: >-
+            (DOCKERHUB_USERNAME != None and DOCKERHUB_USERNAME | length > 0) and
+            (DOCKERHUB_PASSWORD != None and DOCKERHUB_PASSWORD | length > 0)
         - name: Run ethereum node
           ansible.builtin.import_role:
             name: ethereum_node


### PR DESCRIPTION
It was matching the condition because the vars were "null" (Type `None`), thus doing docker login with empty user/password. 

And `None != ''`. matched.