### PR TITLE
feat(ethereum_node): add ethereum_node_gas_limit wrapper var

### DIFF
--- a/roles/besu/defaults/main.yaml
+++ b/roles/besu/defaults/main.yaml
@@ -79,5 +79,10 @@ besu_container_command: >-
 
 besu_container_command_extra_args: []
 
+# Optional block builder gas limit (in gas units). Empty string keeps the besu default.
+besu_gas_limit: ""
+besu_container_command_gas_limit_args: >-
+  {{ ['--target-gas-limit=' ~ (besu_gas_limit | string)] if (besu_gas_limit | string | length > 0) else [] }}
+
 # Default image pull policy
 besu_container_pull: false

--- a/roles/besu/tasks/setup.yaml
+++ b/roles/besu/tasks/setup.yaml
@@ -29,7 +29,7 @@
     env: "{{ besu_container_env }}"
     networks: "{{ besu_container_networks }}"
     entrypoint: "{{ besu_container_entrypoint | default(omit) }}"
-    command: "{{ besu_container_command + besu_container_command_extra_args }}"
+    command: "{{ besu_container_command + besu_container_command_gas_limit_args + besu_container_command_extra_args }}"
     user: "{{ besu_user_meta.uid }}"
     pull: "{{ besu_container_pull | bool }}"
     security_opts: "{{ besu_container_security_opts }}"

--- a/roles/erigon/defaults/main.yaml
+++ b/roles/erigon/defaults/main.yaml
@@ -85,6 +85,11 @@ erigon_container_command: >-
 erigon_container_command_extra_args: []
 #  - --prune=htc
 
+# Optional block builder gas limit (in gas units). Empty string keeps the erigon default.
+erigon_gas_limit: ""
+erigon_container_command_gas_limit_args: >-
+  {{ ['--miner.gaslimit=' ~ (erigon_gas_limit | string)] if (erigon_gas_limit | string | length > 0) else [] }}
+
 
 # Only required changing when running custom networks
 erigon_init_custom_network: false

--- a/roles/erigon/tasks/setup.yaml
+++ b/roles/erigon/tasks/setup.yaml
@@ -68,7 +68,7 @@
     env: "{{ erigon_container_env }}"
     networks: "{{ erigon_container_networks }}"
     entrypoint: "{{ erigon_container_entrypoint | default(omit) }}"
-    command: "{{ erigon_container_command + erigon_container_command_extra_args }}"
+    command: "{{ erigon_container_command + erigon_container_command_gas_limit_args + erigon_container_command_extra_args }}"
     user: "{{ erigon_user_meta.uid }}"
     pull: "{{ erigon_container_pull | bool }}"
     security_opts: "{{ erigon_container_security_opts }}"

--- a/roles/ethereum_node/defaults/main.yaml
+++ b/roles/ethereum_node/defaults/main.yaml
@@ -26,6 +26,11 @@ ethereum_node_cl_supernode_enabled: false
 
 ethereum_node_ipv6_enabled: false
 
+# Block builder / validator suggested gas limit (in gas units).
+# When set, the wrapper translates this into the correct per-client cli flag for
+# the active EL and CL. Leave empty to keep each client's built-in default.
+ethereum_node_gas_limit: ""
+
 # Public IPv6 — set per-role IPs to assign static IPv6 on the shared bridge
 ethereum_node_el_public_ipv6: ""
 ethereum_node_cl_public_ipv6: ""

--- a/roles/ethereum_node/tasks/setup_cl.yaml
+++ b/roles/ethereum_node/tasks/setup_cl.yaml
@@ -22,6 +22,7 @@
     lighthouse_ipv6_enabled: "{{ ethereum_node_ipv6_enabled }}"
     lighthouse_supernode_enabled: "{{ ethereum_node_cl_supernode_enabled }}"
     lighthouse_public_ipv6: "{{ ethereum_node_cl_public_ipv6 }}"
