### PR TITLE
refactor(generate_kubernetes_config): slim chat defaults to the real diff

### DIFF
--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -91,34 +91,19 @@ gen_kubernetes_config_powfaucet_authenticatoor_grants: # noqa var-naming[no-role
 gen_kubernetes_config_pandamenu_enabled: true # noqa var-naming[no-role-prefix]
 gen_kubernetes_config_pandamenu_script: '<script src="https://pandamenu.ethpandaops.io/panda-menu-1.0.1.js" integrity="sha384-icGX6g6CzB0tqlhDc6Su4c6IPVbcbUvfM3xjbbFYsYBwuZR79WkmOxDhGEPfmyn2" crossorigin="anonymous"></script>' # noqa var-naming[no-role-prefix] yaml[line-length]
 
-# Chat (panda-chat) — Open-WebUI + Hermes + panda CLI. Needs a `chat` section in
-# services.enc.yaml: llm_api_key, panda_credentials_json, panda_credentials_file,
-# langfuse_public_key, langfuse_secret_key.
-gen_kubernetes_config_chat_image: "ethpandaops/hermes-agent-panda:latest" # noqa var-naming[no-role-prefix]
-gen_kubernetes_config_chat_llm_provider: "anthropic" # noqa var-naming[no-role-prefix]
+# Chat (panda-chat) — Open-WebUI + Hermes + panda CLI. Disabled for now (its
+# registry entry below is commented out). When enabled it needs a `chat` section
+# in services.enc.yaml (llm_api_key, panda_credentials_json, panda_credentials_file,
+# langfuse_public_key, langfuse_secret_key) and a Cloudflare Access app gating
+# chat.<network_subdomain>. Everything else uses the panda-chat chart defaults;
+# only these knobs are exposed:
+# Optional image pin; empty = chart default tag (appVersion).
+gen_kubernetes_config_chat_image: "" # noqa var-naming[no-role-prefix]
 gen_kubernetes_config_chat_llm_model: "claude-sonnet-4-6" # noqa var-naming[no-role-prefix]
-gen_kubernetes_config_chat_llm_base_url: "" # noqa var-naming[no-role-prefix]
-gen_kubernetes_config_chat_llm_api_mode: "" # noqa var-naming[no-role-prefix]
-gen_kubernetes_config_chat_llm_api_key_env: "ANTHROPIC_API_KEY" # noqa var-naming[no-role-prefix]
-gen_kubernetes_config_chat_enable_login_form: false # noqa var-naming[no-role-prefix]
-# Gate chat behind Cloudflare Access (trusted-header SSO). Requires a CF Access
-# application on chat.<network_subdomain> scoped to the org.
+# Cloudflare Access trusted-header SSO.
 gen_kubernetes_config_chat_auth_enabled: true # noqa var-naming[no-role-prefix]
-gen_kubernetes_config_chat_persistence_size: "8Gi" # noqa var-naming[no-role-prefix]
-# Panda integration. issuer_url/client_id are the panda-proxy *bot* OIDC identity
-# (machine auth to the analytics data plane) — NOT user login, which is the
-# Cloudflare Access trusted-header gate above.
-gen_kubernetes_config_chat_panda_enabled: true # noqa var-naming[no-role-prefix]
-gen_kubernetes_config_chat_panda_proxy_url: "https://panda-proxy.analytics.production.platform.ethpandaops.io" # noqa var-naming[no-role-prefix] yaml[line-length]
-gen_kubernetes_config_chat_panda_issuer_url: "https://dex.primary.production.platform.ethpandaops.io" # noqa var-naming[no-role-prefix] yaml[line-length]
-gen_kubernetes_config_chat_panda_client_id: "panda-proxy" # noqa var-naming[no-role-prefix]
-gen_kubernetes_config_chat_panda_sandbox_image: "ethpandaops/panda:sandbox-v0.31.0" # noqa var-naming[no-role-prefix]
-gen_kubernetes_config_chat_panda_storage_driver: "overlay2" # noqa var-naming[no-role-prefix]
+# Extra panda-menu HTML, prefixed to the global snippet.
 gen_kubernetes_config_chat_pandamenu: "" # noqa var-naming[no-role-prefix]
