### PR TITLE
feat(generate_kubernetes_config): add faucet-agents chart for agent PoW faucet

### DIFF
--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -124,13 +124,14 @@ gen_kubernetes_config_helm_charts: # noqa var-naming[no-role-prefix]
     dependencies:
       - name: powfaucet
         repository: https://ethpandaops.github.io/ethereum-helm-charts
-        version: 1.1.0 # >=1.1.0 for the faucetConcurrencyByAddrOnly value below
+        version: 1.1.0 # >=1.1.0 for the ConcurrencyByAddrOnly / RecurringLimitsByAddrOnly values below
     faucetOverride:
       fullnameOverride: powfaucet-agents
       dnsPrefix: faucet-agents
       titleSuffix: Agent Faucet
       privkeySopsKey: faucet_agents_private_key
-      imageVar: powfaucet_agents
+      imageVar: powfaucet_agents # inventory override; falls back to imageDefault below
+      imageDefault: ghcr.io/qu0b/powfaucet:v2.5.0-agent.4 # PoWFaucet fork with the agent REST mining API
       captchaEnabled: false
       pandamenuEnabled: false
       authenticatoorEnabled: false
@@ -138,6 +139,7 @@ gen_kubernetes_config_helm_charts: # noqa var-naming[no-role-prefix]
       powDifficulty: 8 # lower than the browser faucet (10): agents mine on CPU, keep claims quick
       ipinfoEnabled: false # reached only via the panda proxy; per-IP checks don't apply
       concurrencyByAddrOnly: true # proxy shares one IP; limit concurrency per target address, not per IP
+      recurringLimitsByAddrOnly: true # same: per-IP recurring limits would be a global budget behind the proxy
       # Staged lockdown — set only after the panda proxy ships its faucet
       # handler (it breaks both access paths before that), pointing at the
       # htpasswd secret holding the credential the proxy forwards:

--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -124,7 +124,7 @@ gen_kubernetes_config_helm_charts: # noqa var-naming[no-role-prefix]
     dependencies:
       - name: powfaucet
         repository: https://ethpandaops.github.io/ethereum-helm-charts
-        version: 1.0.0
+        version: 1.1.0 # >=1.1.0 for the faucetConcurrencyByAddrOnly value below
     faucetOverride:
       fullnameOverride: powfaucet-agents
       dnsPrefix: faucet-agents
@@ -137,6 +137,7 @@ gen_kubernetes_config_helm_charts: # noqa var-naming[no-role-prefix]
       restWalletSopsKey: faucet_agents_rest_private_key
       powDifficulty: 8 # lower than the browser faucet (10): agents mine on CPU, keep claims quick
       ipinfoEnabled: false # reached only via the panda proxy; per-IP checks don't apply
+      concurrencyByAddrOnly: true # proxy shares one IP; limit concurrency per target address, not per IP
       # Staged lockdown — set only after the panda proxy ships its faucet
       # handler (it breaks both access paths before that), pointing at the
       # htpasswd secret holding the credential the proxy forwards:

--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -136,6 +136,7 @@ gen_kubernetes_config_helm_charts: # noqa var-naming[no-role-prefix]
       authenticatoorEnabled: false
       restWalletSopsKey: faucet_agents_rest_private_key
       powDifficulty: 8 # lower than the browser faucet (10): agents mine on CPU, keep claims quick
+      ipinfoEnabled: false # reached only via the panda proxy; per-IP checks don't apply
   forkmon:
     valuesTemplatePath: templates/forkmon.yaml.j2
     dependencies:

--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -137,6 +137,10 @@ gen_kubernetes_config_helm_charts: # noqa var-naming[no-role-prefix]
       restWalletSopsKey: faucet_agents_rest_private_key
       powDifficulty: 8 # lower than the browser faucet (10): agents mine on CPU, keep claims quick
       ipinfoEnabled: false # reached only via the panda proxy; per-IP checks don't apply
+      # Staged lockdown — set only after the panda proxy ships its faucet
+      # handler (it breaks both access paths before that), pointing at the
+      # htpasswd secret holding the credential the proxy forwards:
+      # ingressAuthSecret: powfaucet-agents-basic-auth
   forkmon:
     valuesTemplatePath: templates/forkmon.yaml.j2
     dependencies:

