### PR TITLE
feat(generate_kubernetes_config): chat bot auth via client_credentials token

### DIFF
--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -93,7 +93,7 @@ gen_kubernetes_config_pandamenu_script: '<script src="https://pandamenu.ethpanda
 
 # Chat (panda-chat) — Open-WebUI + Hermes + panda CLI. Disabled for now (its
 # registry entry below is commented out). When enabled it needs a `chat` section
-# in services.enc.yaml (llm_api_key, panda_credentials_json, panda_credentials_file,
+# in services.enc.yaml (llm_api_key, panda_bot_token,
 # langfuse_public_key, langfuse_secret_key) and a Cloudflare Access app gating
 # chat.<network_subdomain>. Everything else uses the panda-chat chart defaults;
 # only these knobs are exposed:
@@ -180,7 +180,7 @@ gen_kubernetes_config_helm_charts: # noqa var-naming[no-role-prefix]
   #   dependencies:
   #     - name: panda-chat
   #       repository: https://ethpandaops.github.io/ethereum-helm-charts
-  #       version: 0.1.1
+  #       version: 0.2.0
   forky:
     valuesTemplatePath: templates/forky.yaml.j2
     dependencies:

--- a/roles/generate_kubernetes_config/templates/chat.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/chat.yaml.j2
@@ -43,8 +43,7 @@ devnetTools:
 credentials:
   llmApiKey: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.llm_api_key}>"
   panda:
-    credentialsJson: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.panda_credentials_json}>"
-    credentialsFile: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.panda_credentials_file}>"
+    botToken: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.panda_bot_token}>"
   langfuse:
     publicKey: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.langfuse_public_key}>"
     secretKey: "<path:/secrets/services/services.enc.yaml#chat | jsonPath {.langfuse_secret_key}>"


### PR DESCRIPTION
Companion to ethereum-helm-charts#482: the panda-chat chart 0.2.0 replaced seeded credential files with an Authentik service-account app password (panda#170 `client_credentials` mode — tokens minted in memory, no files, no rotation).

- `chat.yaml.j2`: `credentials.panda.{credentialsJson,credentialsFile}` → `credentials.panda.botToken` from `services.enc.yaml#chat.panda_bot_token` (already seeded, mirrors the production platform SOPS)
- defaults: required-keys comment updated; commented chat registry entry pinned to chart 0.2.0

The bot identity (`panda-chat-svc`) is live and verified in staging + production Authentik. Merge after the chart PR publishes 0.2.0.