-# Langfuse tracing (Hermes observability/langfuse plugin). Keys come from
-# services.enc.yaml#chat (langfuse_public_key, langfuse_secret_key).
-gen_kubernetes_config_chat_langfuse_enabled: true # noqa var-naming[no-role-prefix]
-gen_kubernetes_config_chat_langfuse_base_url: "https://langfuse.analytics.production.platform.ethpandaops.io" # noqa var-naming[no-role-prefix] yaml[line-length]
 
 # Enabled charts configuration
 gen_kubernetes_config_disabled_services: [] # noqa var-naming[no-role-prefix]
@@ -188,12 +173,14 @@ gen_kubernetes_config_helm_charts: # noqa var-naming[no-role-prefix]
       - name: dora
         repository: https://ethpandaops.github.io/ethereum-helm-charts
         version: 1.0.10
+  # chat: disabled for now — uncomment to enable (needs the chart published +
+  # services.enc.yaml#chat + a Cloudflare Access app on chat.<network_subdomain>).
   # chat:
   #   valuesTemplatePath: templates/chat.yaml.j2
   #   dependencies:
   #     - name: panda-chat
   #       repository: https://ethpandaops.github.io/ethereum-helm-charts
-  #       version: 0.1.0
+  #       version: 0.1.1
   forky:
     valuesTemplatePath: templates/forky.yaml.j2
     dependencies:

--- a/roles/generate_kubernetes_config/templates/chat.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/chat.yaml.j2
@@ -1,45 +1,34 @@
 # {{ ansible_managed }}
 # panda-chat — Open-WebUI + Hermes (panda CLI) at https://chat.{{ network_subdomain }}
+# Only per-devnet values + EthPandaOps infra are set here; everything else
+# (image repo, llm provider/key env, panda proxy/issuer/sandbox, resources,
+# persistence, open-webui front end) uses the panda-chat chart defaults.
 
-# Fixed names so the front end can target the agent service.
+# Fixed name so the front end can target the agent service (chat-hermes:8642).
 fullnameOverride: chat
 
 network: {{ ethereum_network_name }}
 chainId: "{{ chainId | default('') }}"
+{% if gen_kubernetes_config_chat_image %}
 
+# Pinned agent image (otherwise the chart default tag = appVersion).
 image:
   repository: {{ gen_kubernetes_config_chat_image.split(':') | first }}
   tag: {{ gen_kubernetes_config_chat_image.split(':') | last }}
   pullPolicy: {% if "latest" in (gen_kubernetes_config_chat_image.split(':') | last) %}Always{% else %}IfNotPresent{% endif %}
 
+{% endif %}
 
 llm:
-  provider: {{ gen_kubernetes_config_chat_llm_provider }}
   model: {{ gen_kubernetes_config_chat_llm_model }}
-  baseUrl: "{{ gen_kubernetes_config_chat_llm_base_url }}"
-  apiMode: "{{ gen_kubernetes_config_chat_llm_api_mode }}"
-  apiKeyEnv: {{ gen_kubernetes_config_chat_llm_api_key_env }}
 
-systemPrompt: |
-  You are the EthPandaOps assistant for the Ethereum devnet "{{ ethereum_network_name }}"
-  (chain id {{ chainId | default('unknown') }}). Help users understand devnet state and use
-  the EthPandaOps tooling: query live data with the `panda` skill, fund accounts with the
-  `faucet` skill, and join the network with the `join-devnet` skill. Always scope data
-  queries to this devnet and be concise.
-
-panda:
-  enabled: {{ gen_kubernetes_config_chat_panda_enabled | lower }}
-  proxyUrl: "{{ gen_kubernetes_config_chat_panda_proxy_url }}"
-  issuerUrl: "{{ gen_kubernetes_config_chat_panda_issuer_url }}"
-  clientId: "{{ gen_kubernetes_config_chat_panda_client_id }}"
-  sandboxImage: "{{ gen_kubernetes_config_chat_panda_sandbox_image }}"
-  storageDriver: "{{ gen_kubernetes_config_chat_panda_storage_driver }}"
-
+# LLM-call tracing → EthPandaOps Langfuse (keys from services.enc.yaml#chat).
 langfuse:
-  enabled: {{ gen_kubernetes_config_chat_langfuse_enabled | lower }}
-  baseUrl: "{{ gen_kubernetes_config_chat_langfuse_base_url }}"
+  enabled: true
+  baseUrl: "https://langfuse.analytics.production.platform.ethpandaops.io"
   env: "{{ ethereum_network_name }}"
 
+# Devnet tooling endpoints for the agent skills, derived from sibling services.
 devnetTools:
   faucet:
     enabled: {{ ('faucet' in gen_kubernetes_config_enabled_charts) | lower }}
