### PR TITLE
feat(generate_kubernetes_config): chat bot auth via Authentik service account

### DIFF
--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -98,6 +98,12 @@ gen_kubernetes_config_chat_panda_enabled: false # noqa var-naming[no-role-prefix
 # ext4/xfs), not the pod's overlay rootfs — so overlay2 stacks fine (fast CoW).
 # Fall back to vfs only on exotic nodes whose kubelet dir is itself overlayfs/NFS.
 gen_kubernetes_config_chat_panda_storage_driver: "overlay2" # noqa var-naming[no-role-prefix]
+# Telegram gateway for the chat agent (shared team bot per devnet). Needs
+# telegram_bot_token in services.enc.yaml#chat; allowed users are numeric
+# Telegram ids (comma-separated), group chats a list of chat ids.
+gen_kubernetes_config_chat_telegram_enabled: false # noqa var-naming[no-role-prefix]
+gen_kubernetes_config_chat_telegram_allowed_users: "" # noqa var-naming[no-role-prefix]
+gen_kubernetes_config_chat_telegram_group_chats: [] # noqa var-naming[no-role-prefix]
 # panda-chat chart version (>= 0.2.0 required when chat_panda_enabled).
 gen_kubernetes_config_chat_chart_version: "0.1.1" # noqa var-naming[no-role-prefix]
 # Optional image pin; empty = chart default tag (appVersion).

--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -87,18 +87,6 @@ gen_kubernetes_config_powfaucet_authenticatoor_grants: # noqa var-naming[no-role
 gen_kubernetes_config_pandamenu_enabled: true # noqa var-naming[no-role-prefix]
 gen_kubernetes_config_pandamenu_script: '<script src="https://pandamenu.ethpandaops.io/panda-menu-1.0.1.js" integrity="sha384-icGX6g6CzB0tqlhDc6Su4c6IPVbcbUvfM3xjbbFYsYBwuZR79WkmOxDhGEPfmyn2" crossorigin="anonymous"></script>' # noqa var-naming[no-role-prefix] yaml[line-length]
 
-# Chat (panda-chat) — Open-WebUI + Hermes + panda CLI. Opt-IN (unlike the other
-# charts, which are opt-out via gen_kubernetes_config_disabled_services): flip
-# gen_kubernetes_config_chat_enabled on per inventory. Minimum prereq is a
-# `chat` section in services.enc.yaml with llm_api_key + langfuse keys; the
-# panda integration (chat_panda_enabled) additionally needs panda_bot_username/
-# panda_bot_token (Authentik service account + app password, chat repo
-# docs/panda-bot-setup.md) and panda-chat chart >= 0.2.0. With panda off the
-# agent is a plain LLM chat (faucet/join-devnet skills still work), so a devnet
-# can spin chat up before the bot identity exists. Auth at the edge is a
-# Cloudflare Access app on chat.<network_subdomain> (chat_auth_enabled; off =
-# public with password login). Everything else uses the panda-chat chart
-# defaults; only these knobs are exposed:
 gen_kubernetes_config_chat_enabled: false # noqa var-naming[no-role-prefix]
 # Panda integration: panda-server sidecar + Authentik bot credentials.
 gen_kubernetes_config_chat_panda_enabled: false # noqa var-naming[no-role-prefix]

--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -106,6 +106,12 @@ gen_kubernetes_config_chat_panda_enabled: false # noqa var-naming[no-role-prefix
 gen_kubernetes_config_chat_chart_version: "0.1.1" # noqa var-naming[no-role-prefix]
 # Optional image pin; empty = chart default tag (appVersion).
 gen_kubernetes_config_chat_image: "" # noqa var-naming[no-role-prefix]
