### PR TITLE
fix inventory by incorporating validator mapping into ranges generation

### DIFF
--- a/roles/ethereum_inventory_web/defaults/main.yaml
+++ b/roles/ethereum_inventory_web/defaults/main.yaml
@@ -13,13 +13,72 @@ eth_inventory_web_container_volumes: # noqa var-naming[no-role-prefix]
   - "{{ eth_inventory_web_dir }}/content:/usr/share/nginx/html:ro"
   - "{{ eth_inventory_web_dir }}/nginx-conf/default.conf:/etc/nginx/conf.d/default.conf:ro"
 
+# Optional validator names mapping file produced by the genesis generator when
+# validator shuffling is enabled. Defaults to the network config metadata
+# directory (empty when that is unknown, which disables mapping translation).
+eth_inventory_web_validator_names_file: >- # noqa var-naming[no-role-prefix]
+  {{ ((eth_testnet_config_local_dir_src | regex_replace('/$', '')) ~ '/validator_names.yaml')
+     if eth_testnet_config_local_dir_src is defined else '' }}
+
+# Parsed validator names mapping (a list of {on-chain-range: {src, from, to}}),
+# or an empty list when no mapping file is present.
+eth_inventory_web_validator_names_mapping: >- # noqa var-naming[no-role-prefix]
+  {%- set raw = lookup('file', eth_inventory_web_validator_names_file, errors='ignore')
+        if (eth_inventory_web_validator_names_file | length > 0) else '' -%}
+  {%- if raw -%}
+  {{ raw | from_yaml }}
+  {%- else -%}
+  {{ [] }}
+  {%- endif -%}
+
+# Final on-chain validator ranges as a list of {range, name, start}. When a
+# mapping file is present each mapping entry is translated: "main-mnemonic"
+# derivation ranges are resolved to the owning host (splitting on host
+# boundaries that don't align with the mapping groups and shifting into the
+# on-chain index space), while other sources are passed through under their own
+# name. Without a mapping file the mnemonic-index keyranges are emitted directly
+# (mnemonic index == on-chain index).
+eth_inventory_web_validator_ranges: >- # noqa var-naming[no-role-prefix]
+  {%- set ns = namespace(ranges=[]) -%}
+  {%- set mapping = eth_inventory_web_validator_names_mapping | default([]) -%}
+  {%- set keyranges = ethereum_genesis_validator_keyranges | default({}) -%}
+  {%- if mapping | length > 0 -%}
+  {%-   for entry in mapping -%}
+  {%-     for onchain_range, val in entry.items() -%}
+  {%-       set oc = (onchain_range | string).split('-') -%}
+  {%-       set oc_start = oc[0] | int -%}
+  {%-       set oc_end = oc[1] | int -%}
+  {%-       if val['src'] != 'main-mnemonic' -%}
+  {%-         set _ = ns.ranges.append({'range': (oc_start | string) ~ '-' ~ (oc_end | string), 'name': val['src'], 'start': oc_start}) -%}
+  {%-       else -%}
+  {%-         set dfrom = val['from'] | int -%}
+  {%-         set dto = val['to'] | int -%}
+  {%-         for host, kr in keyranges.items() -%}
+  {%-           set ov_start = [dfrom, kr.start | int] | max -%}
+  {%-           set ov_end = [dto, (kr.end | int) - 1] | min -%}
+  {%-           if ov_start <= ov_end -%}
+  {%-             set rstart = oc_start + ov_start - dfrom -%}
+  {%-             set rend = oc_start + ov_end - dfrom -%}
+  {%-             set _ = ns.ranges.append({'range': (rstart | string) ~ '-' ~ (rend | string), 'name': host, 'start': rstart}) -%}
+  {%-           endif -%}
+  {%-         endfor -%}
+  {%-       endif -%}
+  {%-     endfor -%}
+  {%-   endfor -%}
+  {%- else -%}
+  {%-   for host, kr in keyranges.items() -%}
+  {%-     set _ = ns.ranges.append({'range': (kr.start | string) ~ '-' ~ ((kr.end | int - 1) | string), 'name': host, 'start': kr.start | int}) -%}
+  {%-   endfor -%}
+  {%- endif -%}
+  {{ ns.ranges }}
+
 eth_inventory_web_content: # noqa var-naming[no-role-prefix]
   - file: v1/validator-ranges.json
     content: |
       {
         "ranges": {
-          {% for k, v in ethereum_genesis_validator_keyranges.items() | sort(attribute='1.start') %}
-          "{{ v.start }}-{{ v.end - 1 }}": "{{ k }}"{% if not loop.last %},{% endif %}
+          {% for item in eth_inventory_web_validator_ranges | sort(attribute='start') %}
+          "{{ item.range }}": "{{ item.name }}"{% if not loop.last %},{% endif %}
           {% endfor %}
         }
       }