@@ -50,7 +39,7 @@ devnetTools:
     rpcUrl: "{{ gen_kubernetes_config_dora_frontend_public_rpc }}"
     explorerUrl: "{{ gen_kubernetes_config_dora_frontend_explorer_link }}"
 
-# From services.enc.yaml#chat: llm_api_key, panda_credentials_json, panda_credentials_file.
+# From services.enc.yaml#chat.
 credentials:
   llmApiKey: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.llm_api_key}>"
   panda:
@@ -60,47 +49,21 @@ credentials:
     publicKey: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.langfuse_public_key}>"
     secretKey: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.langfuse_secret_key}>"
 
-resources:
-  requests:
-    cpu: 300m
-    memory: 1Gi
-  limits:
-    cpu: 3000m
-    memory: 6Gi
-
-persistence:
-  enabled: true
-  size: "{{ gen_kubernetes_config_chat_persistence_size }}"
-
-# Front end. Wired to the in-chart Hermes service (chat-hermes:8642).
+# Front end (subchart). Wired to the in-chart Hermes service; gated at the
+# Cloudflare Access edge via trusted-header SSO. The rest is chart default.
 open-webui:
-  enabled: true
-  ollama:
-    enabled: false
-  pipelines:
-    enabled: false
-  websocket:
-    enabled: false
-    redis:
-      enabled: false
-  persistence:
-    enabled: true
-    size: 5Gi
-  # Org gating: Cloudflare Access (edge) -> Open-WebUI trusted-header SSO.
-  # Requires a CF Access application on chat.{{ network_subdomain }} scoped to the org.
   sso:
     enabled: {{ gen_kubernetes_config_chat_auth_enabled | lower }}
-    enableSignup: true
     trustedHeader:
       enabled: {{ gen_kubernetes_config_chat_auth_enabled | lower }}
-      emailHeader: Cf-Access-Authenticated-User-Email
   openaiBaseApiUrls:
     - "http://chat-hermes:8642/v1"
   extraEnvVars:
     - name: ENABLE_OLLAMA_API
       value: "false"
+    # No password login when SSO is on; fall back to it when chat is public.
     - name: ENABLE_LOGIN_FORM
-      value: "{{ gen_kubernetes_config_chat_enable_login_form | lower }}"
+      value: "{{ (not gen_kubernetes_config_chat_auth_enabled) | lower }}"
     # Bearer for the in-cluster Hermes endpoint, read from the agent Secret.
     - name: OPENAI_API_KEYS
       valueFrom:
@@ -108,8 +71,6 @@ open-webui:
           name: chat-hermes-secret
           key: API_SERVER_KEY
   ingress:
-    enabled: true
-    class: ingress-nginx-public
     host: chat.{{ network_subdomain }}
 {% if gen_kubernetes_config_pandamenu_enabled %}
     annotations:


### PR DESCRIPTION
Follow-up cleanup on the chat (panda-chat) service. The block exposed ~18 `gen_kubernetes_config_chat_*` knobs, **most of which just re-stated the panda-chat chart's own `values.yaml` defaults** (image repo, `llm` provider/baseUrl/apiMode/apiKeyEnv, every `panda.*` proxy/issuer/client/sandbox/storage value, persistence size). That bloated both the role and the rendered per-devnet values for no benefit.

## Changes
- **Defaults:** keep only the 4 genuine knobs — `image` (optional pin; empty = chart appVersion), `llm_model`, `auth_enabled` (CF Access trusted-header SSO), `pandamenu`. Everything else falls through to the chart defaults.
- **Template (`chat.yaml.j2`):** emit only the per-devnet diff (network, chainId, `devnetTools`, `credentials`, ingress host, SSO toggle, agent endpoint wiring) + the EthPandaOps Langfuse infra. Dropped the `systemPrompt`/`resources`/`persistence`/`panda.*` overrides — the chart already defaults them identically.
- **Registry:** bump the (still-commented) `panda-chat` dep 0.1.0 → 0.1.1 to match the republished chart (ethereum-helm-charts#479).

Net: **−55 lines**. Chat remains **disabled** (registry entry stays commented out).

## Verification
`helm template` against the local panda-chat chart with the slimmed values renders cleanly (rc=0): agent image resolves to the chart default `:2026.6.5`, panda proxy/issuer/sandbox come from chart defaults, Langfuse + SSO + ingress host from the template. Jinja renders to valid YAML with the image block both present (pinned) and absent (default).