+    lighthouse_gas_limit: "{{ ethereum_node_gas_limit }}"
 
 - name: "Consensus client: teku"
   when: ethereum_node_cl == "teku"
@@ -45,6 +46,7 @@
     teku_ipv6_enabled: "{{ ethereum_node_ipv6_enabled }}"
     teku_supernode_enabled: "{{ ethereum_node_cl_supernode_enabled }}"
     teku_public_ipv6: "{{ ethereum_node_cl_public_ipv6 }}"
+    teku_gas_limit: "{{ ethereum_node_gas_limit }}"
 
 - name: "Consensus client: prysm"
   when: ethereum_node_cl == "prysm"
@@ -69,6 +71,7 @@
     prysm_ipv6_enabled: "{{ ethereum_node_ipv6_enabled }}"
     prysm_supernode_enabled: "{{ ethereum_node_cl_supernode_enabled }}"
     prysm_public_ipv6: "{{ ethereum_node_cl_public_ipv6 }}"
+    prysm_gas_limit: "{{ ethereum_node_gas_limit }}"
 
 - name: "Consensus client: lodestar"
   when: ethereum_node_cl == "lodestar"
@@ -93,6 +96,7 @@
     lodestar_ipv6_enabled: "{{ ethereum_node_ipv6_enabled }}"
     lodestar_supernode_enabled: "{{ ethereum_node_cl_supernode_enabled }}"
     lodestar_public_ipv6: "{{ ethereum_node_cl_public_ipv6 }}"
+    lodestar_gas_limit: "{{ ethereum_node_gas_limit }}"
 
 - name: "Consensus client: nimbus"
   when: ethereum_node_cl == "nimbus"
@@ -116,6 +120,7 @@
     nimbus_ipv6_enabled: "{{ ethereum_node_ipv6_enabled }}"
     nimbus_supernode_enabled: "{{ ethereum_node_cl_supernode_enabled }}"
     nimbus_public_ipv6: "{{ ethereum_node_cl_public_ipv6 }}"
+    nimbus_gas_limit: "{{ ethereum_node_gas_limit }}"
 
 - name: "Consensus client: grandine"
   when: ethereum_node_cl == "grandine"
@@ -139,3 +144,4 @@
     grandine_ipv6_enabled: "{{ ethereum_node_ipv6_enabled }}"
     grandine_supernode_enabled: "{{ ethereum_node_cl_supernode_enabled }}"
     grandine_public_ipv6: "{{ ethereum_node_cl_public_ipv6 }}"
+    grandine_gas_limit: "{{ ethereum_node_gas_limit }}"

--- a/roles/ethereum_node/tasks/setup_el.yaml
+++ b/roles/ethereum_node/tasks/setup_el.yaml
@@ -12,6 +12,7 @@
     besu_container_pull: "{{ ethereum_node_images_always_pull }}"
     besu_ipv6_enabled: "{{ ethereum_node_ipv6_enabled }}"
     besu_public_ipv6: "{{ ethereum_node_el_public_ipv6 }}"
+    besu_gas_limit: "{{ ethereum_node_gas_limit }}"
 
 - name: "Execution client: geth"
   when: ethereum_node_el == "geth"
@@ -27,6 +28,7 @@
     geth_container_pull: "{{ ethereum_node_images_always_pull }}"
     geth_ipv6_enabled: "{{ ethereum_node_ipv6_enabled }}"
     geth_public_ipv6: "{{ ethereum_node_el_public_ipv6 }}"
+    geth_gas_limit: "{{ ethereum_node_gas_limit }}"
 
 - name: "Execution client: erigon"
   when: ethereum_node_el == "erigon"
@@ -42,6 +44,7 @@
     erigon_container_pull: "{{ ethereum_node_images_always_pull }}"
     erigon_ipv6_enabled: "{{ ethereum_node_ipv6_enabled }}"
     erigon_public_ipv6: "{{ ethereum_node_el_public_ipv6 }}"