--- a/roles/ethereum_inventory_web/defaults/main.yaml
+++ b/roles/ethereum_inventory_web/defaults/main.yaml
@@ -20,65 +20,33 @@ eth_inventory_web_validator_names_file: >- # noqa var-naming[no-role-prefix]
   {{ ((eth_testnet_config_local_dir_src | regex_replace('/$', '')) ~ '/validator_names.yaml')
      if eth_testnet_config_local_dir_src is defined else '' }}
 
-# Parsed validator names mapping (a list of {on-chain-range: {src, from, to}}),
-# or an empty list when no mapping file is present.
-eth_inventory_web_validator_names_mapping: >- # noqa var-naming[no-role-prefix]
-  {%- set raw = lookup('file', eth_inventory_web_validator_names_file, errors='ignore')
-        if (eth_inventory_web_validator_names_file | length > 0) else '' -%}
-  {%- if raw -%}
-  {{ raw | from_yaml }}
-  {%- else -%}
-  {{ [] }}
-  {%- endif -%}
+# Genesis generator image carrying the shared validator-mapping merge script
+# (/apps/validator-mapping/merge.sh). The merge runs in this image so the
+# translation logic is shared with the ethereum-package rather than reimplemented.
+eth_inventory_web_merge_image: >- # noqa var-naming[no-role-prefix]
+  {{ ethereum_genesis_generator_container_image | default('ethpandaops/ethereum-genesis-generator:latest') }}
 
-# Final on-chain validator ranges as a list of {range, name, start}. When a
-# mapping file is present each mapping entry is translated: "main-mnemonic"
-# derivation ranges are resolved to the owning host (splitting on host
-# boundaries that don't align with the mapping groups and shifting into the
-# on-chain index space), while other sources are passed through under their own
-# name. Without a mapping file the mnemonic-index keyranges are emitted directly
-# (mnemonic index == on-chain index).
-eth_inventory_web_validator_ranges: >- # noqa var-naming[no-role-prefix]
-  {%- set ns = namespace(ranges=[]) -%}
-  {%- set mapping = eth_inventory_web_validator_names_mapping | default([]) -%}
-  {%- set keyranges = ethereum_genesis_validator_keyranges | default({}) -%}
-  {%- if mapping | length > 0 -%}
-  {%-   for entry in mapping -%}
-  {%-     for onchain_range, val in entry.items() -%}
-  {%-       set oc = (onchain_range | string).split('-') -%}
-  {%-       set oc_start = oc[0] | int -%}
-  {%-       set oc_end = oc[1] | int -%}
-  {%-       if val['src'] != 'main-mnemonic' -%}
-  {%-         set _ = ns.ranges.append({'range': (oc_start | string) ~ '-' ~ (oc_end | string), 'name': val['src'], 'start': oc_start}) -%}
-  {%-       else -%}
-  {%-         set dfrom = val['from'] | int -%}
-  {%-         set dto = val['to'] | int -%}
-  {%-         for host, kr in keyranges.items() -%}
-  {%-           set ov_start = [dfrom, kr.start | int] | max -%}
-  {%-           set ov_end = [dto, (kr.end | int) - 1] | min -%}
-  {%-           if ov_start <= ov_end -%}
-  {%-             set rstart = oc_start + ov_start - dfrom -%}
-  {%-             set rend = oc_start + ov_end - dfrom -%}
-  {%-             set _ = ns.ranges.append({'range': (rstart | string) ~ '-' ~ (rend | string), 'name': host, 'start': rstart}) -%}
-  {%-           endif -%}
-  {%-         endfor -%}
-  {%-       endif -%}
-  {%-     endfor -%}
-  {%-   endfor -%}
-  {%- else -%}
-  {%-   for host, kr in keyranges.items() -%}
-  {%-     set _ = ns.ranges.append({'range': (kr.start | string) ~ '-' ~ ((kr.end | int - 1) | string), 'name': host, 'start': kr.start | int}) -%}
-  {%-   endfor -%}
-  {%- endif -%}
-  {{ ns.ranges }}
+# Client/host key segments fed to the merge script: the inclusive mnemonic
+# key-index range each host owns, derived from ethereum_genesis_validator_keyranges
+# (whose end index is exclusive).
+eth_inventory_web_segments_json: >- # noqa var-naming[no-role-prefix]
+  {%- set segs = [] -%}
+  {%- for host, kr in (ethereum_genesis_validator_keyranges | default({})).items() -%}
+  {%-   set _ = segs.append({'name': host, 'start': kr.start | int, 'end': (kr.end | int) - 1}) -%}
+  {%- endfor -%}
+  {{ segs | to_json }}
+
+# Final on-chain validator ranges ({ "<start>-<end>": "<name>" }). Computed at
+# run time by the shared merge script (see tasks/main.yaml); empty until then.
+eth_inventory_web_validator_ranges: {} # noqa var-naming[no-role-prefix]
 
 eth_inventory_web_content: # noqa var-naming[no-role-prefix]
   - file: v1/validator-ranges.json
     content: |
       {
         "ranges": {
-          {% for item in eth_inventory_web_validator_ranges | sort(attribute='start') %}
-          "{{ item.range }}": "{{ item.name }}"{% if not loop.last %},{% endif %}
+          {% for rng, name in eth_inventory_web_validator_ranges.items() %}
+          "{{ rng }}": "{{ name }}"{% if not loop.last %},{% endif %}
           {% endfor %}
         }
       }