+# Hermes inference provider (anthropic / openrouter / openai / custom / ...)
+# and the env var the chart materializes credentials.llmApiKey into — hermes
+# resolves the key from that env. Model ID format follows the provider
+# (anthropic: claude-sonnet-4-6, openrouter: anthropic/claude-sonnet-4.6).
+gen_kubernetes_config_chat_llm_provider: "anthropic" # noqa var-naming[no-role-prefix]
+gen_kubernetes_config_chat_llm_api_key_env: "ANTHROPIC_API_KEY" # noqa var-naming[no-role-prefix]
 gen_kubernetes_config_chat_llm_model: "claude-sonnet-4-6" # noqa var-naming[no-role-prefix]
 # Cloudflare Access trusted-header SSO.
 gen_kubernetes_config_chat_auth_enabled: true # noqa var-naming[no-role-prefix]

--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -102,6 +102,10 @@ gen_kubernetes_config_pandamenu_script: '<script src="https://pandamenu.ethpanda
 gen_kubernetes_config_chat_enabled: false # noqa var-naming[no-role-prefix]
 # Panda integration: panda-server sidecar + Authentik bot credentials.
 gen_kubernetes_config_chat_panda_enabled: false # noqa var-naming[no-role-prefix]
+# dockerd storage driver for the panda-server sidecar. vfs works everywhere;
+# the chart's overlay2 default fails on nodes whose pod rootfs is already
+# overlayfs (nested overlay2 -> "driver not supported"), as on the devnet k8s.
+gen_kubernetes_config_chat_panda_storage_driver: "vfs" # noqa var-naming[no-role-prefix]
 # panda-chat chart version (>= 0.2.0 required when chat_panda_enabled).
 gen_kubernetes_config_chat_chart_version: "0.1.1" # noqa var-naming[no-role-prefix]
 # Optional image pin; empty = chart default tag (appVersion).

--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -89,11 +89,10 @@ gen_kubernetes_config_pandamenu_script: '<script src="https://pandamenu.ethpanda
 
 gen_kubernetes_config_chat_enabled: false # noqa var-naming[no-role-prefix]
 # Panda integration: panda-server sidecar + Authentik bot credentials.
+# Uses the "direct" sandbox backend — Python runs as a subprocess inside the
+# panda-server container, relying on the Kubernetes pod boundary for isolation.
+# No dockerd, no sandbox image, no privileged container.
 gen_kubernetes_config_chat_panda_enabled: false # noqa var-naming[no-role-prefix]
-# dockerd storage driver for the panda-server sidecar. vfs works everywhere;
-# the chart's overlay2 default fails on nodes whose pod rootfs is already
-# overlayfs (nested overlay2 -> "driver not supported"), as on the devnet k8s.
-gen_kubernetes_config_chat_panda_storage_driver: "vfs" # noqa var-naming[no-role-prefix]
 # panda-chat chart version (>= 0.2.0 required when chat_panda_enabled).
 gen_kubernetes_config_chat_chart_version: "0.1.1" # noqa var-naming[no-role-prefix]
 # Optional image pin; empty = chart default tag (appVersion).

--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -87,6 +87,24 @@ gen_kubernetes_config_powfaucet_authenticatoor_grants: # noqa var-naming[no-role
 gen_kubernetes_config_pandamenu_enabled: true # noqa var-naming[no-role-prefix]
 gen_kubernetes_config_pandamenu_script: '<script src="https://pandamenu.ethpandaops.io/panda-menu-1.0.1.js" integrity="sha384-icGX6g6CzB0tqlhDc6Su4c6IPVbcbUvfM3xjbbFYsYBwuZR79WkmOxDhGEPfmyn2" crossorigin="anonymous"></script>' # noqa var-naming[no-role-prefix] yaml[line-length]
 
