### PR TITLE
dora: render buildoorOverviewUrl when configured

### DIFF
--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -158,7 +158,7 @@ gen_kubernetes_config_helm_charts: # noqa var-naming[no-role-prefix]
     dependencies:
       - name: dora
         repository: https://ethpandaops.github.io/ethereum-helm-charts
-        version: 1.0.9
+        version: 1.0.10
   forky:
     valuesTemplatePath: templates/forky.yaml.j2
     dependencies:

--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -57,6 +57,7 @@ gen_kubernetes_config_dora_execution_indexer_details_max_size: "100GB" # noqa va
 gen_kubernetes_config_dora_postgres_size: >- # noqa var-naming[no-role-prefix]
   {{ "80Gi" if gen_kubernetes_config_dora_execution_indexer_enabled else "10Gi" }}
 gen_kubernetes_config_dora_mev_relays: [] # noqa var-naming[no-role-prefix]
+gen_kubernetes_config_dora_buildoor_overview_url: "https://buildoor.{{ network_subdomain }}" # noqa var-naming[no-role-prefix]
 
 # authenticatoor configuration
 gen_kubernetes_config_authenticatoor_cf_team_domain: "ethpandaops.cloudflareaccess.com" # noqa var-naming[no-role-prefix]

--- a/roles/generate_kubernetes_config/templates/dora.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/dora.yaml.j2
@@ -34,6 +34,7 @@ dora:
   name: {{ ethereum_network_name }}
   configPath: "https://config.{{ network_subdomain }}/cl/config.yaml"
   validatorNamesInventory: "https://config.{{ network_subdomain }}/api/v1/nodes/validator-ranges"
+  buildoorOverviewUrl: "{{ gen_kubernetes_config_dora_buildoor_overview_url }}"
   ethExplorerLink: "{{ gen_kubernetes_config_dora_frontend_explorer_link }}"
   publicRpcUrl: "{{ gen_kubernetes_config_dora_frontend_public_rpc }}"
   rainbowkitProjectId: "{{ gen_kubernetes_config_dora_frontend_rainbowkit_id }}"


### PR DESCRIPTION
## Summary

Renders `buildoorOverviewUrl: https://buildoor.{{ network_subdomain }}` in the dora helm values, in line with how `ethExplorerLink` / `frontend_public_rpc` / `validatorNamesInventory` are derived from `network_subdomain`. Dora consumes this to resolve builder names + per-instance external links via `<overview>/api/overview/hosts` + each instance's `/api/buildoor/overview`.

Pairs with https://github.com/ethpandaops/dora/pull/728 (introduces the `buildoorOverviewUrl` config knob in dora).

## Changes

- `defaults/main.yaml` — new var `gen_kubernetes_config_dora_buildoor_overview_url` defaulting to `https://buildoor.{{ network_subdomain }}`.
- `templates/dora.yaml.j2` — render `buildoorOverviewUrl` unconditionally next to `validatorNamesInventory`. Override the default to `""` (or override the var per-network) if a network doesn't have a buildoor instance.

## Test plan

- [ ] Render with defaults → `buildoorOverviewUrl: "https://buildoor.<network_subdomain>"` appears.
- [ ] Override the var to a custom URL → that URL is emitted instead.