### PR TITLE
fix(generate_kubernetes_config): tolerate helm repos stored with trailing-slash URLs

### DIFF
--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -30,7 +30,7 @@ gen_kubernetes_config_helm_repositories: # noqa var-naming[no-role-prefix]
   - name: ethereum-helm-charts
     url: https://ethpandaops.github.io/ethereum-helm-charts
   - name: blobscan-helm-charts
-    url: https://blobscan.github.io/blobscan-helm-charts/
+    url: https://blobscan.github.io/blobscan-helm-charts
   - name: blockscout-helm-charts
     url: https://blockscout.github.io/helm-charts
   - name: bitnami

--- a/roles/generate_kubernetes_config/tasks/helm_repositories.yaml
+++ b/roles/generate_kubernetes_config/tasks/helm_repositories.yaml
@@ -1,5 +1,10 @@
+# kubernetes.core.helm_repository strips the trailing slash from the requested
+# URL but compares it against the stored URL verbatim, so a repo previously
+# added with a trailing slash fails with "Repository already have a repository
+# named ..." on every run. force_update re-adds instead of failing.
 - name: Add helm repository for {{ item.name }}
   kubernetes.core.helm_repository:
     name: "{{ item.name }}"
     url: "{{ item.url }}"
     state: present
+    force_update: true


### PR DESCRIPTION
## Problem

Running any playbook that includes `generate_kubernetes_config` fails on hosts where a helm repository was previously added with a trailing-slash URL:

```
TASK [ethpandaops.general.generate_kubernetes_config : Add helm repository for blobscan-helm-charts]
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Repository already have a repository named blobscan-helm-charts"}
```

Root cause is an asymmetric comparison in `kubernetes.core.helm_repository` (present on their `main` too): the module normalizes the *requested* URL with `rstrip("/")` but compares it against the *stored* URL from `helm repo list` verbatim:

```python
repo_url = repo_url.rstrip("/")
...
elif repository_status["url"] != repo_url:
    module.fail_json(msg="Repository already have a repository named {0}".format(repo_name))
```

So a repo stored as `https://blobscan.github.io/blobscan-helm-charts/` (added by an older module version, or manually via `helm repo add`) mismatches the stripped `...blobscan-helm-charts` forever — every subsequent run fails and the only manual escape is `helm repo remove`.

## Fix

- Pass `force_update: true` to `kubernetes.core.helm_repository` so an existing entry is re-added (`helm repo add --force-update`) instead of failing on the URL comparison. Tradeoff: the task now always reports `changed`.
- Drop the trailing slash from the `blobscan-helm-charts` default URL so fresh installs store the normalized form.

## Verification

Reproduced the bad state and confirmed the fix heals it:

```
$ helm repo add blobscan-helm-charts https://blobscan.github.io/blobscan-helm-charts/
$ ansible localhost -m kubernetes.core.helm_repository -a "name=blobscan-helm-charts url=https://blobscan.github.io/blobscan-helm-charts/"
localhost | FAILED! => {"msg": "Repository already have a repository named blobscan-helm-charts"}

$ ansible localhost -m kubernetes.core.helm_repository -a "name=blobscan-helm-charts url=https://blobscan.github.io/blobscan-helm-charts/ force_update=true"
localhost | CHANGED => {"command": ".../helm repo add blobscan-helm-charts https://blobscan.github.io/blobscan-helm-charts --force-update"}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)