+    erigon_gas_limit: "{{ ethereum_node_gas_limit }}"
 
 - name: "Execution client: nethermind"
   when: ethereum_node_el == "nethermind"
@@ -57,6 +60,7 @@
     nethermind_container_pull: "{{ ethereum_node_images_always_pull }}"
     nethermind_ipv6_enabled: "{{ ethereum_node_ipv6_enabled }}"
     nethermind_public_ipv6: "{{ ethereum_node_el_public_ipv6 }}"
+    nethermind_gas_limit: "{{ ethereum_node_gas_limit }}"
 
 - name: "Execution client: ethereumjs"
   when: ethereum_node_el == "ethereumjs"
@@ -85,6 +89,7 @@
     reth_container_pull: "{{ ethereum_node_images_always_pull }}"
     reth_ipv6_enabled: "{{ ethereum_node_ipv6_enabled }}"
     reth_public_ipv6: "{{ ethereum_node_el_public_ipv6 }}"
+    reth_gas_limit: "{{ ethereum_node_gas_limit }}"
 
 - name: "Execution client: nimbusel"
   when: ethereum_node_el == "nimbusel"
@@ -100,6 +105,7 @@
     nimbusel_container_pull: "{{ ethereum_node_images_always_pull }}"
     nimbusel_ipv6_enabled: "{{ ethereum_node_ipv6_enabled }}"
     nimbusel_public_ipv6: "{{ ethereum_node_el_public_ipv6 }}"
+    nimbusel_gas_limit: "{{ ethereum_node_gas_limit }}"
 
 - name: "Execution client: ethrex"
   when: ethereum_node_el == "ethrex"
@@ -115,3 +121,4 @@
     ethrex_container_pull: "{{ ethereum_node_images_always_pull }}"
     ethrex_ipv6_enabled: "{{ ethereum_node_ipv6_enabled }}"
     ethrex_public_ipv6: "{{ ethereum_node_el_public_ipv6 }}"
+    ethrex_gas_limit: "{{ ethereum_node_gas_limit }}"

--- a/roles/ethrex/defaults/main.yaml
+++ b/roles/ethrex/defaults/main.yaml
@@ -64,5 +64,10 @@ ethrex_container_command: >-
 
 ethrex_container_command_extra_args: []
 
+# Optional block builder gas limit (in gas units). Empty string keeps the ethrex default.
+ethrex_gas_limit: ""
+ethrex_container_command_gas_limit_args: >-
+  {{ ['--builder.gas-limit=' ~ (ethrex_gas_limit | string)] if (ethrex_gas_limit | string | length > 0) else [] }}
+
 # Default image pull policy
 ethrex_container_pull: false

--- a/roles/ethrex/tasks/setup.yaml
+++ b/roles/ethrex/tasks/setup.yaml
@@ -29,7 +29,7 @@
     env: "{{ ethrex_container_env }}"
     networks: "{{ ethrex_container_networks }}"
     entrypoint: "{{ ethrex_container_entrypoint | default(omit) }}"
-    command: "{{ ethrex_container_command + ethrex_container_command_extra_args }}"
+    command: "{{ ethrex_container_command + ethrex_container_command_gas_limit_args + ethrex_container_command_extra_args }}"
     user: "{{ ethrex_user_meta.uid }}"
     pull: "{{ ethrex_container_pull | bool }}"
     security_opts: "{{ ethrex_container_security_opts }}"

--- a/roles/geth/defaults/main.yaml
+++ b/roles/geth/defaults/main.yaml
@@ -81,6 +81,11 @@ geth_container_command_extra_args: []
 #  - --http.api=eth,net,web3
 #  - --http.vhosts=*
 
+# Optional block builder gas limit (in gas units). Empty string keeps the geth default.
+geth_gas_limit: ""
+geth_container_command_gas_limit_args: >-
+  {{ ['--miner.gaslimit=' ~ (geth_gas_limit | string)] if (geth_gas_limit | string | length > 0) else [] }}
+
 # Only required changing when running custom networks
 geth_init_custom_network: false
 geth_init_autoremove_enabled: false

