### PR TITLE
feat(generate_kubernetes_config): add chat service (panda-chat)

### DIFF
--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -91,6 +91,35 @@ gen_kubernetes_config_powfaucet_authenticatoor_grants: # noqa var-naming[no-role
 gen_kubernetes_config_pandamenu_enabled: true # noqa var-naming[no-role-prefix]
 gen_kubernetes_config_pandamenu_script: '<script src="https://pandamenu.ethpandaops.io/panda-menu-1.0.1.js" integrity="sha384-icGX6g6CzB0tqlhDc6Su4c6IPVbcbUvfM3xjbbFYsYBwuZR79WkmOxDhGEPfmyn2" crossorigin="anonymous"></script>' # noqa var-naming[no-role-prefix] yaml[line-length]
 
+# Chat (panda-chat) — Open-WebUI + Hermes + panda CLI. Needs a `chat` section in
+# services.enc.yaml: llm_api_key, panda_credentials_json, panda_credentials_file,
+# langfuse_public_key, langfuse_secret_key.
+gen_kubernetes_config_chat_image: "ethpandaops/hermes-agent-panda:latest" # noqa var-naming[no-role-prefix]
+gen_kubernetes_config_chat_llm_provider: "anthropic" # noqa var-naming[no-role-prefix]
+gen_kubernetes_config_chat_llm_model: "claude-sonnet-4-6" # noqa var-naming[no-role-prefix]
+gen_kubernetes_config_chat_llm_base_url: "" # noqa var-naming[no-role-prefix]
+gen_kubernetes_config_chat_llm_api_mode: "" # noqa var-naming[no-role-prefix]
+gen_kubernetes_config_chat_llm_api_key_env: "ANTHROPIC_API_KEY" # noqa var-naming[no-role-prefix]
+gen_kubernetes_config_chat_enable_login_form: false # noqa var-naming[no-role-prefix]
+# Gate chat behind Cloudflare Access (trusted-header SSO). Requires a CF Access
+# application on chat.<network_subdomain> scoped to the org.
+gen_kubernetes_config_chat_auth_enabled: true # noqa var-naming[no-role-prefix]
+gen_kubernetes_config_chat_persistence_size: "8Gi" # noqa var-naming[no-role-prefix]
+# Panda integration. issuer_url/client_id are the panda-proxy *bot* OIDC identity
+# (machine auth to the analytics data plane) — NOT user login, which is the
+# Cloudflare Access trusted-header gate above.
+gen_kubernetes_config_chat_panda_enabled: true # noqa var-naming[no-role-prefix]
+gen_kubernetes_config_chat_panda_proxy_url: "https://panda-proxy.analytics.production.platform.ethpandaops.io" # noqa var-naming[no-role-prefix] yaml[line-length]
+gen_kubernetes_config_chat_panda_issuer_url: "https://dex.primary.production.platform.ethpandaops.io" # noqa var-naming[no-role-prefix] yaml[line-length]
+gen_kubernetes_config_chat_panda_client_id: "panda-proxy" # noqa var-naming[no-role-prefix]
+gen_kubernetes_config_chat_panda_sandbox_image: "ethpandaops/panda:sandbox-v0.31.0" # noqa var-naming[no-role-prefix]
+gen_kubernetes_config_chat_panda_storage_driver: "overlay2" # noqa var-naming[no-role-prefix]
+gen_kubernetes_config_chat_pandamenu: "" # noqa var-naming[no-role-prefix]
+# Langfuse tracing (Hermes observability/langfuse plugin). Keys come from
+# services.enc.yaml#chat (langfuse_public_key, langfuse_secret_key).
+gen_kubernetes_config_chat_langfuse_enabled: true # noqa var-naming[no-role-prefix]
+gen_kubernetes_config_chat_langfuse_base_url: "https://langfuse.analytics.production.platform.ethpandaops.io" # noqa var-naming[no-role-prefix] yaml[line-length]
+
 # Enabled charts configuration
 gen_kubernetes_config_disabled_services: [] # noqa var-naming[no-role-prefix]
 gen_kubernetes_config_enabled_charts: "{{ gen_kubernetes_config_helm_charts.keys() | reject('in', gen_kubernetes_config_disabled_services) | list }}" # noqa var-naming[no-role-prefix] yaml[line-length]
