### PR TITLE
xatu_sentry: add xatu_sentry_config_beacon_subscriptions variable

### DIFF
--- a/roles/xatu_sentry/defaults/main.yaml
+++ b/roles/xatu_sentry/defaults/main.yaml
@@ -25,6 +25,9 @@ xatu_sentry_config_server_tls_enabled: true
 xatu_sentry_config_server_auth_user: xatu-user
 xatu_sentry_config_server_auth_password: xatu-password
 xatu_sentry_config_network_name_override: ""
+# Extra beacon event topics to subscribe to. When empty, the sentry uses its
+# built-in default subscription set.
+xatu_sentry_config_beacon_subscriptions: []
 
 xatu_sentry_config: |
   logging: "info"
@@ -33,6 +36,12 @@ xatu_sentry_config: |
   ethereum:
     beaconNodeAddress: {{ xatu_sentry_config_beacon_uri }}
     overrideNetworkName: {{ xatu_sentry_config_network_name_override }}
+  {%- if xatu_sentry_config_beacon_subscriptions %}
+    beaconSubscriptions:
+  {%- for topic in xatu_sentry_config_beacon_subscriptions %}
+      - {{ topic }}
+  {%- endfor %}
+  {%- endif %}
   outputs:
   - name: grpc
     type: xatu


### PR DESCRIPTION
Inventories that need extra beacon event topics (e.g. the six Gloas SSE topics, which the sentry's built-in default subscription set deliberately excludes) currently have to override the entire `xatu_sentry_config` template string just to add a `beaconSubscriptions` list — forking them from the role template and creating drift risk.

This exposes `xatu_sentry_config_beacon_subscriptions` (default `[]`) and renders the list into the config only when non-empty, so the default rendered output is byte-identical to before. Verified both render paths produce valid YAML.

Motivated by the glamsterdam-devnets rollout, where group_vars currently carries a full-config override for exactly this reason; once this merges that override shrinks back to leaf variables.