--- a/roles/ethereum_inventory_web/tasks/main.yaml
+++ b/roles/ethereum_inventory_web/tasks/main.yaml
@@ -20,7 +20,7 @@
   become: false
   when: ethereum_genesis_validator_keyranges is defined
   block:
-    - name: Create temp dir for validator ranges merge
+    - name: Create temp dir for validator ranges merge # noqa var-naming[no-role-prefix]
       ansible.builtin.tempfile:
         state: directory
         suffix: validator-ranges-merge
@@ -32,7 +32,7 @@
         dest: "{{ eth_inventory_web_merge_tmp.path }}/segments.json"
         mode: "0644"
 
-    - name: Check for validator names mapping file
+    - name: Check for validator names mapping file # noqa var-naming[no-role-prefix]
       ansible.builtin.stat:
         path: "{{ eth_inventory_web_validator_names_file }}"
       register: eth_inventory_web_mapping_stat
@@ -45,12 +45,12 @@
         mode: "0644"
       when: eth_inventory_web_mapping_stat.stat.exists | default(false)
 
-    - name: Check if Docker is rootless
+    - name: Check if Docker is rootless # noqa var-naming[no-role-prefix]
       ansible.builtin.command: docker info -f '{{ "{{json .SecurityOptions}}" }}'
       register: eth_inventory_web_docker_secopts
       changed_when: false
 