@@ -159,6 +188,12 @@ gen_kubernetes_config_helm_charts: # noqa var-naming[no-role-prefix]
       - name: dora
         repository: https://ethpandaops.github.io/ethereum-helm-charts
         version: 1.0.10
+  chat:
+    valuesTemplatePath: templates/chat.yaml.j2
+    dependencies:
+      - name: panda-chat
+        repository: https://ethpandaops.github.io/ethereum-helm-charts
+        version: 0.1.0
   forky:
     valuesTemplatePath: templates/forky.yaml.j2
     dependencies:

--- a/roles/generate_kubernetes_config/templates/chat.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/chat.yaml.j2
@@ -1,0 +1,121 @@
+# {{ ansible_managed }}
+# panda-chat — Open-WebUI + Hermes (panda CLI) at https://chat.{{ network_subdomain }}
+
+# Fixed names so the front end can target the agent service.
+fullnameOverride: chat
+
+network: {{ ethereum_network_name }}
+chainId: "{{ chainId | default('') }}"
+
+image:
+  repository: {{ gen_kubernetes_config_chat_image.split(':') | first }}
+  tag: {{ gen_kubernetes_config_chat_image.split(':') | last }}
+  pullPolicy: {% if "latest" in (gen_kubernetes_config_chat_image.split(':') | last) %}Always{% else %}IfNotPresent{% endif %}
+
+
+llm:
+  provider: {{ gen_kubernetes_config_chat_llm_provider }}
+  model: {{ gen_kubernetes_config_chat_llm_model }}
+  baseUrl: "{{ gen_kubernetes_config_chat_llm_base_url }}"
+  apiMode: "{{ gen_kubernetes_config_chat_llm_api_mode }}"
+  apiKeyEnv: {{ gen_kubernetes_config_chat_llm_api_key_env }}
+
+systemPrompt: |
+  You are the EthPandaOps assistant for the Ethereum devnet "{{ ethereum_network_name }}"
+  (chain id {{ chainId | default('unknown') }}). Help users understand devnet state and use
+  the EthPandaOps tooling: query live data with the `panda` skill, fund accounts with the
+  `faucet` skill, and join the network with the `join-devnet` skill. Always scope data
+  queries to this devnet and be concise.
+
+panda:
+  enabled: {{ gen_kubernetes_config_chat_panda_enabled | lower }}
+  proxyUrl: "{{ gen_kubernetes_config_chat_panda_proxy_url }}"
+  issuerUrl: "{{ gen_kubernetes_config_chat_panda_issuer_url }}"
+  clientId: "{{ gen_kubernetes_config_chat_panda_client_id }}"
+  sandboxImage: "{{ gen_kubernetes_config_chat_panda_sandbox_image }}"
+  storageDriver: "{{ gen_kubernetes_config_chat_panda_storage_driver }}"
+
+langfuse:
+  enabled: {{ gen_kubernetes_config_chat_langfuse_enabled | lower }}
+  baseUrl: "{{ gen_kubernetes_config_chat_langfuse_base_url }}"
+  env: "{{ ethereum_network_name }}"
+
+devnetTools:
+  faucet:
+    enabled: {{ ('faucet' in gen_kubernetes_config_enabled_charts) | lower }}
+    url: "https://faucet.{{ network_subdomain }}"
+  join:
+    enabled: true
+    configUrl: "https://config.{{ network_subdomain }}"
+    rpcUrl: "{{ gen_kubernetes_config_dora_frontend_public_rpc }}"
+    explorerUrl: "{{ gen_kubernetes_config_dora_frontend_explorer_link }}"
+
+# From services.enc.yaml#chat: llm_api_key, panda_credentials_json, panda_credentials_file.
+credentials:
+  llmApiKey: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.llm_api_key}>"
+  panda:
+    credentialsJson: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.panda_credentials_json}>"
+    credentialsFile: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.panda_credentials_file}>"
+  langfuse:
+    publicKey: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.langfuse_public_key}>"
+    secretKey: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.langfuse_secret_key}>"
+
+resources:
+  requests:
+    cpu: 300m
+    memory: 1Gi
+  limits:
+    cpu: 3000m
+    memory: 6Gi
+
+persistence:
+  enabled: true
+  size: "{{ gen_kubernetes_config_chat_persistence_size }}"
+
+# Front end. Wired to the in-chart Hermes service (chat-hermes:8642).
+open-webui:
+  enabled: true
+  ollama:
+    enabled: false
+  pipelines:
+    enabled: false
+  websocket:
+    enabled: false
+    redis:
+      enabled: false
+  persistence:
+    enabled: true
+    size: 5Gi
+  # Org gating: Cloudflare Access (edge) -> Open-WebUI trusted-header SSO.
+  # Requires a CF Access application on chat.{{ network_subdomain }} scoped to the org.
+  sso:
+    enabled: {{ gen_kubernetes_config_chat_auth_enabled | lower }}
+    enableSignup: true
+    trustedHeader:
+      enabled: {{ gen_kubernetes_config_chat_auth_enabled | lower }}
+      emailHeader: Cf-Access-Authenticated-User-Email
+  openaiBaseApiUrls:
+    - "http://chat-hermes:8642/v1"
+  extraEnvVars:
+    - name: ENABLE_OLLAMA_API
+      value: "false"
+    - name: ENABLE_LOGIN_FORM
+      value: "{{ gen_kubernetes_config_chat_enable_login_form | lower }}"
+    # Bearer for the in-cluster Hermes endpoint, read from the agent Secret.
+    - name: OPENAI_API_KEYS
+      valueFrom:
+        secretKeyRef:
+          name: chat-hermes-secret
+          key: API_SERVER_KEY
+  ingress:
+    enabled: true
+    class: ingress-nginx-public
+    host: chat.{{ network_subdomain }}
+{% if gen_kubernetes_config_pandamenu_enabled %}
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-body-size: "0"
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        sub_filter '</head>' '{{ gen_kubernetes_config_chat_pandamenu | default('') }}{{ gen_kubernetes_config_pandamenu_script }}</head>';
+        sub_filter_types text/html;
+        sub_filter_once off;
+{% endif %}


