### PR TITLE
feat(bootstrap): add runlike as a pip package

### DIFF
--- a/roles/bootstrap/defaults/main.yml
+++ b/roles/bootstrap/defaults/main.yml
@@ -43,6 +43,9 @@ bootstrap_default_common_packages:
   - tree
   - smartmontools
 
+bootstrap_default_pip_packages:
+  - runlike
+
 bootstrap_ntp_enabled: true
 bootstrap_ntp_servers:
   # Generic

--- a/roles/bootstrap/tasks/main.yml
+++ b/roles/bootstrap/tasks/main.yml
@@ -167,6 +167,13 @@
     state: absent
   loop: "{{ bootstrap_python_system_version.python_system_path }}"
 
+# Install pip packages
+- name: Install pip packages
+  ansible.builtin.pip:
+    name: "{{ bootstrap_default_pip_packages }}"
+    state: present
+  when: bootstrap_default_pip_packages | length > 0
+
 # Reboot the machine if required
 - name: Check if reboot required
   ansible.builtin.stat:


### PR DESCRIPTION
## Summary
- Add pip package installation support to the bootstrap role
- Include `runlike` as a default pip package via `bootstrap_default_pip_packages`
- Task runs after EXTERNALLY-MANAGED file removal to ensure system-wide pip installs work

## Test plan
- [ ] Run bootstrap role on a target host and verify `runlike` is installed
- [ ] Verify the task is skipped when `bootstrap_default_pip_packages` is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)