--- a/roles/geth/tasks/setup.yaml
+++ b/roles/geth/tasks/setup.yaml
@@ -54,7 +54,7 @@
     env: "{{ geth_container_env }}"
     networks: "{{ geth_container_networks }}"
     entrypoint: "{{ geth_container_entrypoint | default(omit) }}"
-    command: "{{ geth_container_command + geth_container_command_extra_args }}"
+    command: "{{ geth_container_command + geth_container_command_gas_limit_args + geth_container_command_extra_args }}"
     user: "{{ geth_user_meta.uid }}"
     pull: "{{ geth_container_pull | bool }}"
     security_opts: "{{ geth_container_security_opts }}"

--- a/roles/grandine/defaults/main.yaml
+++ b/roles/grandine/defaults/main.yaml
@@ -116,6 +116,11 @@ grandine_container_command_extra_args: []
 # - --network=mainnet
 # - --graffiti=hello-world
 
+# Optional validator suggested gas limit (in gas units). Empty string keeps the grandine default.
+grandine_gas_limit: ""
+grandine_container_command_gas_limit_args: >-
+  {{ ['--default-gas-limit=' ~ (grandine_gas_limit | string)] if (grandine_gas_limit | string | length > 0) else [] }}
+
 checkpoint_sync_url: https://beaconstate.ethstaker.cc # noqa var-naming[no-role-prefix]
 grandine_checkpoint_sync_enabled: true
 grandine_container_command_checkpoint_args:

--- a/roles/grandine/tasks/setup.yaml
+++ b/roles/grandine/tasks/setup.yaml
@@ -54,6 +54,7 @@
         (grandine_validator_enabled | ternary(grandine_container_validator_args +
           (grandine_mev_boost_enabled | ternary(grandine_mev_boost_beacon_command,[])),
         [])) +