### PR DESCRIPTION
## What

Registers a new **`chat`** service in the devnet pipeline that renders the
[`panda-chat`](https://github.com/ethpandaops/ethereum-helm-charts/pull/476) chart
per devnet — the same flow as `dora`. Gives a devnet an AI chat at `chat.<network>`:
Open-WebUI → Hermes agent → `panda` CLI, plus faucet + join-devnet skills.

- **`templates/chat.yaml.j2`** — renders panda-chat values: ingress `chat.<network>`
  + panda-menu, Open-WebUI wired to the in-chart Hermes (`chat-hermes:8642`), panda
  proxy + bot creds, Langfuse tracing, and `devnetTools` (faucet/join/RPC/explorer)
  derived from the inventory.
- **`defaults/main.yaml`** — `chat` entry in `gen_kubernetes_config_helm_charts`
  (dep `panda-chat`) + `gen_kubernetes_config_chat_*` vars.

### Org gating (on by default)

`gen_kubernetes_config_chat_auth_enabled: true` renders Open-WebUI **trusted-header
SSO**, gating `chat.<network>` behind the devnet's **existing Cloudflare Access**
edge (`Cf-Access-Authenticated-User-Email`) — the same primitive that already gates
`auth.<network>` (authenticatoor/faucet). No Dex, no extra secret, no glue pod.

## Depends on / merge order

**Merge after** ethpandaops/ethereum-helm-charts#476 is merged **and published** —
the `chat` service's `panda-chat` dependency resolves from the chart index.

1. ethereum-helm-charts#476 — publish the chart
2. **(this PR)** — register the service
3. secrets: `chat` section in `services.enc.yaml` + a CF Access app on `chat.<network>`
4. bal-devnets — enable on devnet-7, render `kubernetes/devnet-7/chat/`, ArgoCD deploys

## Verification

Rendered `chat.yaml.j2` against a devnet-7-like var set: valid YAML; the
`open-webui.sso.trustedHeader` block toggles correctly with
`gen_kubernetes_config_chat_auth_enabled` (on → gated, off → public); secret paths
resolve to `services.enc.yaml#chat`.