### PR TITLE
Add docker group/groups to vouch role

### DIFF
--- a/roles/vouch/tasks/setup.yaml
+++ b/roles/vouch/tasks/setup.yaml
@@ -35,6 +35,7 @@
     networks: "{{ vouch_container_networks }}"
     entrypoint: "{{ vouch_container_entrypoint | default(omit) }}"
     command: "{{ vouch_container_command | default(omit) }}"
-    user: "{{ vouch_user_meta.uid }}"
+    user: "{{ vouch_user_meta.uid }}:{{ vouch_user_meta.group }}"
+    groups: "{{ vouch_container_groups | default(omit) }}"
     pull: "{{ vouch_container_pull | bool }}"
     security_opts: "{{ vouch_container_security_opts }}"


### PR DESCRIPTION
I need to get /etc/letsencrypt certificates into the container, so my playbook chowns them to a group that I can then assign to the container process user using <https://docs.ansible.com/ansible/latest/collections/community/docker/docker_container_module.html#parameter-groups>

While setting this up I noticed that the container user has gid 0, so I fixed that as well.