### PR TITLE
dora: make mevRelays configurable (default unchanged)

### DIFF
--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -56,12 +56,14 @@ gen_kubernetes_config_dora_execution_indexer_retention: "336h" # noqa var-naming
 gen_kubernetes_config_dora_execution_indexer_details_max_size: "100GB" # noqa var-naming[no-role-prefix]
 gen_kubernetes_config_dora_postgres_size: >- # noqa var-naming[no-role-prefix]
   {{ "80Gi" if gen_kubernetes_config_dora_execution_indexer_enabled else "10Gi" }}
-# Override to [] on networks without an MEV relay (e.g. ePBS devnets where the
-# protocol-native builder market replaces external mev-boost relays).
-gen_kubernetes_config_dora_mev_relays: # noqa var-naming[no-role-prefix]
-  - index: 0
-    name: "Flashbots"
-    url: "http://mev-relay-1.{{ network_subdomain }}:9062/"
+# Default empty: ePBS devnets (e.g. glamsterdam) deliver the builder market
+# via the protocol itself and don't deploy mev-boost relays. Networks that DO
+# run a relay should override in inventory, e.g.:
+#   gen_kubernetes_config_dora_mev_relays:
+#     - index: 0
+#       name: "Flashbots"
+#       url: "http://mev-relay-1.{{ network_subdomain }}:9062/"
+gen_kubernetes_config_dora_mev_relays: [] # noqa var-naming[no-role-prefix]
 
 # authenticatoor configuration
 gen_kubernetes_config_authenticatoor_cf_team_domain: "ethpandaops.cloudflareaccess.com" # noqa var-naming[no-role-prefix]

--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -56,13 +56,6 @@ gen_kubernetes_config_dora_execution_indexer_retention: "336h" # noqa var-naming
 gen_kubernetes_config_dora_execution_indexer_details_max_size: "100GB" # noqa var-naming[no-role-prefix]
 gen_kubernetes_config_dora_postgres_size: >- # noqa var-naming[no-role-prefix]
   {{ "80Gi" if gen_kubernetes_config_dora_execution_indexer_enabled else "10Gi" }}
-# Default empty: ePBS devnets (e.g. glamsterdam) deliver the builder market
-# via the protocol itself and don't deploy mev-boost relays. Networks that DO
-# run a relay should override in inventory, e.g.:
-#   gen_kubernetes_config_dora_mev_relays:
-#     - index: 0
-#       name: "Flashbots"
-#       url: "http://mev-relay-1.{{ network_subdomain }}:9062/"
 gen_kubernetes_config_dora_mev_relays: [] # noqa var-naming[no-role-prefix]
 
 # authenticatoor configuration

--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -56,6 +56,12 @@ gen_kubernetes_config_dora_execution_indexer_retention: "336h" # noqa var-naming
 gen_kubernetes_config_dora_execution_indexer_details_max_size: "100GB" # noqa var-naming[no-role-prefix]
 gen_kubernetes_config_dora_postgres_size: >- # noqa var-naming[no-role-prefix]
   {{ "80Gi" if gen_kubernetes_config_dora_execution_indexer_enabled else "10Gi" }}
+# Override to [] on networks without an MEV relay (e.g. ePBS devnets where the
+# protocol-native builder market replaces external mev-boost relays).
+gen_kubernetes_config_dora_mev_relays: # noqa var-naming[no-role-prefix]
+  - index: 0
+    name: "Flashbots"
+    url: "http://mev-relay-1.{{ network_subdomain }}:9062/"
 
 # authenticatoor configuration
 gen_kubernetes_config_authenticatoor_cf_team_domain: "ethpandaops.cloudflareaccess.com" # noqa var-naming[no-role-prefix]

--- a/roles/generate_kubernetes_config/templates/dora.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/dora.yaml.j2
@@ -76,10 +76,10 @@ dora:
       persistence:
         size: "{{ gen_kubernetes_config_dora_postgres_size }}"
 
+{% if gen_kubernetes_config_dora_mev_relays %}
   mevRelays:
-    - index: 0
-      name: "Flashbots"
-      url: "http://mev-relay-1.{{ network_subdomain }}:9062/"
+{{ gen_kubernetes_config_dora_mev_relays | to_nice_yaml(indent=2) | indent(4, True) }}
+{% endif %}
 
   authGroups:
     pandaops:


### PR DESCRIPTION
## Summary

Expose the dora mev relay list as `gen_kubernetes_config_dora_mev_relays`. **Default is `[]`** — the j2 template skips the `mevRelays` block entirely unless a network explicitly opts in via inventory.

ePBS networks (Glamsterdam etc.) ship a protocol-native builder market and don't deploy external mev-boost relays, so the previous hardcoded Flashbots entry caused dora to poll a non-existent hostname and time out.

## ⚠️ Breaking change

Networks that **currently rely on the hardcoded Flashbots entry** at `http://mev-relay-1.<network_subdomain>:9062/` must add an override:

```yaml
# inventories/<network>/group_vars/all/all.yaml
gen_kubernetes_config_dora_mev_relays:
  - index: 0
    name: "Flashbots"
    url: "http://mev-relay-1.{{ network_subdomain }}:9062/"
```

Without the override their rendered dora `values.yaml` will no longer contain a `mevRelays:` block.

## Why default to []

On `glamsterdam-devnet-5` (no `mev-relay-1` host), the previous behavior left dora pointed at `mev-relay-1.glamsterdam-devnet-5.ethpandaops.io:9062`. The hostname has no DNS record so it falls through the Cloudflare wildcard to a public IP (104.26.x / 172.67.x) and dora spams the relay-fetch loop:

```
level=error msg="error loading mev blocks from relay 0 (Flashbots):
  ... dial tcp 172.67.68.196:9062: i/o timeout"
  service=mev-relay
```

70 occurrences in 6 hours. Defaulting to `[]` makes the inventory the source of truth for "is there a relay here" — same pattern as other infra-presence checks in the role.

## Test plan

- [x] `ansible-lint roles/generate_kubernetes_config/` passes (profile production)
- [ ] Default render: no `mevRelays:` key in the dora chart values
- [ ] With override set: `mevRelays:` block renders with the configured entries