### PR TITLE
Disable chat in generate_kubernetes_config

### DIFF
--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -133,12 +133,12 @@ gen_kubernetes_config_helm_charts: # noqa var-naming[no-role-prefix]
       - name: dora
         repository: https://ethpandaops.github.io/ethereum-helm-charts
         version: 1.0.10
-  chat:
-    valuesTemplatePath: templates/chat.yaml.j2
-    dependencies:
-      - name: panda-chat
-        repository: https://ethpandaops.github.io/ethereum-helm-charts
-        version: 0.1.1
+  # chat:
+  #   valuesTemplatePath: templates/chat.yaml.j2
+  #   dependencies:
+  #     - name: panda-chat
+  #       repository: https://ethpandaops.github.io/ethereum-helm-charts
+  #       version: 0.1.1
   forky:
     valuesTemplatePath: templates/forky.yaml.j2
     dependencies:


### PR DESCRIPTION
Comments out the `chat` app (panda-chat) in the `generate_kubernetes_config` role defaults to disable it for now.