+# Chat (panda-chat) — Open-WebUI + Hermes + panda CLI. Opt-IN (unlike the other
+# charts, which are opt-out via gen_kubernetes_config_disabled_services): flip
+# gen_kubernetes_config_chat_enabled on per inventory. Minimum prereq is a
+# `chat` section in services.enc.yaml with llm_api_key + langfuse keys; the
+# panda integration (chat_panda_enabled) additionally needs panda_bot_username/
+# panda_bot_token (Authentik service account + app password, chat repo
+# docs/panda-bot-setup.md) and panda-chat chart >= 0.2.0. With panda off the
+# agent is a plain LLM chat (faucet/join-devnet skills still work), so a devnet
+# can spin chat up before the bot identity exists. Auth at the edge is a
+# Cloudflare Access app on chat.<network_subdomain> (chat_auth_enabled; off =
+# public with password login). Everything else uses the panda-chat chart
+# defaults; only these knobs are exposed:
+gen_kubernetes_config_chat_enabled: false # noqa var-naming[no-role-prefix]
+# Panda integration: panda-server sidecar + Authentik bot credentials.
+gen_kubernetes_config_chat_panda_enabled: false # noqa var-naming[no-role-prefix]
+# panda-chat chart version (>= 0.2.0 required when chat_panda_enabled).
+gen_kubernetes_config_chat_chart_version: "0.1.1" # noqa var-naming[no-role-prefix]
+# Optional image pin; empty = chart default tag (appVersion).
 gen_kubernetes_config_chat_image: "" # noqa var-naming[no-role-prefix]
 gen_kubernetes_config_chat_llm_model: "claude-sonnet-4-6" # noqa var-naming[no-role-prefix]
 # Cloudflare Access trusted-header SSO.
@@ -95,7 +113,8 @@ gen_kubernetes_config_chat_auth_enabled: true # noqa var-naming[no-role-prefix]
 
 # Enabled charts configuration
 gen_kubernetes_config_disabled_services: [] # noqa var-naming[no-role-prefix]
-gen_kubernetes_config_enabled_charts: "{{ gen_kubernetes_config_helm_charts.keys() | reject('in', gen_kubernetes_config_disabled_services) | list }}" # noqa var-naming[no-role-prefix] yaml[line-length]
+# chat is opt-in: rejected here unless gen_kubernetes_config_chat_enabled.
+gen_kubernetes_config_enabled_charts: "{{ gen_kubernetes_config_helm_charts.keys() | reject('in', gen_kubernetes_config_disabled_services) | reject('in', [] if gen_kubernetes_config_chat_enabled else ['chat']) | list }}" # noqa var-naming[no-role-prefix] yaml[line-length]
 
 gen_kubernetes_config_helm_charts: # noqa var-naming[no-role-prefix]
   config:
@@ -133,12 +152,14 @@ gen_kubernetes_config_helm_charts: # noqa var-naming[no-role-prefix]
       - name: dora
         repository: https://ethpandaops.github.io/ethereum-helm-charts
         version: 1.0.10
+  # chat is opt-in via gen_kubernetes_config_chat_enabled (see the chat
+  # section above); listed here so the registry stays declarative.
   chat:
     valuesTemplatePath: templates/chat.yaml.j2
     dependencies:
       - name: panda-chat
         repository: https://ethpandaops.github.io/ethereum-helm-charts
-        version: 0.1.1
+        version: "{{ gen_kubernetes_config_chat_chart_version }}"
   forky:
     valuesTemplatePath: templates/forky.yaml.j2
     dependencies:

--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -89,10 +89,15 @@ gen_kubernetes_config_pandamenu_script: '<script src="https://pandamenu.ethpanda
 
 gen_kubernetes_config_chat_enabled: false # noqa var-naming[no-role-prefix]
 # Panda integration: panda-server sidecar + Authentik bot credentials.
-# Uses the "direct" sandbox backend — Python runs as a subprocess inside the
-# panda-server container, relying on the Kubernetes pod boundary for isolation.
-# No dockerd, no sandbox image, no privileged container.
+# Uses panda's "docker" sandbox backend — each execution runs in its own
+# sandbox container via an in-pod dockerd in the privileged panda-server
+# sidecar (the hermes container stays unprivileged and credential-free).
 gen_kubernetes_config_chat_panda_enabled: false # noqa var-naming[no-role-prefix]
