### PR TITLE
fix(ethereum_node_fact_discovery): correct ethrex node key path

### DIFF
--- a/roles/ethereum_node_fact_discovery/defaults/main.yaml
+++ b/roles/ethereum_node_fact_discovery/defaults/main.yaml
@@ -9,7 +9,7 @@ ethereum_node_fact_discovery_el_key_cmd:
   nethermind: xxd -p -c32 {{ nethermind_datadir | default('/data/nethermind') }}/keystore/node.key.plain
   reth: cat {{ reth_datadir | default('/data/reth') }}/discovery-secret
   nimbusel: cat {{ nimbusel_datadir | default('/data/nimbusel') }}/nodekey | cut -d 'x' -f2
-  ethrex: xxd -p -c32 {{ ethrex_datadir | default('/data/ethrex') }}/node.key
+  ethrex: xxd -p -c32 {{ ethrex_datadir | default('/data/ethrex') }}/chain-{{ ethereum_network_id | trim }}/node.key
 
 # How to find the EL enode on the target system
 ethereum_node_fact_discovery_el_enode_cmd:


### PR DESCRIPTION
## Summary
- ethrex stores its node key under `chain-<network_id>/node.key`, not directly in the datadir
- the default `ethereum_node_fact_discovery_el_key_cmd[ethrex]` was pointing at the wrong path, causing the `Get EL node key` task to fail with `xxd: /data/ethrex/node.key: No such file or directory`
- update the default command to include the `chain-{{ ethereum_network_id | trim }}` segment

## Test plan
- [ ] Run the `ethereum_node_fact_discovery` role against an ethrex node and confirm the `Get EL node key` task succeeds