### PR TITLE
feat(generate_kubernetes_config): support git-lfs parsed genesis redirect

### DIFF
--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -38,6 +38,11 @@ gen_kubernetes_config_helm_repositories: # noqa var-naming[no-role-prefix]
   - name: ethpandaops-general-helm-charts
     url: https://ethpandaops.github.io/general-helm-charts
 
+# Set to true when parsedConsensusGenesis.json is tracked with git-lfs (file
+# over GitHub's 100MB limit): raw.githubusercontent.com only serves the LFS
+# pointer, so the config redirect must go through media.githubusercontent.com.
+gen_kubernetes_config_parsed_genesis_lfs: false # noqa var-naming[no-role-prefix]
+
 gen_kubernetes_config_ethereum_node_name: >- # noqa var-naming[no-role-prefix] yaml[line-length]
   {{ gen_kubernetes_config_ethereum_node.cl }}-{{ gen_kubernetes_config_ethereum_node.el }}-{{ gen_kubernetes_config_ethereum_node.value }}
 

--- a/roles/generate_kubernetes_config/templates/config.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/config.yaml.j2
@@ -37,8 +37,13 @@ config:
       upstream: raw.githubusercontent.com
       target: /ethpandaops/{{ devnet_name }}-devnets/master/network-configs/{{ ethereum_network_name | replace(devnet_name + "-", '') }}/metadata/genesis.ssz
     - path: /parsed/parsedConsensusGenesis.json
+{% if gen_kubernetes_config_parsed_genesis_lfs %}
+      upstream: media.githubusercontent.com
+      target: /media/ethpandaops/{{ devnet_name }}-devnets/master/network-configs/{{ ethereum_network_name | replace(devnet_name + "-", '') }}/parsed/parsedConsensusGenesis.json
+{% else %}
       upstream: raw.githubusercontent.com
       target: /ethpandaops/{{ devnet_name }}-devnets/master/network-configs/{{ ethereum_network_name | replace(devnet_name + "-", '') }}/parsed/parsedConsensusGenesis.json
+{% endif %}
 
     # Execution Layer specific redirects
     - path: /el/enodes.txt


### PR DESCRIPTION
## Problem

glamsterdam devnet-7 has 500k exited validators in genesis, which puts `parsed/parsedConsensusGenesis.json` at 189MB — over GitHub's 100MB hard limit — so it is now tracked with git-lfs in ethpandaops/glamsterdam-devnets. For LFS-tracked files, `raw.githubusercontent.com` serves the 134-byte LFS pointer instead of the content, which breaks the `/parsed/parsedConsensusGenesis.json` redirect on the config endpoint.

`media.githubusercontent.com/media/<org>/<repo>/<ref>/<path>` serves the actual LFS content, but 404s for regular (non-LFS) blobs, so it can't be the unconditional upstream — every other devnet's parsed genesis is a regular blob.

## Change

New role default `gen_kubernetes_config_parsed_genesis_lfs: false`. When set to `true` in a devnet's inventory, the config redirect for `/parsed/parsedConsensusGenesis.json` uses `media.githubusercontent.com` with the `/media` target prefix; all other files and devnets are unaffected.

Already set in glamsterdam-devnets devnet-7 inventory (ethpandaops/glamsterdam-devnets@1c28ea6), where the generated `kubernetes/devnet-7/config/values.yaml` was patched by hand pending this PR.

## Verification

```
$ curl -sI https://raw.githubusercontent.com/ethpandaops/glamsterdam-devnets/master/network-configs/devnet-7/parsed/parsedConsensusGenesis.json | grep content-length
content-length: 134        # LFS pointer, not the file

$ curl -sI https://media.githubusercontent.com/media/ethpandaops/glamsterdam-devnets/master/network-configs/devnet-7/parsed/parsedConsensusGenesis.json | grep content-length
content-length: 198064570  # actual content
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)