-    - name: Compute merge arguments
+    - name: Compute merge arguments # noqa var-naming[no-role-prefix]
       ansible.builtin.set_fact:
         eth_inventory_web_docker_user_flag: >-
           {{ ('name=rootless' in eth_inventory_web_docker_secopts.stdout)
@@ -59,7 +59,7 @@
           {{ (eth_inventory_web_mapping_stat.stat.exists | default(false))
           | ternary('--mapping /in/validator_names.yaml', '') }}
 
-    - name: Run validator ranges merge
+    - name: Run validator ranges merge # noqa var-naming[no-role-prefix]
       ansible.builtin.shell: >
         docker run --rm {{ eth_inventory_web_docker_user_flag }}
         --entrypoint bash
@@ -76,7 +76,7 @@
         path: "{{ eth_inventory_web_merge_tmp.path }}"
         state: absent
 
-- name: Set validator ranges fact
+- name: Set validator ranges fact # noqa var-naming[no-role-prefix]
   ansible.builtin.set_fact:
     eth_inventory_web_validator_ranges: "{{ (eth_inventory_web_merge_cmd.stdout | from_json).ranges }}"
   when:

--- a/roles/ethereum_inventory_web/tasks/main.yaml
+++ b/roles/ethereum_inventory_web/tasks/main.yaml
@@ -12,6 +12,77 @@
     group: "root"
     mode: "0644"
 
+- name: Build validator ranges from genesis mapping
+  vars:
+    ansible_connection: local
+  delegate_to: 127.0.0.1
+  run_once: true
+  become: false
+  when: ethereum_genesis_validator_keyranges is defined
+  block:
+    - name: Create temp dir for validator ranges merge
+      ansible.builtin.tempfile:
+        state: directory
+        suffix: validator-ranges-merge
+      register: eth_inventory_web_merge_tmp
+
+    - name: Write client key segments
+      ansible.builtin.copy:
+        content: "{{ eth_inventory_web_segments_json }}"
+        dest: "{{ eth_inventory_web_merge_tmp.path }}/segments.json"
+        mode: "0644"
+
+    - name: Check for validator names mapping file
+      ansible.builtin.stat:
+        path: "{{ eth_inventory_web_validator_names_file }}"
+      register: eth_inventory_web_mapping_stat
+      when: eth_inventory_web_validator_names_file | length > 0
+
+    - name: Copy validator names mapping into merge input
+      ansible.builtin.copy:
+        src: "{{ eth_inventory_web_validator_names_file }}"
+        dest: "{{ eth_inventory_web_merge_tmp.path }}/validator_names.yaml"
+        mode: "0644"
+      when: eth_inventory_web_mapping_stat.stat.exists | default(false)
+
+    - name: Check if Docker is rootless
+      ansible.builtin.command: docker info -f '{{ "{{json .SecurityOptions}}" }}'
+      register: eth_inventory_web_docker_secopts
+      changed_when: false
+
+    - name: Compute merge arguments
+      ansible.builtin.set_fact:
+        eth_inventory_web_docker_user_flag: >-
+          {{ ('name=rootless' in eth_inventory_web_docker_secopts.stdout)
+          | ternary('', '-u ' ~ (ansible_effective_user_id | default(ansible_uid, true))) }}
+        eth_inventory_web_mapping_arg: >-
+          {{ (eth_inventory_web_mapping_stat.stat.exists | default(false))
+          | ternary('--mapping /in/validator_names.yaml', '') }}
+
+    - name: Run validator ranges merge
+      ansible.builtin.shell: >
+        docker run --rm {{ eth_inventory_web_docker_user_flag }}
+        --entrypoint bash
+        -v {{ eth_inventory_web_merge_tmp.path }}:/in
+        {{ eth_inventory_web_merge_image }}
+        /apps/validator-mapping/merge.sh {{ eth_inventory_web_mapping_arg }}
+        --segments /in/segments.json --format json
+      register: eth_inventory_web_merge_cmd
+      changed_when: false
+      failed_when: (eth_inventory_web_merge_cmd.rc != 0) or (eth_inventory_web_merge_cmd.stdout == "")
+
+    - name: Clean up merge temp dir
+      ansible.builtin.file:
+        path: "{{ eth_inventory_web_merge_tmp.path }}"
+        state: absent
+
+- name: Set validator ranges fact
+  ansible.builtin.set_fact:
+    eth_inventory_web_validator_ranges: "{{ (eth_inventory_web_merge_cmd.stdout | from_json).ranges }}"
+  when:
+    - ethereum_genesis_validator_keyranges is defined
+    - eth_inventory_web_merge_cmd.stdout is defined
+
 - name: Create directories
   ansible.builtin.file:
     path: "{{ (eth_inventory_web_dir + '/content/' + item.file) | dirname }}"


### PR DESCRIPTION
gated on https://github.com/ethpandaops/ethereum-genesis-generator/pull/296

Fixes validator name attribution in the `ethereum_inventory_web` role by incorporating the validator mapping.

- When a `validator_names.yaml` is present (network-config metadata dir), the role translates the mnemonic-index `ethereum_genesis_validator_keyranges` into the final on-chain validator ranges — accounting for index shifts (e.g. post-genesis deposits) and splitting hosts across mapping groups.
- Non-main-mnemonic sources are passed through under their own name.
- Backward compatible: without a mapping file the keyranges are emitted directly (mnemonic index == on-chain index).
