### PR TITLE
Add vouch health checking

### DIFF
--- a/roles/vouch/defaults/main/main.yaml
+++ b/roles/vouch/defaults/main/main.yaml
@@ -10,10 +10,8 @@ vouch_container_name: "vouch"
 vouch_container_image: "attestant/vouch:latest"
 
 vouch_container_stop_timeout: "300"
-vouch_container_ports: []
 vouch_container_volumes:
   - "{{ vouch_config_dir }}:{{ vouch_config_dir }}:ro"
-vouch_container_networks: []
 vouch_container_command:
   - "--base-dir={{ vouch_config_dir }}"
 vouch_container_pull: false

--- a/roles/vouch/defaults/main/main.yaml
+++ b/roles/vouch/defaults/main/main.yaml
@@ -16,3 +16,9 @@ vouch_container_command:
   - "--base-dir={{ vouch_config_dir }}"
 vouch_container_pull: false
 vouch_container_security_opts: []
+
+vouch_healthcheck_image: "curlimages/curl:latest"
+vouch_disable_healthcheck: false
+vouch_healthcheck_retries: 10
+vouch_healthcheck_delay: 1
+vouch_healthcheck_timeout: 10

--- a/roles/vouch/tasks/setup.yaml
+++ b/roles/vouch/tasks/setup.yaml
@@ -29,10 +29,11 @@
     state: started
     restart_policy: always
     stop_timeout: "{{ vouch_container_stop_timeout }}"
+    network_mode: "{{ vouch_container_network_mode | default(omit) }}"
     ports: "{{ vouch_container_ports | default(omit) }}"
     volumes: "{{ vouch_container_volumes }}"
     env: "{{ vouch_container_env | default(omit) }}"
-    networks: "{{ vouch_container_networks }}"
+    networks: "{{ vouch_container_networks | default(omit) }}"
     entrypoint: "{{ vouch_container_entrypoint | default(omit) }}"
     command: "{{ vouch_container_command | default(omit) }}"
     user: "{{ vouch_user_meta.uid }}:{{ vouch_user_meta.group }}"

--- a/roles/vouch/tasks/setup.yaml
+++ b/roles/vouch/tasks/setup.yaml
@@ -55,7 +55,7 @@
     detach: false
     cleanup: true
     state: started
-    command: "curl -sf http://{{vouch_metrics.host }}:{{ vouch_metrics.port }}/metrics"
+    command: "curl -sf http://{{ vouch_metrics.host }}:{{ vouch_metrics.port }}/metrics"
   register: _vouch_metrics_curl_result
   until: _vouch_metrics_curl_result.status == 0 and (_vouch_metrics_curl_result.container.Output | regex_search('^vouch_ready.*1$', multiline=true) is not none)
   retries: "{{ vouch_healthcheck_retries }}"

--- a/roles/vouch/tasks/setup.yaml
+++ b/roles/vouch/tasks/setup.yaml
@@ -44,3 +44,22 @@
     dns_opts: "{{ vouch_container_dns_opts | default(omit) }}"
     dns_search_domains: "{{ vouch_container_dns_search_domains | default(omit) }}"
     hostname: "{{ vouch_container_hostname | default(omit) }}"
+  register: _vouch_container_result
+
+- name: Wait for vouch container to be healthy
+  community.docker.docker_container:
+    name: "{{ vouch_container_name }}_healthcheck"
+    image: "{{ vouch_healthcheck_image }}"
+    network_mode: "container:{{ vouch_container_name }}"
+    recreate: true
+    detach: false
+    cleanup: true
+    state: started
+    command: "curl -sf http://{{vouch_metrics.host }}:{{ vouch_metrics.port }}/metrics"
+  register: _vouch_metrics_curl_result
+  until: _vouch_metrics_curl_result.status == 0 and (_vouch_metrics_curl_result.container.Output | regex_search('^vouch_ready.*1$', multiline=true) is not none)
+  retries: "{{ vouch_healthcheck_retries }}"
+  delay: "{{ vouch_healthcheck_delay }}"
+  timeout: "{{ vouch_healthcheck_timeout }}"
+  changed_when: false
+  when: (vouch_disable_healthcheck is not true) and _vouch_container_result.changed


### PR DESCRIPTION
The vouch image doesn't contain curl, so adding a healthcheck to docker isn't straightforward. Instead, use a separate curl image to check the metrics endpoint, with a regex_search for `vouch_ready: 1`.

Tested locally using a `type: dir` collection dependency- negatively tested by changing the 1 to a 3 in the regex.

The second commit tidies up some default setting mistakes I made previously and enables vouch to be run in `network_mode: host` which I might need to do to get it to play nice with wireguard.