### PR TITLE
feat(generate_kubernetes_config): make assertoor test list configurable

### DIFF
--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -57,6 +57,7 @@ gen_kubernetes_config_dora_execution_indexer_details_max_size: "100GB" # noqa va
 gen_kubernetes_config_dora_postgres_size: >- # noqa var-naming[no-role-prefix]
   {{ "80Gi" if gen_kubernetes_config_dora_execution_indexer_enabled else "10Gi" }}
 gen_kubernetes_config_dora_mev_relays: [] # noqa var-naming[no-role-prefix]
+gen_kubernetes_config_assertoor_tests: [] # noqa var-naming[no-role-prefix]
 gen_kubernetes_config_dora_buildoor_overview_url: "https://buildoor.{{ network_subdomain }}" # noqa var-naming[no-role-prefix]
 
 # authenticatoor configuration

--- a/roles/generate_kubernetes_config/templates/assertoor.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/assertoor.yaml.j2
@@ -60,4 +60,9 @@ assertoor:
 {% endif %}
 {% endfor %}
 
+{% if gen_kubernetes_config_assertoor_tests | length > 0 %}
+  assertoorTests:
+{{ gen_kubernetes_config_assertoor_tests | to_nice_yaml(indent=2) | indent(4, true) }}
+{%- else %}
   assertoorTests: []
+{% endif %}


### PR DESCRIPTION
## What

The assertoor values template hardcodes `assertoorTests: []`, so there is no way to register assertoor tests from a devnet's inventory — test registration currently happens ad-hoc via the assertoor API and is lost on redeploys.

This adds a `gen_kubernetes_config_assertoor_tests` role var (default `[]`, keeping current output byte-identical) that is rendered into `assertoorTests` when set. Entries use assertoor's external-test registration schema, e.g.:

```yaml
gen_kubernetes_config_assertoor_tests:
  - id: deploy-eip8282-contracts
    file: https://raw.githubusercontent.com/ethpandaops/assertoor/master/playbooks/gloas-dev/deploy-eip8282-contracts.yaml
    schedule:
      startup: true
```

## Why

glamsterdam-devnet-7 omits the EIP-8282 builder request contracts from genesis and deploys them pre-gloas via an assertoor startup test (ethpandaops/assertoor#217). That test must be registered declaratively so it survives redeploys and runs as soon as assertoor comes up.

## Verification

Rendered the new block with ansible (`to_nice_yaml | indent`) against a populated list — output parses back to the exact registration entries; with the var unset the template still renders `assertoorTests: []`.