### PR TITLE
fix: resolve docker run uid on the controller instead of remote facts

### DIFF
--- a/roles/ethereum_genesis/tasks/generate_genesis.yaml
+++ b/roles/ethereum_genesis/tasks/generate_genesis.yaml
@@ -43,7 +43,7 @@
     - name: Compute docker user flag
       ansible.builtin.set_fact:
         ethereum_genesis_docker_user_flag: >-
-          {{ ethereum_genesis_docker_is_rootless | ternary('', '-u ' ~ (ansible_effective_user_id | default(ansible_uid, true))) }}
+          {{ ethereum_genesis_docker_is_rootless | ternary('', '-u ' ~ lookup('ansible.builtin.pipe', 'id -u')) }}
 
     - name: Run genesis generator
       ansible.builtin.shell: >

--- a/roles/ethereum_genesis/tasks/generate_validator_keys.yaml
+++ b/roles/ethereum_genesis/tasks/generate_validator_keys.yaml
@@ -29,7 +29,7 @@
     - name: Compute docker user flag
       ansible.builtin.set_fact:
         ethereum_genesis_docker_user_flag: >-
-          {{ ethereum_genesis_docker_is_rootless | ternary('', '-u ' ~ (ansible_effective_user_id | default(ansible_uid, true))) }}
+          {{ ethereum_genesis_docker_is_rootless | ternary('', '-u ' ~ lookup('ansible.builtin.pipe', 'id -u')) }}
 
     - name: Set docker platform based on architecture
       ansible.builtin.set_fact:

--- a/roles/ethereum_inventory_web/tasks/main.yaml
+++ b/roles/ethereum_inventory_web/tasks/main.yaml
@@ -54,7 +54,7 @@
       ansible.builtin.set_fact:
         eth_inventory_web_docker_user_flag: >-
           {{ ('name=rootless' in eth_inventory_web_docker_secopts.stdout)
-          | ternary('', '-u ' ~ (ansible_effective_user_id | default(ansible_uid, true))) }}
+          | ternary('', '-u ' ~ lookup('ansible.builtin.pipe', 'id -u')) }}
         eth_inventory_web_mapping_arg: >-
           {{ (eth_inventory_web_mapping_stat.stat.exists | default(false))
           | ternary('--mapping /in/validator_names.yaml', '') }}


### PR DESCRIPTION
## Problem

`ethereum_inventory_web` fails with:

```
fatal: [bootnode-1 -> 127.0.0.1]: FAILED! => {"msg": "The task includes an option with an undefined variable.. 'ansible_uid' is undefined ..."}
```

The docker user flag is computed as:

```yaml
'-u ' ~ (ansible_effective_user_id | default(ansible_uid, true))
```

Two bugs compound here:

1. `ansible_effective_user_id` resolves from the **inventory host's** facts. When the play gathers facts with `become: true` (as the bootnode plays in the devnet repos do), it is `0` — and `default(..., true)` treats falsy values as missing, so it falls through to the fallback.
2. The fallback `ansible_uid` is not a real Ansible fact, so templating fails with an undefined variable error.

Even when it doesn't error, the value is wrong: these docker commands run in blocks delegated to `127.0.0.1` with `become: false`, so passing the *remote* host's euid (e.g. `-u 0`) to a *local* `docker run` defeats the purpose of the flag (writing output as the controller user).

The same expression in `ethereum_genesis` only works by accident because that role is normally applied to localhost, where the euid is non-zero.

## Fix

Use `lookup('ansible.builtin.pipe', 'id -u')`, which always evaluates on the controller — matching where the docker command actually runs. Applied to all three occurrences (`ethereum_inventory_web`, `ethereum_genesis/generate_genesis`, `ethereum_genesis/generate_validator_keys`).

Verified on glamsterdam-devnet-5: `-t ethereum_inventory_web -l bootnode` now completes and produces `-u 501` for the merge container.