+        grandine_container_command_gas_limit_args +
         (grandine_checkpoint_sync_enabled | ternary(
           grandine_container_command_extra_args + grandine_container_command_checkpoint_args,
           grandine_container_command_extra_args

--- a/roles/lighthouse/defaults/main.yaml
+++ b/roles/lighthouse/defaults/main.yaml
@@ -168,6 +168,11 @@ lighthouse_validator_container_command_extra_args: []
   # - --http-port=5062
   # - --graffiti=hello-world
 
+# Optional validator suggested gas limit (in gas units). Empty string keeps the lighthouse default.
+lighthouse_gas_limit: ""
+lighthouse_validator_container_command_gas_limit_args: >-
+  {{ ['--gas-limit=' ~ (lighthouse_gas_limit | string)] if (lighthouse_gas_limit | string | length > 0) else [] }}
+
 # Default image pull policy
 lighthouse_container_pull: false
 

--- a/roles/lighthouse/tasks/setup.yaml
+++ b/roles/lighthouse/tasks/setup.yaml
@@ -91,6 +91,7 @@
         command: >-
           {{
             lighthouse_validator_container_command +
+            lighthouse_validator_container_command_gas_limit_args +
             lighthouse_validator_container_command_extra_args +
             (lighthouse_mev_boost_enabled | ternary(lighthouse_mev_boost_validator_command, []))
           }}

--- a/roles/lodestar/defaults/main.yaml
+++ b/roles/lodestar/defaults/main.yaml
@@ -152,6 +152,11 @@ lodestar_validator_container_command_extra_args: []
   # - --builder
   # - --graffiti=hello-world
 
+# Optional validator suggested gas limit (in gas units). Empty string keeps the lodestar default.
+lodestar_gas_limit: ""
+lodestar_validator_container_command_gas_limit_args: >-
+  {{ ['--defaultGasLimit=' ~ (lodestar_gas_limit | string)] if (lodestar_gas_limit | string | length > 0) else [] }}
+
 # Default image pull policy
 lodestar_container_pull: false
 

--- a/roles/lodestar/tasks/setup.yaml
+++ b/roles/lodestar/tasks/setup.yaml
@@ -91,6 +91,7 @@
         command: >-
           {{
             lodestar_validator_container_command +
+            lodestar_validator_container_command_gas_limit_args +
             lodestar_validator_container_command_extra_args +
             (lodestar_mev_boost_enabled | ternary(lodestar_mev_boost_validator_command, []))
           }}

--- a/roles/nethermind/defaults/main.yaml
+++ b/roles/nethermind/defaults/main.yaml
@@ -83,5 +83,10 @@ nethermind_container_command: >-
 
 nethermind_container_command_extra_args: []
 
+# Optional block builder gas limit (in gas units). Empty string keeps the nethermind default.
+nethermind_gas_limit: ""
+nethermind_container_command_gas_limit_args: >-
+  {{ ['--Blocks.TargetBlockGasLimit=' ~ (nethermind_gas_limit | string)] if (nethermind_gas_limit | string | length > 0) else [] }}
+
 # Default image pull policy
 nethermind_container_pull: false

--- a/roles/nethermind/tasks/setup.yaml
+++ b/roles/nethermind/tasks/setup.yaml
@@ -32,7 +32,7 @@
     env: "{{ nethermind_container_env }}"
     networks: "{{ nethermind_container_networks }}"
     entrypoint: "{{ nethermind_container_entrypoint | default(omit) }}"
-    command: "{{ nethermind_container_command + nethermind_container_command_extra_args }}"
+    command: "{{ nethermind_container_command + nethermind_container_command_gas_limit_args + nethermind_container_command_extra_args }}"
     user: "{{ nethermind_user_meta.uid }}"
     pull: "{{ nethermind_container_pull | bool }}"
     security_opts: "{{ nethermind_container_security_opts }}"

--- a/roles/nimbus/defaults/main.yaml
+++ b/roles/nimbus/defaults/main.yaml
@@ -121,6 +121,11 @@ nimbus_container_command: >-
 nimbus_container_command_extra_args: []
   # - --graffiti=hello-world
 
+# Optional validator suggested gas limit (in gas units). Empty string keeps the nimbus default.
+nimbus_gas_limit: ""
+nimbus_container_command_gas_limit_args: >-
+  {{ ['--suggested-gas-limit=' ~ (nimbus_gas_limit | string)] if (nimbus_gas_limit | string | length > 0) else [] }}
+
 ################################################################################
 ##
 ## Validator specific configuration
@@ -141,6 +146,7 @@ nimbus_validator_container_command: >-
     ] +
     nimbus_validator_container_args +
     nimbus_container_command_metrics +
+    nimbus_container_command_gas_limit_args +
     nimbus_container_command_extra_args
   }}
 

--- a/roles/nimbus/tasks/setup.yaml
+++ b/roles/nimbus/tasks/setup.yaml
@@ -76,9 +76,10 @@
     command: >-
       {{
         nimbus_validator_enabled | ternary(
-          nimbus_container_command + nimbus_validator_container_args + nimbus_container_command_extra_args +
+          nimbus_container_command + nimbus_validator_container_args +
+          nimbus_container_command_gas_limit_args + nimbus_container_command_extra_args +
           (nimbus_mev_boost_enabled | ternary(nimbus_mev_boost_beacon_command, [])),
-          nimbus_container_command + nimbus_container_command_extra_args,
+          nimbus_container_command + nimbus_container_command_gas_limit_args + nimbus_container_command_extra_args,
         )
       }}
     user: "{{ nimbus_user_meta.uid }}"

--- a/roles/nimbusel/defaults/main.yaml
+++ b/roles/nimbusel/defaults/main.yaml
@@ -88,5 +88,10 @@ nimbusel_container_command_extra_args: []
 #  - --rpc-api=eth,debug
 #  - --http.vhosts=*
 