--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -118,7 +118,7 @@ gen_kubernetes_config_helm_charts: # noqa var-naming[no-role-prefix]
     dependencies:
       - name: powfaucet
         repository: https://ethpandaops.github.io/ethereum-helm-charts
-        version: 1.0.0
+        version: 1.1.0 # >=1.1.0 omits ethTxGasLimit unless set, so the faucet's own default applies
   faucet-agents:
     valuesTemplatePath: templates/powfaucet.yaml.j2
     dependencies:

--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -135,6 +135,7 @@ gen_kubernetes_config_helm_charts: # noqa var-naming[no-role-prefix]
       pandamenuEnabled: false
       authenticatoorEnabled: false
       restWalletSopsKey: faucet_agents_rest_private_key
+      powDifficulty: 8 # lower than the browser faucet (10): agents mine on CPU, keep claims quick
   forkmon:
     valuesTemplatePath: templates/forkmon.yaml.j2
     dependencies:

--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -131,7 +131,7 @@ gen_kubernetes_config_helm_charts: # noqa var-naming[no-role-prefix]
       titleSuffix: Agent Faucet
       privkeySopsKey: faucet_agents_private_key
       imageVar: powfaucet_agents # inventory override; falls back to imageDefault below
-      imageDefault: ghcr.io/qu0b/powfaucet:v2.5.0-agent.4 # PoWFaucet fork with the agent REST mining API
+      imageDefault: ghcr.io/qu0b/powfaucet:v2.5.0-agent.5 # PoWFaucet fork with the agent REST mining API
       captchaEnabled: false
       pandamenuEnabled: false
       authenticatoorEnabled: false

--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -119,6 +119,22 @@ gen_kubernetes_config_helm_charts: # noqa var-naming[no-role-prefix]
       - name: powfaucet
         repository: https://ethpandaops.github.io/ethereum-helm-charts
         version: 1.0.0
+  faucet-agents:
+    valuesTemplatePath: templates/powfaucet.yaml.j2
+    dependencies:
+      - name: powfaucet
+        repository: https://ethpandaops.github.io/ethereum-helm-charts
+        version: 1.0.0
+    faucetOverride:
+      fullnameOverride: powfaucet-agents
+      dnsPrefix: faucet-agents
+      titleSuffix: Agent Faucet
+      privkeySopsKey: faucet_agents_private_key
+      imageVar: powfaucet_agents
+      captchaEnabled: false
+      pandamenuEnabled: false
+      authenticatoorEnabled: false
+      restWalletSopsKey: faucet_agents_rest_private_key
   forkmon:
     valuesTemplatePath: templates/forkmon.yaml.j2
     dependencies:

--- a/roles/generate_kubernetes_config/templates/powfaucet.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/powfaucet.yaml.j2
@@ -76,6 +76,10 @@ powfaucet:
   faucetCaptchaSitekey: "<path:/secrets/services/services.enc.yaml#hcaptcha | jsonPath {.site_key}>"
   faucetCaptchaSecret: "<path:/secrets/services/services.enc.yaml#hcaptcha | jsonPath {.secret_key}>"
 
+  # IP-reputation checks make no sense when the faucet is only reached via the
+  # panda proxy (every request carries the proxy's IP), so agents disable it.
+  faucetIpinfoEnabled: {{ item.value.faucetOverride.ipinfoEnabled | default(true) | lower }}
+
   faucetRecurringLimitsAmountWei: 5000000000000000000000 # 5000 ETH
   faucetMaxDropWei: 500000000000000000000 # 500 ETH
   faucetPowEnabled: true

--- a/roles/generate_kubernetes_config/templates/powfaucet.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/powfaucet.yaml.j2
@@ -91,6 +91,10 @@ powfaucet:
   # panda proxy (every request carries the proxy's IP), so agents disable it.
   faucetIpinfoEnabled: {{ item.value.faucetOverride.ipinfoEnabled | default(true) | lower }}
 