+# dockerd storage driver for the panda-server sidecar. overlay2 is reliable
+# because the chart puts dockerd's data-root on a node-local emptyDir (real
+# ext4/xfs), not the pod's overlay rootfs — so overlay2 stacks fine (fast CoW).
+# Fall back to vfs only on exotic nodes whose kubelet dir is itself overlayfs/NFS.
+gen_kubernetes_config_chat_panda_storage_driver: "overlay2" # noqa var-naming[no-role-prefix]
 # panda-chat chart version (>= 0.2.0 required when chat_panda_enabled).
 gen_kubernetes_config_chat_chart_version: "0.1.1" # noqa var-naming[no-role-prefix]
 # Optional image pin; empty = chart default tag (appVersion).

--- a/roles/generate_kubernetes_config/templates/chat.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/chat.yaml.j2
@@ -1,75 +1,79 @@
 # {{ ansible_managed }}
-fullnameOverride: chat
+# Everything nests under the dependency chart's name — the generated wrapper
+# chart (Chart.yaml.j2) has no templates of its own, so top-level values
+# never reach the panda-chat subchart.
+panda-chat:
+  fullnameOverride: chat
 
-network: {{ ethereum_network_name }}
-chainId: "{{ ethereum_genesis_chain_id }}"
+  network: {{ ethereum_network_name }}
+  chainId: "{{ ethereum_genesis_chain_id }}"
 {% if gen_kubernetes_config_chat_image %}
 
-image:
-  repository: {{ gen_kubernetes_config_chat_image.split(':') | first }}
-  tag: {{ gen_kubernetes_config_chat_image.split(':') | last }}
-  pullPolicy: {% if "latest" in (gen_kubernetes_config_chat_image.split(':') | last) %}Always{% else %}IfNotPresent{% endif %}
+  image:
+    repository: {{ gen_kubernetes_config_chat_image.split(':') | first }}
+    tag: {{ gen_kubernetes_config_chat_image.split(':') | last }}
+    pullPolicy: {% if "latest" in (gen_kubernetes_config_chat_image.split(':') | last) %}Always{% else %}IfNotPresent{% endif %}
 
 {% endif %}
 
-llm:
-  model: {{ gen_kubernetes_config_chat_llm_model }}
+  llm:
+    model: {{ gen_kubernetes_config_chat_llm_model }}
 
-# Panda integration (panda-server sidecar + Authentik bot identity). Off =
-# plain LLM chat; the bot credentials are only referenced when on, so the
-# devnet can run chat before services.enc.yaml#chat has panda_bot_* keys.
-panda:
-  enabled: {{ gen_kubernetes_config_chat_panda_enabled | lower }}
-
-# LLM-call tracing → EthPandaOps Langfuse (keys from services.enc.yaml#chat).
-langfuse:
-  enabled: true
-  baseUrl: "https://langfuse.analytics.production.platform.ethpandaops.io"
-
-devnetTools:
-  faucet:
-    enabled: {{ ('faucet' in gen_kubernetes_config_enabled_charts) | lower }}
-    url: "https://faucet.{{ network_subdomain }}"
-  join:
-    configUrl: "https://config.{{ network_subdomain }}"
-    rpcUrl: "{{ gen_kubernetes_config_dora_frontend_public_rpc }}"
-    explorerUrl: "{{ gen_kubernetes_config_dora_frontend_explorer_link }}"
-
-credentials:
-  llmApiKey: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.llm_api_key}>"
-{% if gen_kubernetes_config_chat_panda_enabled %}
+  # Panda integration (panda-server sidecar + Authentik bot identity). Off =
+  # plain LLM chat; the bot credentials are only referenced when on, so the
+  # devnet can run chat before services.enc.yaml#chat has panda_bot_* keys.
   panda:
-    botUsername: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.panda_bot_username}>"
-    botToken: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.panda_bot_token}>"
-{% endif %}
-  langfuse:
-    publicKey: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.langfuse_public_key}>"
-    secretKey: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.langfuse_secret_key}>"
+    enabled: {{ gen_kubernetes_config_chat_panda_enabled | lower }}
 
