### PR TITLE
add otelcol_contrib role

### DIFF
--- a/roles/otelcol_contrib/README.md
+++ b/roles/otelcol_contrib/README.md
@@ -10,11 +10,11 @@ You'll need docker on the target system. Make sure to install it upfront.
 
 Default variables are defined in [defaults/main.yaml](defaults/main.yaml). The most useful ones:
 
-- `otelcol_config` — the full collector YAML config (templated as a string)
-- `otelcol_container_image` — image and tag (defaults to a pinned `otel/opentelemetry-collector-contrib` version)
-- `otelcol_container_networks` — docker networks to attach to (useful when other containers need to push OTLP to the collector by name)
-- `otelcol_container_user` — UID:GID to run as. Defaults to `"0:0"` (root) so the filelog receiver can read root-owned container log files. Set to a non-root UID/GID if your host setup permits.
-- `otelcol_container_volumes` — defaults mount the collector config, `/var/lib/docker/containers` (read-only, for the `filelog` receiver) and the docker socket.
+- `otelcol_contrib_config` — the full collector YAML config (templated as a string)
+- `otelcol_contrib_container_image` — image and tag (defaults to a pinned `otel/opentelemetry-collector-contrib` version)
+- `otelcol_contrib_container_networks` — docker networks to attach to (useful when other containers need to push OTLP to the collector by name)
+- `otelcol_contrib_container_user` — UID:GID to run as. Defaults to `"0:0"` (root) so the filelog receiver can read root-owned container log files. Set to a non-root UID/GID if your host setup permits.
+- `otelcol_contrib_container_volumes` — defaults mount the collector config, `/var/lib/docker/containers` (read-only, for the `filelog` receiver) and the docker socket.
 
 ## Dependencies
 
@@ -40,7 +40,7 @@ roles:
     - name: docker
   - role: ethpandaops.general.otelcol_contrib
     vars:
