### PR TITLE
bump dora chart to 1.0.9

### DIFF
--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -156,7 +156,7 @@ gen_kubernetes_config_helm_charts: # noqa var-naming[no-role-prefix]
     dependencies:
       - name: dora
         repository: https://ethpandaops.github.io/ethereum-helm-charts
-        version: 1.0.8
+        version: 1.0.9
   forky:
     valuesTemplatePath: templates/forky.yaml.j2
     dependencies:


### PR DESCRIPTION
## Summary

- Bumps the `dora` chart dependency in `roles/generate_kubernetes_config/defaults/main.yaml` from `1.0.8` → `1.0.9`.
- 1.0.9 ships the fix for the empty `ranges.yaml` parse error on default deployments.

## Depends on

- ethpandaops/ethereum-helm-charts#474 — needs to merge and the 1.0.9 chart release to land before this is usable.

## Test plan

- [ ] Wait for #474 to merge and 1.0.9 to appear at https://ethpandaops.github.io/ethereum-helm-charts
- [ ] Render a devnet kubernetes config with this role and confirm `Chart.lock` resolves `dora` to `1.0.9`
- [ ] Deploy and verify dora no longer logs `cannot unmarshal !!seq into map[string]string` from `module=validator_names`