-open-webui:
-  sso:
-    enabled: {{ gen_kubernetes_config_chat_auth_enabled | lower }}
-    trustedHeader:
+  # LLM-call tracing → EthPandaOps Langfuse (keys from services.enc.yaml#chat).
+  langfuse:
+    enabled: true
+    baseUrl: "https://langfuse.analytics.production.platform.ethpandaops.io"
+
+  devnetTools:
+    faucet:
+      enabled: {{ ('faucet' in gen_kubernetes_config_enabled_charts) | lower }}
+      url: "https://faucet.{{ network_subdomain }}"
+    join:
+      configUrl: "https://config.{{ network_subdomain }}"
+      rpcUrl: "{{ gen_kubernetes_config_dora_frontend_public_rpc }}"
+      explorerUrl: "{{ gen_kubernetes_config_dora_frontend_explorer_link }}"
+
+  credentials:
+    llmApiKey: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.llm_api_key}>"
+{% if gen_kubernetes_config_chat_panda_enabled %}
+    panda:
+      botUsername: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.panda_bot_username}>"
+      botToken: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.panda_bot_token}>"
+{% endif %}
+    langfuse:
+      publicKey: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.langfuse_public_key}>"
+      secretKey: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.langfuse_secret_key}>"
+
+  open-webui:
+    sso:
       enabled: {{ gen_kubernetes_config_chat_auth_enabled | lower }}
-  openaiBaseApiUrls:
-    - "http://chat-hermes:8642/v1"
-  extraEnvVars:
-    - name: ENABLE_OLLAMA_API
-      value: "false"
-    - name: ENABLE_LOGIN_FORM
-      value: "{{ (not gen_kubernetes_config_chat_auth_enabled) | lower }}"
-    - name: OPENAI_API_KEYS
-      valueFrom:
-        secretKeyRef:
-          name: chat-hermes-secret
-          key: API_SERVER_KEY
-  ingress:
-    host: chat.{{ network_subdomain }}
+      trustedHeader:
+        enabled: {{ gen_kubernetes_config_chat_auth_enabled | lower }}
+    openaiBaseApiUrls:
+      - "http://chat-hermes:8642/v1"
+    extraEnvVars:
+      - name: ENABLE_OLLAMA_API
+        value: "false"
+      - name: ENABLE_LOGIN_FORM
+        value: "{{ (not gen_kubernetes_config_chat_auth_enabled) | lower }}"
+      - name: OPENAI_API_KEYS
+        valueFrom:
+          secretKeyRef:
+            name: chat-hermes-secret
+            key: API_SERVER_KEY
+    ingress:
+      host: chat.{{ network_subdomain }}
 {% if gen_kubernetes_config_pandamenu_enabled %}
-    annotations:
-      nginx.ingress.kubernetes.io/proxy-body-size: "0"
-      nginx.ingress.kubernetes.io/configuration-snippet: |
-        sub_filter '</head>' '{{ gen_kubernetes_config_chat_pandamenu | default('') }}{{ gen_kubernetes_config_pandamenu_script }}</head>';
-        sub_filter_types text/html;
-        sub_filter_once off;
+      annotations:
+        nginx.ingress.kubernetes.io/proxy-body-size: "0"
+        nginx.ingress.kubernetes.io/configuration-snippet: |
+          sub_filter '</head>' '{{ gen_kubernetes_config_chat_pandamenu | default('') }}{{ gen_kubernetes_config_pandamenu_script }}</head>';
+          sub_filter_types text/html;
+          sub_filter_once off;
 {% endif %}

--- a/roles/generate_kubernetes_config/templates/chat.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/chat.yaml.j2
@@ -15,6 +15,13 @@ image:
 llm:
   model: {{ gen_kubernetes_config_chat_llm_model }}
 
+# Panda integration (panda-server sidecar + Authentik bot identity). Off =
+# plain LLM chat; the bot credentials are only referenced when on, so the
+# devnet can run chat before services.enc.yaml#chat has panda_bot_* keys.
+panda:
+  enabled: {{ gen_kubernetes_config_chat_panda_enabled | lower }}
+
+# LLM-call tracing → EthPandaOps Langfuse (keys from services.enc.yaml#chat).
 langfuse:
   enabled: true
   baseUrl: "https://langfuse.analytics.production.platform.ethpandaops.io"