+  # Same reason: behind the proxy all traffic shares one IP, so per-IP
+  # concurrency collapses to one global session. Limit per target address only.
+  faucetConcurrencyByAddrOnly: {{ item.value.faucetOverride.concurrencyByAddrOnly | default(false) | lower }}
+
   faucetRecurringLimitsAmountWei: 5000000000000000000000 # 5000 ETH
   faucetMaxDropWei: 500000000000000000000 # 500 ETH
   faucetPowEnabled: true

--- a/roles/generate_kubernetes_config/templates/powfaucet.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/powfaucet.yaml.j2
@@ -22,13 +22,24 @@ powfaucet:
     enabled: true
 
     className: ingress-nginx-public
-{% if (item.value.faucetOverride.pandamenuEnabled | default(true)) and gen_kubernetes_config_pandamenu_enabled %}
+{% set _pandamenu = (item.value.faucetOverride.pandamenuEnabled | default(true)) and gen_kubernetes_config_pandamenu_enabled %}
+{% set _ingress_auth_secret = item.value.faucetOverride.ingressAuthSecret | default('') %}
+{% if _pandamenu or _ingress_auth_secret %}
     annotations:
+{% if _pandamenu %}
       nginx.ingress.kubernetes.io/proxy-body-size: "0"
       nginx.ingress.kubernetes.io/configuration-snippet: |
         sub_filter '</head>' '{{ gen_kubernetes_config_powfaucet_pandamenu | default('') }}{{ gen_kubernetes_config_pandamenu_script }}</head>';
         sub_filter_types text/html;
         sub_filter_once off;
+{% endif %}
+{% if _ingress_auth_secret %}
+      # Lock the faucet behind basic auth that only the panda proxy holds, so it
+      # is reachable solely via the proxy (which authenticates the caller first).
+      nginx.ingress.kubernetes.io/auth-type: basic
+      nginx.ingress.kubernetes.io/auth-secret: {{ _ingress_auth_secret }}
+      nginx.ingress.kubernetes.io/auth-realm: "panda proxy only"
+{% endif %}
 {% endif %}
 
     hosts:

--- a/roles/generate_kubernetes_config/templates/powfaucet.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/powfaucet.yaml.j2
@@ -1,12 +1,13 @@
 # {{ ansible_managed }}
 
 powfaucet:
-  fullnameOverride: powfaucet
+  fullnameOverride: {{ item.value.faucetOverride.fullnameOverride | default('powfaucet') }}
 
+{% set _img = default_tooling_images[item.value.faucetOverride.imageVar | default('powfaucet')] %}
   image:
-    repository: {{ default_tooling_images.powfaucet.split(':') | first }}
-    tag: {{ default_tooling_images.powfaucet.split(':') | last}}
-    pullPolicy: {% if "latest" in (default_tooling_images.powfaucet.split(':') | last) %}Always{% else %}IfNotPresent{% endif %}
+    repository: {{ _img.split(':') | first }}
+    tag: {{ _img.split(':') | last}}
+    pullPolicy: {% if "latest" in (_img.split(':') | last) %}Always{% else %}IfNotPresent{% endif %}
 
 
   resources:
@@ -21,7 +22,7 @@ powfaucet:
     enabled: true
 
     className: ingress-nginx-public
-{% if gen_kubernetes_config_pandamenu_enabled %}
+{% if (item.value.faucetOverride.pandamenuEnabled | default(true)) and gen_kubernetes_config_pandamenu_enabled %}
     annotations:
       nginx.ingress.kubernetes.io/proxy-body-size: "0"
       nginx.ingress.kubernetes.io/configuration-snippet: |
@@ -31,14 +32,14 @@ powfaucet:
 {% endif %}
 
     hosts:
-      - host: faucet.{{ network_subdomain }}
+      - host: {{ item.value.faucetOverride.dnsPrefix | default('faucet') }}.{{ network_subdomain }}
         paths:
           - path: /
             pathType: Prefix
   httpProxyCount: 2
 