+# Optional block builder gas limit (in gas units). Empty string keeps the nimbus-eth1 default.
+nimbusel_gas_limit: ""
+nimbusel_container_command_gas_limit_args: >-
+  {{ ['--gas-limit=' ~ (nimbusel_gas_limit | string)] if (nimbusel_gas_limit | string | length > 0) else [] }}
+
 # Default image pull policy
 nimbusel_container_pull: false

--- a/roles/nimbusel/tasks/setup.yaml
+++ b/roles/nimbusel/tasks/setup.yaml
@@ -29,7 +29,7 @@
     env: "{{ nimbusel_container_env }}"
     networks: "{{ nimbusel_container_networks }}"
     entrypoint: "{{ nimbusel_container_entrypoint | default(omit) }}"
-    command: "{{ nimbusel_container_command + nimbusel_container_command_extra_args }}"
+    command: "{{ nimbusel_container_command + nimbusel_container_command_gas_limit_args + nimbusel_container_command_extra_args }}"
     user: "{{ nimbusel_user_meta.uid }}"
     pull: "{{ nimbusel_container_pull | bool }}"
     security_opts: "{{ nimbusel_container_security_opts }}"

--- a/roles/prysm/defaults/main.yaml
+++ b/roles/prysm/defaults/main.yaml
@@ -162,6 +162,11 @@ prysm_validator_container_command:
 prysm_validator_container_command_extra_args: []
   # - --graffiti=hello-world
 
+# Optional validator suggested gas limit (in gas units). Empty string keeps the prysm default.
+prysm_gas_limit: ""
+prysm_validator_container_command_gas_limit_args: >-
+  {{ ['--suggested-gas-limit=' ~ (prysm_gas_limit | string)] if (prysm_gas_limit | string | length > 0) else [] }}
+
 # Default image pull policy
 prysm_container_pull: false
 

--- a/roles/prysm/tasks/setup.yaml
+++ b/roles/prysm/tasks/setup.yaml
@@ -89,6 +89,7 @@
         command: >-
           {{
             prysm_validator_container_command +
+            prysm_validator_container_command_gas_limit_args +
             prysm_validator_container_command_extra_args +
             (prysm_mev_boost_enabled | ternary(prysm_mev_boost_validator_command, []))
           }}

--- a/roles/reth/defaults/main.yaml
+++ b/roles/reth/defaults/main.yaml
@@ -84,6 +84,11 @@ reth_container_command_extra_args: []
 #  - --http.api=eth,net,web3
 #  - --http.vhosts=*
 
+# Optional block builder gas limit (in gas units). Empty string keeps the reth default.
+reth_gas_limit: ""
+reth_container_command_gas_limit_args: >-
+  {{ ['--builder.gaslimit=' ~ (reth_gas_limit | string)] if (reth_gas_limit | string | length > 0) else [] }}
+
 # Default image pull policy
 reth_container_pull: false
 

--- a/roles/reth/tasks/setup.yaml
+++ b/roles/reth/tasks/setup.yaml
@@ -45,7 +45,7 @@
     entrypoint: "{{ reth_container_entrypoint | default(omit) }}"
     command: >-
       {{
-        reth_container_command + reth_container_command_extra_args +
+        reth_container_command + reth_container_command_gas_limit_args + reth_container_command_extra_args +
         (reth_rbuilder_enabled | ternary(reth_rbuilder_container_args, []))
       }}
     user: "{{ reth_user_meta.uid }}"

--- a/roles/teku/defaults/main.yaml
+++ b/roles/teku/defaults/main.yaml
@@ -109,6 +109,11 @@ teku_container_command_extra_args:
 # - --logging=INFO
 # - ---validators-graffiti=hello-world
 
