### PR TITLE
feat(otelcol_contrib): docker log collection with per-container metadata

### DIFF
--- a/roles/otelcol_contrib/README.md
+++ b/roles/otelcol_contrib/README.md
@@ -16,6 +16,40 @@ Default variables are defined in [defaults/main.yaml](defaults/main.yaml). The m
 - `otelcol_contrib_container_user` — UID:GID to run as. Defaults to `"0:0"` (root) so the filelog receiver can read root-owned container log files. Set to a non-root UID/GID if your host setup permits.
 - `otelcol_contrib_container_volumes` — defaults mount the collector config, `/var/lib/docker/containers` (read-only, for the `filelog` receiver) and the docker socket.
 
+### Docker log collection with per-container metadata
+
+A plain `filelog` receiver tailing `/var/lib/docker/containers/*/*-json.log` only knows the container **id** (the path) — it can't tell you the container name, image or labels. Those live in the Docker daemon, and the role already mounts the socket. The role ships ready-made building blocks that read that metadata live (no container restarts, no log-driver changes):
+
+- `otelcol_contrib_docker_observer` — the `docker_observer` extension that discovers containers via the socket.
+- `otelcol_contrib_docker_logs_receiver` — a `receiver_creator/docker` that spawns one `filelog` receiver per container, attaching `container.name`, `container.image.name` and `container.id` as resource attributes, parsing the docker json format and mapping the json `level` field to severity. New containers are picked up automatically.
+- `otelcol_contrib_docker_logs_excluded_names` — list of container-name regex fragments to skip (defaults to just the collector's own container; add your own sidecars/tooling).
+
+Interpolate them into your `otelcol_contrib_config` and add `receiver_creator/docker` to the logs pipeline:
+
+```yaml
+otelcol_contrib_config: |
+  extensions:
+{{ otelcol_contrib_docker_observer | to_nice_yaml(indent=2, width=1000) | indent(4, True) }}
+  receivers:
+{{ otelcol_contrib_docker_logs_receiver | to_nice_yaml(indent=2, width=1000) | indent(4, True) }}
+  processors:
+    resource:
+      attributes:
+        # ...any host-level attributes you want on every log (env, region, ...)...
+        - {key: deployment.environment, value: "production", action: upsert}
+  exporters:
+    otlphttp: { endpoint: "https://otlp.example.com" }
+  service:
+    extensions: [docker_observer]
+    pipelines:
+      logs:
+        receivers: [receiver_creator/docker]
+        processors: [resource]
+        exporters: [otlphttp]
+```
+
+Per-container `container.name` / `container.image.name` / `container.id` come from the Docker socket; any host-level identity is added via the `resource` processor in your own config.
+
 ## Dependencies
 
 You'll need docker to run this role. One way of installing docker could be via ansible galaxy with the following dependencies set within `requirements.yaml`:

--- a/roles/otelcol_contrib/defaults/main.yaml
+++ b/roles/otelcol_contrib/defaults/main.yaml
@@ -21,3 +21,63 @@ otelcol_contrib_container_env: {}
 otelcol_contrib_container_user: "0:0"
 
 otelcol_contrib_config: ""
+
+# --- Docker log collection (composable building blocks) -------------------
+# Reusable config fragments for collecting Docker container logs with rich
+# per-container metadata read live from the Docker socket — no container
+# restarts and no log-driver changes. Interpolate them into your
+# `otelcol_contrib_config` under `extensions:` / `receivers:` (see README),
+# then add `receiver_creator/docker` to your logs pipeline.
+#
+# The receiver_creator + docker_observer pair discovers running containers via
+# the socket (already mounted by otelcol_contrib_container_volumes) and spawns
+# one filelog receiver per container, attaching `container.name`,
+# `container.image.name` and `container.id` as resource attributes. New
+# containers are picked up automatically (fixes the static-filelog problem of
+# not noticing new files without a restart).
+
+# Container names excluded from log collection. A list; each entry is a regex
+# fragment matched anchored against the container name. Defaults to just the
+# collector's own container so it doesn't ingest its own logs. Override with
+# your own noise list, e.g. ["otelcol", "node_exporter", "my-sidecar-.*"].
+otelcol_contrib_docker_logs_excluded_names:
+  - "{{ otelcol_contrib_container_name }}"
+
+# docker_observer extension — discovers containers + metadata via the socket.
+otelcol_contrib_docker_observer:
+  docker_observer:
+    endpoint: "unix:///var/run/docker.sock"
+    cache_sync_interval: 60s
+
+# receiver_creator that tails each discovered container's json-file log with
+# Docker metadata attached, parses the docker format, and maps the json `level`
+# field to OTel severity.
+otelcol_contrib_docker_logs_receiver:
+  receiver_creator/docker:
+    watch_observers: ["docker_observer"]
+    receivers:
+      filelog:
+        rule: 'type == "container" && not (name matches "^({{ otelcol_contrib_docker_logs_excluded_names | join("|") }})$")'
+        resource_attributes:
+          container.name: "`name`"
+          container.image.name: "`image`"
+          container.id: "`container_id`"
+        config:
+          include: ["/var/lib/docker/containers/`container_id`/`container_id`-json.log"]
+          include_file_path: true
+          start_at: end
+          operators:
+            - type: container
+              format: docker
+              add_metadata_from_filepath: false
+            - type: json_parser
+              if: 'body matches "^\\s*\\{"'
+              on_error: send
+              severity:
+                parse_from: attributes.level
+                overwrite_text: true
+                mapping:
+                  fatal4: ["emergency", "emerg"]
+                  fatal3: ["alert"]
+                  fatal2: ["critical", "crit"]
+                  fatal: ["panic"]


### PR DESCRIPTION
Adds reusable, **generic** building blocks to the `otelcol_contrib` role for collecting Docker container logs with rich per-container metadata, read live from the Docker socket — no container restarts, no log-driver changes.

A plain `filelog` receiver tailing `/var/lib/docker/containers/*/*-json.log` only has the container **id** (from the path); container name/image/labels live in the daemon. These fragments use the `docker_observer` extension + `receiver_creator` to spawn one `filelog` receiver per container, attaching `container.name`, `container.image.name`, `container.id` as resource attributes, parsing the docker json format, and mapping the json `level` field to severity. New containers are discovered automatically.

New defaults (all opt-in — consumers that set `otelcol_contrib_config` are unaffected):
- `otelcol_contrib_docker_observer` — the `docker_observer` extension.
- `otelcol_contrib_docker_logs_receiver` — the `receiver_creator/docker` receiver.
- `otelcol_contrib_docker_logs_excluded_names` — **list** of container-name regex fragments to exclude. Defaults to just the collector's own container; consumers add their own tooling/sidecars.

Nothing app-specific is baked in — host-level identity (environment, region, …) and any extra exclusions are the consumer's. README documents how to interpolate the fragments into a config and wire `receiver_creator/docker` into the logs pipeline.