@@ -30,9 +37,11 @@ devnetTools:
 
 credentials:
   llmApiKey: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.llm_api_key}>"
+{% if gen_kubernetes_config_chat_panda_enabled %}
   panda:
     botUsername: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.panda_bot_username}>"
     botToken: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.panda_bot_token}>"
+{% endif %}
   langfuse:
     publicKey: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.langfuse_public_key}>"
     secretKey: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.langfuse_secret_key}>"

--- a/roles/generate_kubernetes_config/templates/chat.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/chat.yaml.j2
@@ -31,8 +31,8 @@ devnetTools:
 credentials:
   llmApiKey: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.llm_api_key}>"
   panda:
-    credentialsJson: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.panda_credentials_json}>"
-    credentialsFile: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.panda_credentials_file}>"
+    botUsername: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.panda_bot_username}>"
+    botToken: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.panda_bot_token}>"
   langfuse:
     publicKey: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.langfuse_public_key}>"
     secretKey: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.langfuse_secret_key}>"

--- a/roles/generate_kubernetes_config/templates/chat.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/chat.yaml.j2
@@ -41,6 +41,27 @@ panda-chat:
       configUrl: "https://config.{{ network_subdomain }}"
       rpcUrl: "{{ gen_kubernetes_config_dora_frontend_public_rpc }}"
       explorerUrl: "{{ gen_kubernetes_config_dora_frontend_explorer_link }}"
+    # Declared tool map for the agent's context briefing (DEVNET_TOOL_URLS):
+    # only tools this role actually deploys for the devnet — the agent never
+    # probes or guesses URLs.
+    observability:
+{% for tool in ['dora', 'forky', 'tracoor', 'assertoor'] %}
+{% if tool in gen_kubernetes_config_enabled_charts %}
+      {{ tool }}: "https://{{ tool }}.{{ network_subdomain }}"
+{% endif %}
+{% endfor %}
+{% if gen_kubernetes_config_chat_telegram_enabled %}
+
+  # Telegram gateway: the SAME Hermes agent, reachable from Telegram on the go.
+  # Shared team bot per devnet (BotFather token in sops); the adapter long-polls
+  # Telegram so no ingress/webhook is needed and CF Access stays untouched.
+  telegram:
+    enabled: true
+    allowedUsers: "{{ gen_kubernetes_config_chat_telegram_allowed_users }}"
+{% if gen_kubernetes_config_chat_telegram_group_chats %}
+    groupAllowedChats: {{ gen_kubernetes_config_chat_telegram_group_chats | to_json }}
+{% endif %}
+{% endif %}
 
   credentials:
     # Stable OW<->Hermes bearer: the chart can't preserve a generated one under
@@ -55,6 +76,10 @@ panda-chat:
     langfuse:
       publicKey: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.langfuse_public_key}>"
       secretKey: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.langfuse_secret_key}>"
+{% if gen_kubernetes_config_chat_telegram_enabled %}
+    telegram:
+      botToken: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.telegram_bot_token}>"
+{% endif %}
 
   open-webui:
     sso:
@@ -73,6 +98,13 @@ panda-chat:
           secretKeyRef:
             name: chat-hermes-secret
             key: API_SERVER_KEY
+      # Branding + mobile quick-start prompts. NOTE: OW persists these on first
+      # boot (PersistentConfig) — changes need a fresh OW DB or an in-app edit.
+      - name: WEBUI_NAME
+        value: "{{ ethereum_network_name }} chat"
+      - name: DEFAULT_PROMPT_SUGGESTIONS
+        value: '[{"title": ["Devnet health check", "finality, slots, nodes"], "content": "Give me a health check of this devnet: finality status, recent missed slots, and any nodes that look unhealthy."}, {"title": ["Recent errors", "last hour, all clients"], "content": "Show error logs from the last hour across all clients and summarize what is failing."}, {"title": ["Node status", "head slot + sync per node"], "content": "List the nodes on this devnet with head slot and sync status for each."}, {"title": ["Fund my account", "faucet drip"], "content": "Fund my account with test ETH from the faucet: "}]'
+
     ingress:
       host: chat.{{ network_subdomain }}
 {% if gen_kubernetes_config_pandamenu_enabled %}