+# Optional validator builder-registration gas limit (in gas units). Empty string keeps the teku default.
+teku_gas_limit: ""
+teku_container_command_gas_limit_args: >-
+  {{ ['--validators-builder-registration-default-gas-limit=' ~ (teku_gas_limit | string)] if (teku_gas_limit | string | length > 0) else [] }}
+
 checkpoint_sync_url: https://beaconstate.ethstaker.cc # noqa var-naming[no-role-prefix]
 teku_checkpoint_sync_enabled: true
 teku_container_command_checkpoint_args:
@@ -136,6 +141,7 @@ teku_validator_container_command: >-
     ] +
     teku_validator_container_args +
     teku_container_command_metrics +
+    teku_container_command_gas_limit_args +
     teku_container_command_extra_args
   }}
 

--- a/roles/teku/tasks/setup.yaml
+++ b/roles/teku/tasks/setup.yaml
@@ -52,6 +52,7 @@
     command: >-
       {{
         teku_container_command +
+        teku_container_command_gas_limit_args +
         teku_container_command_extra_args +
         (teku_validator_enabled | ternary(teku_validator_container_args, [])) +
         (teku_checkpoint_sync_enabled | ternary(teku_container_command_checkpoint_args, [])) +


### PR DESCRIPTION
## Summary
- Add `ethereum_node_gas_limit` to the `ethereum_node` role so the block builder / validator suggested gas limit can be set in one place; the wrapper translates it into the correct per-client CLI flag for every supported EL and CL.
- Add a matching `<client>_gas_limit` variable to each EL/CL role so the flag can also be set directly when the wrapper is not in use. Empty string preserves the client default.

Inventories using glamsterdam devnet-3 currently set the gas limit nine times (once per client) — `--miner.gaslimit=`, `--target-gas-limit=`, `--Blocks.TargetBlockGasLimit=`, `--builder.gaslimit=`, `--builder.gas-limit=`, `--gas-limit=`, `--defaultGasLimit=`, `--suggested-gas-limit=`, `--default-gas-limit=`, `--validators-builder-registration-default-gas-limit=`. After this change the inventory only needs `ethereum_node_gas_limit: 150000000`.

## Mapping (applied when `ethereum_node_gas_limit` is non-empty)
| Client | Flag | Where |
|---|---|---|
| geth, erigon | `--miner.gaslimit=N` | EL command |
| besu | `--target-gas-limit=N` | EL command |
| nethermind | `--Blocks.TargetBlockGasLimit=N` | EL command |
| reth | `--builder.gaslimit=N` | EL command |
| ethrex | `--builder.gas-limit=N` | EL command |
| nimbusel | `--gas-limit=N` | EL command |
| lighthouse | `--gas-limit=N` | validator |
| prysm | `--suggested-gas-limit=N` | validator |
| lodestar | `--defaultGasLimit=N` | validator |
| teku | `--validators-builder-registration-default-gas-limit=N` | BN + standalone VC |
| nimbus | `--suggested-gas-limit=N` | BN + standalone VC |
| grandine | `--default-gas-limit=N` | unified BN |

`ethereumjs` has no equivalent flag in its CLI, so it is intentionally not wired up.

## Usage
```yaml
- role: ethpandaops.general.ethereum_node
  ethereum_node_el: geth
  ethereum_node_cl: lighthouse
  ethereum_node_gas_limit: 150000000
```

Or directly on a single client role:
```yaml
- role: ethpandaops.general.geth
  geth_gas_limit: 150000000
```

## Test plan
- [ ] Apply on a devnet host with each EL (geth, besu, erigon, nethermind, reth, ethrex, nimbusel) and confirm the gas-limit flag appears in `docker inspect` for the client container.
- [ ] Apply with each CL (lighthouse, prysm, lodestar, teku, nimbus, grandine) and confirm the flag is on the validator container (or the unified BN container for teku/nimbus/grandine).
- [ ] Confirm leaving `ethereum_node_gas_limit` empty does not add any gas-limit flag to any client.
- [ ] Sanity-check on glamsterdam devnet-3 by replacing the per-client `*_container_command_extra_args` overrides with a single `ethereum_node_gas_limit: 150000000` in `all/all.yaml`.