-  faucetTitle: "{{ ethereum_network_name }} PoW Faucet"
-  faucetPrivkey: "<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.faucet_private_key}>"
+  faucetTitle: "{{ ethereum_network_name }} {{ item.value.faucetOverride.titleSuffix | default('PoW Faucet') }}"
+  faucetPrivkey: "{{ item.value.faucetOverride.privkeySopsRef | default('<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.' + devnet_name + '-devnets.' + (item.value.faucetOverride.privkeySopsKey | default('faucet_private_key')) + '}>') }}"
   faucetRpcUrl: "https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@{{ ethereum_node_rpc_prefix }}{{ primary_bootnode }}.{{ network_server_subdomain }}"
 {# Multi-RPC endpoint list. If the operator set gen_kubernetes_config_powfaucet_rpc_endpoints, that wins.
    Otherwise auto-generate from inventory: tooling/bootnode first, then ethereum_node clients sorted
@@ -71,7 +72,7 @@ powfaucet:
   faucetExplorerLink: "{{ gen_kubernetes_config_dora_frontend_explorer_link }}/tx/{txid}"
   faucetTxGasLimit: 100000
 
-  faucetCaptchaEnabled: true
+  faucetCaptchaEnabled: {{ item.value.faucetOverride.captchaEnabled | default(true) | lower }}
   faucetCaptchaSitekey: "<path:/secrets/services/services.enc.yaml#hcaptcha | jsonPath {.site_key}>"
   faucetCaptchaSecret: "<path:/secrets/services/services.enc.yaml#hcaptcha | jsonPath {.secret_key}>"
 
@@ -81,7 +82,7 @@ powfaucet:
   faucetPowRewardPerHash: 1000000000000000000 # 1 ETH
   faucetPowDifficulty: 10
 
-{% if gen_kubernetes_config_powfaucet_authenticatoor_enabled %}
+{% if (item.value.faucetOverride.authenticatoorEnabled | default(true)) and gen_kubernetes_config_powfaucet_authenticatoor_enabled %}
   faucetAuthenticatoorEnabled: true
   faucetAuthenticatoorAuthUrl: "https://auth.{{ network_subdomain }}"
   faucetAuthenticatoorExpectedAudience: "{{ network_subdomain }}"
@@ -89,4 +90,14 @@ powfaucet:
   faucetAuthenticatoorGrants:
 {{ gen_kubernetes_config_powfaucet_authenticatoor_grants | to_nice_yaml(indent=2) | indent(4, true) }}
 {% endif %}
+{% endif %}
+
+{% if item.value.faucetOverride.restWalletSopsRef is defined %}
+  extraEnv:
+    - name: FAUCET_ETH_REST_WALLET_KEY
+      value: "{{ item.value.faucetOverride.restWalletSopsRef }}"
+{% elif item.value.faucetOverride.restWalletSopsKey is defined %}
+  extraEnv:
+    - name: FAUCET_ETH_REST_WALLET_KEY
+      value: "{{ '<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.' + devnet_name + '-devnets.' + item.value.faucetOverride.restWalletSopsKey + '}>' }}"
 {% endif %}

--- a/roles/generate_kubernetes_config/templates/powfaucet.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/powfaucet.yaml.j2
@@ -80,7 +80,7 @@ powfaucet:
   faucetMaxDropWei: 500000000000000000000 # 500 ETH
   faucetPowEnabled: true
   faucetPowRewardPerHash: 1000000000000000000 # 1 ETH
-  faucetPowDifficulty: 10
+  faucetPowDifficulty: {{ item.value.faucetOverride.powDifficulty | default(10) }}
 
 {% if (item.value.faucetOverride.authenticatoorEnabled | default(true)) and gen_kubernetes_config_powfaucet_authenticatoor_enabled %}
   faucetAuthenticatoorEnabled: true

--- a/roles/generate_kubernetes_config/templates/powfaucet.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/powfaucet.yaml.j2
@@ -3,7 +3,10 @@
 powfaucet:
   fullnameOverride: {{ item.value.faucetOverride.fullnameOverride | default('powfaucet') }}
 
-{% set _img = default_tooling_images[item.value.faucetOverride.imageVar | default('powfaucet')] %}
+{# Inventory image var wins; else the chart entry's pinned default. No further
+   fallback — an unresolvable image should fail the template, not deploy the
+   wrong faucet build. #}
+{% set _img = default_tooling_images[item.value.faucetOverride.imageVar | default('powfaucet')] | default(item.value.faucetOverride.imageDefault) %}
   image:
     repository: {{ _img.split(':') | first }}
     tag: {{ _img.split(':') | last}}
@@ -94,6 +97,9 @@ powfaucet:
   # Same reason: behind the proxy all traffic shares one IP, so per-IP
   # concurrency collapses to one global session. Limit per target address only.
   faucetConcurrencyByAddrOnly: {{ item.value.faucetOverride.concurrencyByAddrOnly | default(false) | lower }}
+
+  # And per-IP recurring limits would be one global budget for all agents.
+  faucetRecurringLimitsByAddrOnly: {{ item.value.faucetOverride.recurringLimitsByAddrOnly | default(false) | lower }}
 
   faucetRecurringLimitsAmountWei: 5000000000000000000000 # 5000 ETH
   faucetMaxDropWei: 500000000000000000000 # 500 ETH

--- a/roles/generate_kubernetes_config/templates/powfaucet.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/powfaucet.yaml.j2
@@ -84,7 +84,6 @@ powfaucet:
 {%   endfor %}
 {% endif %}
   faucetExplorerLink: "{{ gen_kubernetes_config_dora_frontend_explorer_link }}/tx/{txid}"
-  faucetTxGasLimit: 100000
 
   faucetCaptchaEnabled: {{ item.value.faucetOverride.captchaEnabled | default(true) | lower }}
   faucetCaptchaSitekey: "<path:/secrets/services/services.enc.yaml#hcaptcha | jsonPath {.site_key}>"


### PR DESCRIPTION
## What

Adds a **`faucet-agents`** chart to `generate_kubernetes_config`: a second, agent-friendly PoW faucet rendered from the same `powfaucet.yaml.j2` template via `item.value.faucetOverride`.

The agent faucet overrides the regular faucet:
- separate ingress host (`faucet-agents.<subdomain>`) and wallet keys (`faucet_agents_private_key` + `faucet_agents_rest_private_key`, the latter exported as `FAUCET_ETH_REST_WALLET_KEY`);
- separate image: `default_tooling_images.powfaucet_agents` if the inventory defines it, else the pinned `imageDefault` (`ghcr.io/qu0b/powfaucet:v2.5.0-agent.5`, a PoWFaucet build with the agent REST mining API);
- captcha / pandamenu / authenticatoor disabled (agents mine via the REST API, not the browser);
- **`powDifficulty` override** — agent faucet defaults to 8 (browser faucet stays 10) so CPU claims stay quick;
- **`concurrencyByAddrOnly` + `recurringLimitsByAddrOnly`** (powfaucet chart 1.1.0, ethereum-helm-charts#485 — merged) — behind the panda proxy all requests share one IP, so per-IP concurrency collapses to a single global session and the per-IP recurring limit becomes a global daily budget; both checks are scoped to the target address instead.

**Enabled by default**, like every other chart. Networks that don't want it (or haven't added the two `faucet_agents_*` secret keys) disable it the standard way: `gen_kubernetes_config_disabled_services: [faucet-agents]`. Without the keys only the faucet-agents ArgoCD app fails to render — nothing else is affected.

**Drops the `faucetTxGasLimit: 100000` hardcode** from the template: the faucet app owns the sane default now (its default covers a transfer that creates the recipient account — ~207k measured under Amsterdam rules via `eth_estimateGas`). powfaucet chart 1.1.0 omits `ethTxGasLimit` unless explicitly set, so both chart entries bump to 1.1.0. Supersedes the template side of #567.

Backward compatible: the regular `faucet` chart has no `faucetOverride`, so every lookup falls back to the previous hardcoded value via `| default()`.

## Rollout per devnet

1. Add `faucet_agents_private_key` + `faucet_agents_rest_private_key` to the network's services secret store (fresh wallet — do not reuse the browser faucet key, the two instances would race on nonces), or disable via `gen_kubernetes_config_disabled_services`.
2. After the panda proxy ships the faucet handler (panda#277), lock the ingress down via the staged `ingressAuthSecret` comment.