### PR TITLE
feat(generate_kubernetes_config): project the devnet's xatu tag into config values

### DIFF
--- a/roles/generate_kubernetes_config/templates/config.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/config.yaml.j2
@@ -81,3 +81,8 @@ config:
     - path: /api/v1/nodes/validator-ranges
       upstream: {{ primary_bootnode }}.{{ network_server_subdomain }}
       target: /meta/api/v1/validator-ranges.json
+
+{% if default_tooling_images is defined and default_tooling_images.xatu_sentry is defined %}
+xatu:
+  tag: {{ default_tooling_images.xatu_sentry.split(':') | last }}
+{% endif %}


### PR DESCRIPTION
The generated `kubernetes/<devnet>/config/values.yaml` is what the platform ArgoCD ApplicationSets read through their git files generator. Emit the tag of the devnet's `xatu_sentry` image, so a devnet's xatu pin lives only in its own `images.yaml` instead of being restated per class in the platform repo.

`xatu_sentry` stays the single knob — no new variables. Platform prefixes `release/` onto the tag when it needs the branch for the migrator.

Devnets that set no `xatu_sentry` publish no block and are unaffected.

Pairs with ethpandaops/glamsterdam-devnets#34 and ethpandaops/platform#372.

https://claude.ai/code/session_01J2RzFzqWHvyHbEmVWJscZf