-      otelcol_config: |
+      otelcol_contrib_config: |
         receivers:
           filelog:
             include: [/var/lib/docker/containers/*/*-json.log]

--- a/roles/otelcol_contrib/README.md
+++ b/roles/otelcol_contrib/README.md
@@ -1,0 +1,61 @@
+# ethpandaops.general.otelcol_contrib
+
+This role runs [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) inside a docker container.
+
+## Requirements
+
+You'll need docker on the target system. Make sure to install it upfront.
+
+## Role Variables
+
+Default variables are defined in [defaults/main.yaml](defaults/main.yaml). The most useful ones:
+
+- `otelcol_config` — the full collector YAML config (templated as a string)
+- `otelcol_container_image` — image and tag (defaults to a pinned `otel/opentelemetry-collector-contrib` version)
+- `otelcol_container_networks` — docker networks to attach to (useful when other containers need to push OTLP to the collector by name)
+- `otelcol_container_user` — UID:GID to run as. Defaults to `"0:0"` (root) so the filelog receiver can read root-owned container log files. Set to a non-root UID/GID if your host setup permits.
+- `otelcol_container_volumes` — defaults mount the collector config, `/var/lib/docker/containers` (read-only, for the `filelog` receiver) and the docker socket.
+
+## Dependencies
+
+You'll need docker to run this role. One way of installing docker could be via ansible galaxy with the following dependencies set within `requirements.yaml`:
+
+```yaml
+roles:
+- src: geerlingguy.docker
+  version: latest
+- src: geerlingguy.pip
+  version: latest
+```
+
+## Example Playbook
+
+```yaml
+- hosts: localhost
+  become: true
+  roles:
+  - role: geerlingguy.docker
+  - role: geerlingguy.pip
+    pip_install_packages:
+    - name: docker
+  - role: ethpandaops.general.otelcol_contrib
+    vars:
+      otelcol_config: |
+        receivers:
+          filelog:
+            include: [/var/lib/docker/containers/*/*-json.log]
+            include_file_path: true
+            start_at: end
+            operators:
+              - type: container
+                format: docker
+                add_metadata_from_filepath: true
+        exporters:
+          otlphttp:
+            endpoint: https://otlp.example.com
+        service:
+          pipelines:
+            logs:
+              receivers: [filelog]
+              exporters: [otlphttp]
+```

--- a/roles/otelcol_contrib/defaults/main.yaml
+++ b/roles/otelcol_contrib/defaults/main.yaml
@@ -2,7 +2,7 @@ otelcol_datadir: /data/otelcol
 
 otelcol_cleanup: false
 
-otelcol_container_image: otel/opentelemetry-collector-contrib:0.151.0
+otelcol_container_image: otel/opentelemetry-collector-contrib:0.152.0
 otelcol_container_name: otelcol
 otelcol_container_command: ["--config", "/etc/otelcol/config.yaml"]
 otelcol_container_ports: []

--- a/roles/otelcol_contrib/defaults/main.yaml
+++ b/roles/otelcol_contrib/defaults/main.yaml
@@ -1,23 +1,23 @@
-otelcol_datadir: /data/otelcol
+otelcol_contrib_datadir: /data/otelcol
 
-otelcol_cleanup: false
+otelcol_contrib_cleanup: false
 
-otelcol_container_image: otel/opentelemetry-collector-contrib:0.152.0
-otelcol_container_name: otelcol
-otelcol_container_command: ["--config", "/etc/otelcol/config.yaml"]
-otelcol_container_ports: []
-otelcol_container_restart_policy: always
-otelcol_container_networks: []
-otelcol_container_volumes:
-  - "{{ otelcol_datadir }}/config.yaml:/etc/otelcol/config.yaml:ro"
+otelcol_contrib_container_image: otel/opentelemetry-collector-contrib:0.152.0
+otelcol_contrib_container_name: otelcol
+otelcol_contrib_container_command: ["--config", "/etc/otelcol/config.yaml"]
+otelcol_contrib_container_ports: []
+otelcol_contrib_container_restart_policy: always
+otelcol_contrib_container_networks: []
+otelcol_contrib_container_volumes:
+  - "{{ otelcol_contrib_datadir }}/config.yaml:/etc/otelcol/config.yaml:ro"
   - "/var/lib/docker/containers:/var/lib/docker/containers:ro"
   - "/var/run/docker.sock:/var/run/docker.sock:ro"
-otelcol_container_env: {}
+otelcol_contrib_container_env: {}
 
 # Run as root by default so the filelog receiver can read root-owned
 # /var/lib/docker/containers/*.log files. Override to a non-root UID/GID
 # (e.g. "1000:999") if your host setup makes those paths readable to a
 # specific user/group.
-otelcol_container_user: "0:0"
+otelcol_contrib_container_user: "0:0"
 
-otelcol_config: ""
+otelcol_contrib_config: ""

--- a/roles/otelcol_contrib/defaults/main.yaml
+++ b/roles/otelcol_contrib/defaults/main.yaml
@@ -1,0 +1,23 @@
+otelcol_datadir: /data/otelcol
+
+otelcol_cleanup: false
+
+otelcol_container_image: otel/opentelemetry-collector-contrib:0.151.0
+otelcol_container_name: otelcol
+otelcol_container_command: ["--config", "/etc/otelcol/config.yaml"]
+otelcol_container_ports: []
+otelcol_container_restart_policy: always
+otelcol_container_networks: []
+otelcol_container_volumes:
+  - "{{ otelcol_datadir }}/config.yaml:/etc/otelcol/config.yaml:ro"
+  - "/var/lib/docker/containers:/var/lib/docker/containers:ro"
+  - "/var/run/docker.sock:/var/run/docker.sock:ro"
+otelcol_container_env: {}
+
+# Run as root by default so the filelog receiver can read root-owned
+# /var/lib/docker/containers/*.log files. Override to a non-root UID/GID
+# (e.g. "1000:999") if your host setup makes those paths readable to a
+# specific user/group.
+otelcol_container_user: "0:0"
+
+otelcol_config: ""

--- a/roles/otelcol_contrib/handlers/main.yaml
+++ b/roles/otelcol_contrib/handlers/main.yaml
@@ -1,5 +1,5 @@
 - name: Restart otelcol container
-  community.general.docker_container:
+  community.docker.docker_container:
     name: "{{ otelcol_container_name }}"
     state: started
     restart: true

--- a/roles/otelcol_contrib/handlers/main.yaml
+++ b/roles/otelcol_contrib/handlers/main.yaml
@@ -1,0 +1,5 @@
+- name: Restart otelcol container
+  community.general.docker_container:
+    name: "{{ otelcol_container_name }}"
+    state: started
+    restart: true

--- a/roles/otelcol_contrib/handlers/main.yaml
+++ b/roles/otelcol_contrib/handlers/main.yaml
@@ -1,5 +1,5 @@
 - name: Restart otelcol container
   community.docker.docker_container:
-    name: "{{ otelcol_container_name }}"
+    name: "{{ otelcol_contrib_container_name }}"
     state: started
     restart: true

--- a/roles/otelcol_contrib/tasks/cleanup.yaml
+++ b/roles/otelcol_contrib/tasks/cleanup.yaml
@@ -1,4 +1,4 @@
 - name: Stop otelcol container
-  community.general.docker_container:
+  community.docker.docker_container:
     name: "{{ otelcol_container_name }}"
     state: absent

--- a/roles/otelcol_contrib/tasks/cleanup.yaml
+++ b/roles/otelcol_contrib/tasks/cleanup.yaml
@@ -1,4 +1,4 @@
 - name: Stop otelcol container
   community.docker.docker_container:
-    name: "{{ otelcol_container_name }}"
+    name: "{{ otelcol_contrib_container_name }}"
     state: absent

--- a/roles/otelcol_contrib/tasks/cleanup.yaml
+++ b/roles/otelcol_contrib/tasks/cleanup.yaml
@@ -1,0 +1,4 @@
+- name: Stop otelcol container
+  community.general.docker_container:
+    name: "{{ otelcol_container_name }}"
+    state: absent

--- a/roles/otelcol_contrib/tasks/main.yaml
+++ b/roles/otelcol_contrib/tasks/main.yaml
@@ -1,0 +1,7 @@
+- name: Setup otelcol
+  ansible.builtin.import_tasks: setup.yaml
+  when: not otelcol_cleanup
+
+- name: Cleanup otelcol
+  ansible.builtin.import_tasks: cleanup.yaml
+  when: otelcol_cleanup

--- a/roles/otelcol_contrib/tasks/main.yaml
+++ b/roles/otelcol_contrib/tasks/main.yaml
@@ -1,7 +1,7 @@
 - name: Setup otelcol
   ansible.builtin.import_tasks: setup.yaml
-  when: not otelcol_cleanup
+  when: not otelcol_contrib_cleanup
 
 - name: Cleanup otelcol
   ansible.builtin.import_tasks: cleanup.yaml
-  when: otelcol_cleanup
+  when: otelcol_contrib_cleanup

--- a/roles/otelcol_contrib/tasks/setup.yaml
+++ b/roles/otelcol_contrib/tasks/setup.yaml
@@ -1,25 +1,25 @@
 - name: Create required directories
   ansible.builtin.file:
-    path: "{{ otelcol_datadir }}"
+    path: "{{ otelcol_contrib_datadir }}"
     state: directory
     mode: "0755"
 
 - name: Create otelcol config
   ansible.builtin.copy:
-    content: "{{ otelcol_config }}"
-    dest: "{{ otelcol_datadir }}/config.yaml"
+    content: "{{ otelcol_contrib_config }}"
+    dest: "{{ otelcol_contrib_datadir }}/config.yaml"
     mode: '0644'
   notify: Restart otelcol container
 
 - name: Run otelcol container
   community.docker.docker_container:
-    name: "{{ otelcol_container_name }}"
-    image: "{{ otelcol_container_image }}"
+    name: "{{ otelcol_contrib_container_name }}"
+    image: "{{ otelcol_contrib_container_image }}"
     image_name_mismatch: recreate
-    command: "{{ otelcol_container_command }}"
-    ports: "{{ otelcol_container_ports }}"
-    restart_policy: "{{ otelcol_container_restart_policy }}"
-    networks: "{{ otelcol_container_networks }}"
-    volumes: "{{ otelcol_container_volumes }}"
-    env: "{{ otelcol_container_env }}"
-    user: "{{ otelcol_container_user }}"
+    command: "{{ otelcol_contrib_container_command }}"
+    ports: "{{ otelcol_contrib_container_ports }}"
+    restart_policy: "{{ otelcol_contrib_container_restart_policy }}"
+    networks: "{{ otelcol_contrib_container_networks }}"
+    volumes: "{{ otelcol_contrib_container_volumes }}"
+    env: "{{ otelcol_contrib_container_env }}"
+    user: "{{ otelcol_contrib_container_user }}"

--- a/roles/otelcol_contrib/tasks/setup.yaml
+++ b/roles/otelcol_contrib/tasks/setup.yaml
@@ -1,0 +1,25 @@
+- name: Create required directories
+  ansible.builtin.file:
+    path: "{{ otelcol_datadir }}"
+    state: directory
+    mode: "0755"
+
+- name: Create otelcol config
+  ansible.builtin.copy:
+    content: "{{ otelcol_config }}"
+    dest: "{{ otelcol_datadir }}/config.yaml"
+    mode: '0644'
+  notify: Restart otelcol container
+
+- name: Run otelcol container
+  community.general.docker_container:
+    name: "{{ otelcol_container_name }}"
+    image: "{{ otelcol_container_image }}"
+    image_name_mismatch: recreate
+    command: "{{ otelcol_container_command }}"
+    ports: "{{ otelcol_container_ports }}"
+    restart_policy: "{{ otelcol_container_restart_policy }}"
+    networks: "{{ otelcol_container_networks }}"
+    volumes: "{{ otelcol_container_volumes }}"
+    env: "{{ otelcol_container_env }}"
+    user: "{{ otelcol_container_user }}"

--- a/roles/otelcol_contrib/tasks/setup.yaml
+++ b/roles/otelcol_contrib/tasks/setup.yaml
@@ -12,7 +12,7 @@
   notify: Restart otelcol container
 
 - name: Run otelcol container
-  community.general.docker_container:
+  community.docker.docker_container:
     name: "{{ otelcol_container_name }}"
     image: "{{ otelcol_container_image }}"
     image_name_mismatch: recreate


### PR DESCRIPTION
Adds a new role for running `opentelemetry-collector-contrib` in a docker container, mirroring the existing vector role pattern. Templated YAML config via `otelcol_config`. Defaults mount `/var/lib/docker/containers` and the docker socket for the `filelog` / `dockerstats` receivers; runs as root by default so filelog can read root-owned container log files (configurable via `otelcol_container_user`).