### PR TITLE
generate_kubernetes_config: raise powfaucet max drop to 500 ETH, daily limit to 5000 ETH

### DIFF
--- a/roles/generate_kubernetes_config/templates/powfaucet.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/powfaucet.yaml.j2
@@ -75,7 +75,8 @@ powfaucet:
   faucetCaptchaSitekey: "<path:/secrets/services/services.enc.yaml#hcaptcha | jsonPath {.site_key}>"
   faucetCaptchaSecret: "<path:/secrets/services/services.enc.yaml#hcaptcha | jsonPath {.secret_key}>"
 
-  faucetRecurringLimitsAmountWei: 500000000000000000000 # 500 ETH
+  faucetRecurringLimitsAmountWei: 5000000000000000000000 # 5000 ETH
+  faucetMaxDropWei: 500000000000000000000 # 500 ETH
   faucetPowEnabled: true
   faucetPowRewardPerHash: 1000000000000000000 # 1 ETH
   faucetPowDifficulty: 10


### PR DESCRIPTION
Sets `faucetMaxDropWei` to 500 ETH (the powfaucet chart defaults `maxDropAmount` to 50 ETH; the template never set it) and bumps `faucetRecurringLimitsAmountWei` from 500 to 5000 ETH per day, so all devnets get these limits on config generation.

Replaces ethpandaops/glamsterdam-devnets#21 which patched the generated values at the devnet level.