### PR TITLE
fix(snapshot_fetcher): remove fetching of block info and client version

### DIFF
--- a/roles/snapshot_fetcher/templates/download_snapshot.sh.j2
+++ b/roles/snapshot_fetcher/templates/download_snapshot.sh.j2
@@ -17,16 +17,6 @@ echo "Client: $CLIENT"
 echo "Target Block: $BLOCK"
 echo "================================"
 
-# Get block info
-echo "Fetching snapshot info for $NETWORK $CLIENT at block $BLOCK..."
-BLOCK_INFO=$(curl -s "$BASE_URL/$NETWORK/$CLIENT/$BLOCK/_snapshot_eth_getBlockByNumber.json")
-snapshot_fetcher_block=$(echo "$BLOCK_INFO" | jq -r '.result.number')
-CLIENT_VERSION=$(curl -s "$BASE_URL/$NETWORK/$CLIENT/$BLOCK/_snapshot_web3_clientVersion.json" | jq -r '.result')
-
-echo "Snapshot info:"
-echo "Block: $snapshot_fetcher_block"
-echo "Client: $CLIENT_VERSION"
-
 # Download and extract
 echo "Starting snapshot download container..."
 


### PR DESCRIPTION
Removed block info fetching and client version retrieval from snapshot download script.

Some manually pushed snapshots might not have those additional files to get versions. It's also not really needed when fetching snapshots. Just a nice to have info...