--- a/roles/generate_kubernetes_config/templates/chat.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/chat.yaml.j2
@@ -42,6 +42,9 @@ panda-chat:
       explorerUrl: "{{ gen_kubernetes_config_dora_frontend_explorer_link }}"
 
   credentials:
+    # Stable OW<->Hermes bearer: the chart can't preserve a generated one under
+    # ArgoCD (client-side `helm template`), so it must be a fixed sops value.
+    apiServerKey: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.api_server_key}>"
     llmApiKey: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.llm_api_key}>"
 {% if gen_kubernetes_config_chat_panda_enabled %}
     panda:

--- a/roles/generate_kubernetes_config/templates/chat.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/chat.yaml.j2
@@ -26,6 +26,7 @@ panda-chat:
   # devnet can run chat before services.enc.yaml#chat has panda_bot_* keys.
   panda:
     enabled: {{ gen_kubernetes_config_chat_panda_enabled | lower }}
+    storageDriver: "{{ gen_kubernetes_config_chat_panda_storage_driver }}"
 
   # LLM-call tracing → EthPandaOps Langfuse (keys from services.enc.yaml#chat).
   langfuse:

--- a/roles/generate_kubernetes_config/templates/chat.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/chat.yaml.j2
@@ -17,7 +17,9 @@ panda-chat:
 {% endif %}
 
   llm:
+    provider: {{ gen_kubernetes_config_chat_llm_provider }}
     model: {{ gen_kubernetes_config_chat_llm_model }}
+    apiKeyEnv: {{ gen_kubernetes_config_chat_llm_api_key_env }}
 
   # Panda integration (panda-server sidecar + Authentik bot identity). Off =
   # plain LLM chat; the bot credentials are only referenced when on, so the


### PR DESCRIPTION
## Summary

Chat template counterpart of the panda-chat 0.2.0 chart (ethpandaops/ethereum-helm-charts#481), plus chat enablement made fully configurable so a devnet can spin chat up **before** the bot identity exists:

**Credentials (panda-chat 0.2.0 schema):** AVP paths in `chat.yaml.j2` move from `{.panda_credentials_json}` / `{.panda_credentials_file}` to `{.panda_bot_username}` / `{.panda_bot_token}` (Authentik service account + app password; see ethpandaops/chat `docs/panda-bot-setup.md`).

**New knobs (all default-off / backward-compatible — no existing inventory changes behavior):**
- `gen_kubernetes_config_chat_enabled` (default `false`) — chat is now a permanent registry entry but **opt-in**: it's rejected from `enabled_charts` unless flipped on (the other charts stay opt-out via `disabled_services`).
- `gen_kubernetes_config_chat_panda_enabled` (default `false`) — gates the panda-server sidecar AND the `panda_bot_*` credential references. Off = plain LLM chat (faucet/join-devnet skills still work) needing only `llm_api_key` + langfuse keys in `services.enc.yaml#chat`; the panda keys aren't referenced so AVP can't fail on them.
- `gen_kubernetes_config_chat_chart_version` (default `"0.1.1"`) — bump to `>= 0.2.0` per inventory when enabling panda (the 0.2.0 schema requires it).

**Verified:** defaults parse; `enabled_charts` evaluates identically for all existing charts with the flag off, includes `chat` only when on, and `disabled_services` still works; `chat.yaml.j2` renders valid YAML in both panda modes (credentials.panda block present only when enabled).

Spin-up path today: set `chat_enabled: true` (panda off) with just `llm_api_key`/langfuse in SOPS → plain chat. After the panda release + platform deploy: add `panda_bot_*` keys, flip `chat_panda_enabled: true`, bump the chart version.