### PR TITLE
feat(validator_keys): reshuffle deployed keys when inventory ranges change

### DIFF
--- a/roles/ethereum_genesis/tasks/generate_validator_keys.yaml
+++ b/roles/ethereum_genesis/tasks/generate_validator_keys.yaml
@@ -35,6 +35,23 @@
       ansible.builtin.set_fact:
         ethereum_genesis_docker_platform: "{{ 'linux/arm64' if ansible_architecture == 'aarch64' or ansible_architecture == 'arm64' else 'linux/amd64' }}"
 
+    # Each generated key dir carries a .keyrange marker ("start-end"). If a
+    # host's assigned range changed in the inventory (or the marker is missing,
+    # e.g. keys generated before markers existed), drop the dir so the guarded
+    # generation task below regenerates it. Regeneration is deterministic from
+    # the mnemonic, so this is always safe locally.
+    - name: Remove locally generated keys whose range changed
+      loop: "{{ ethereum_genesis_validator_keyranges | dict2items }}"
+      vars:
+        ethereum_genesis_keydir: "{{ ethereum_genesis_validator_keys_output_dir }}/{{ item.key }}"
+        ethereum_genesis_keyrange: "{{ item.value.start }}-{{ item.value.end }}"
+      ansible.builtin.shell: >
+        if [ -d "{{ ethereum_genesis_keydir }}" ] &&
+           [ "$(cat "{{ ethereum_genesis_keydir }}/.keyrange" 2>/dev/null)" != "{{ ethereum_genesis_keyrange }}" ];
+        then rm -rf "{{ ethereum_genesis_keydir }}" && echo removed; fi
+      register: ethereum_genesis_stale_keys
+      changed_when: "'removed' in ethereum_genesis_stale_keys.stdout"
+
     - name: Create validator keys
       loop: "{{ ethereum_genesis_validator_keyranges | dict2items }}"
       ansible.builtin.shell: >
@@ -52,6 +69,13 @@
         --source-mnemonic="{{ ethereum_genesis_validator_mnemonic }}"
       args:
         creates: "{{ ethereum_genesis_validator_keys_output_dir }}/{{ item.key }}"
+
+    - name: Record generated key range
+      loop: "{{ ethereum_genesis_validator_keyranges | dict2items }}"
+      ansible.builtin.copy:
+        content: "{{ item.value.start }}-{{ item.value.end }}"
+        dest: "{{ ethereum_genesis_validator_keys_output_dir }}/{{ item.key }}/.keyrange"
+        mode: "0644"
 
     - name: Create bls address change operations
       when:

--- a/roles/validator_keys/defaults/main.yaml
+++ b/roles/validator_keys/defaults/main.yaml
@@ -1,3 +1,43 @@
 validator_keys_sync_files:
  - src: /path/to/local/keydir
    dest: /path/to/remote/keydir
+
+# --- Reshuffle support ---------------------------------------------------------
+# Opt-in switch for replacing already-deployed keys when the host's assigned
+# validator range changed in the inventory. Enable per run:
+#   ansible-playbook playbook.yaml --tags ethereum_genesis,validator_keys \
+#     -l '<affected hosts>' -e validator_keys_reshuffle=true
+# The flow relies on the LINEAR strategy for a play-wide barrier between
+# "all drifted validator clients stopped" and "any of them started again":
+# run it from a play with `strategy: linear` (NOT a free strategy) and keep
+# all affected hosts (donors AND recipients of moved keys) in the same play
+# batch (do not set batch_count / serial for a reshuffle run).
+validator_keys_reshuffle: false
+
+# The validator range this host is supposed to run, from the inventory.
+validator_keys_expected_range: "{{ validator_start | default(0) }}-{{ validator_end | default(0) }}"
+
+# Marker file recording which range is currently deployed on the host. The
+# default resolves to the validator datadir for every supported client layout
+# (parent directory of the first sync destination).
+validator_keys_range_marker: "{{ validator_keys_sync_files[0].dest | regex_replace('/+$', '') | dirname }}/.validator_keyrange"
+
+# Local directory holding this host's generated keys (written by the
+# ethereum_genesis role, which maintains a matching .keyrange marker in it).
+validator_keys_local_dir: "{{ inventory_dir }}/files/validator_keys/{{ inventory_hostname }}"
+
+# Name of the validator-client docker container to stop/start around a key
+# replacement. If the container does not exist yet (fresh host), the reshuffle
+# only stages the keys and leaves starting the client to the node role.
+validator_keys_container_name: validator
+
+# A drifted host with deployed keys but no matching container is refused (an
+# unknown client could still be serving those keys). Set to true only when the
+# deployed keys are provably not being served by anything.
+validator_keys_container_missing_ok: false
+
+# Seconds to hold ALL drifted validator clients stopped before any of them is
+# started with reassigned keys. Must cover at least 2 full epochs so a key
+# that moved between hosts can never double-sign inside its slashing window
+# (2 epochs at 12s slots = 768s; default adds a little slack).
+validator_keys_reshuffle_wait_seconds: 800

--- a/roles/validator_keys/tasks/main.yaml
+++ b/roles/validator_keys/tasks/main.yaml
@@ -14,7 +14,7 @@
 #   register: validator_bls_change_file
 
 - name: Copy key directories
-  when: not validator_keys_dir_0.stat.exists
+  when: not validator_keys_dir_0.stat.exists and not (validator_keys_reshuffle | bool)
   block:
     - name: Create dest dir
       ansible.builtin.file:
@@ -27,6 +27,188 @@
         src: "{{ item.src }}"
         dest: "{{ item.dest }}"
       loop: "{{ validator_keys_sync_files }}"
+
+# Record which range is deployed so a later reshuffle run can detect drift.
+# Never overwrite an existing marker here: outside reshuffle mode the inventory
+# may already have moved ahead of what is actually deployed on the host.
+- name: Check reshuffle range marker
+  ansible.builtin.stat:
+    path: "{{ validator_keys_range_marker }}"
+  register: validator_keys_marker_stat
+
+- name: Seed reshuffle range marker from inventory
+  when: not (validator_keys_reshuffle | bool) and not validator_keys_marker_stat.stat.exists
+  ansible.builtin.copy:
+    content: "{{ validator_keys_expected_range }}"
+    dest: "{{ validator_keys_range_marker }}"
+    mode: "0644"
+
+- name: Reshuffle validator keys
+  when: validator_keys_reshuffle | bool
+  block:
+    - name: Read deployed range marker
+      when: validator_keys_marker_stat.stat.exists
+      ansible.builtin.slurp:
+        src: "{{ validator_keys_range_marker }}"
+      register: validator_keys_marker_content
+
+    - name: Determine range drift
+      ansible.builtin.set_fact:
+        validator_keys_drifted: >-
+          {{ not validator_keys_marker_stat.stat.exists
+             or (validator_keys_marker_content.content | b64decode | trim) != (validator_keys_expected_range | trim) }}
+
+    - name: Report reshuffle decision
+      ansible.builtin.debug:
+        msg: >-
+          deployed={{ validator_keys_marker_stat.stat.exists
+                      | ternary(validator_keys_marker_content.content | default('') | b64decode | trim, 'none') }}
+          expected={{ validator_keys_expected_range }}
+          drifted={{ validator_keys_drifted }}
+
+    # The ethereum_genesis role regenerates local keys on range changes and
+    # maintains files/validator_keys/<host>/.keyrange. Refuse to push keys that
+    # do not match the inventory (e.g. the genesis play was skipped).
+    - name: Verify locally generated keys match the expected range
+      when: validator_keys_drifted
+      delegate_to: 127.0.0.1
+      become: false
+      vars:
+        validator_keys_local_marker: "{{ lookup('file', validator_keys_local_dir + '/.keyrange', errors='ignore') }}"
+      ansible.builtin.assert:
+        that:
+          - validator_keys_local_marker | trim == validator_keys_expected_range | trim
+        fail_msg: >-
+          Local keys in {{ validator_keys_local_dir }} are '{{ validator_keys_local_marker }}',
+          inventory expects '{{ validator_keys_expected_range }}'. Run the ethereum_genesis
+          play first (--tags ethereum_genesis) to regenerate them.
+
+    - name: Check validator container
+      community.docker.docker_container_info:
+        name: "{{ validator_keys_container_name }}"
+      register: validator_keys_container_info
+
+    # Node roles may pre-create empty key directories, so "directory exists" is
+    # not evidence of deployed keys — look for actual files inside the sync
+    # destinations (-print -quit: stop at the first one).
+    - name: Count deployed key files
+      ansible.builtin.shell: >-
+        set -o pipefail;
+        find {{ validator_keys_sync_files | map(attribute='dest')
+                | map('regex_replace', '/+$', '') | map('quote') | join(' ') }}
+        -type f -print -quit 2>/dev/null | wc -l
+      args:
+        executable: /bin/bash
+      register: validator_keys_deployed_files
+      changed_when: false
+      failed_when: false
+
+    # Keys are deployed but no container matches validator_keys_container_name:
+    # wiping now would leave an unknown validator client signing from memory
+    # while another host loads the same keys. Refuse instead of guessing (note
+    # teku/nimbus-style clients load keys in the BEACON container — point
+    # validator_keys_container_name at it). Override with
+    # validator_keys_container_missing_ok=true only when the deployed keys are
+    # provably not being served (e.g. staged on a host whose validator client
+    # was never created).
+    - name: Fail if deployed keys have no known validator container
+      when: >-
+        validator_keys_drifted
+        and (validator_keys_deployed_files.stdout | trim | int) > 0
+        and not validator_keys_container_info.exists
+        and not (validator_keys_container_missing_ok | bool)
+      ansible.builtin.fail:
+        msg: >-
+          Keys are deployed on this host but no container named
+          '{{ validator_keys_container_name }}' exists. Set
+          validator_keys_container_name to this host's validator client
+          container before reshuffling.
+
+    # Linear strategy: every task below completes on ALL play hosts before the
+    # next task starts. Stopping here and starting at the end of the block
+    # therefore gives a play-wide stop -> wait -> start barrier.
+    - name: Stop validator container
+      when: validator_keys_drifted and validator_keys_container_info.exists
+      community.docker.docker_container:
+        name: "{{ validator_keys_container_name }}"
+        state: stopped
+        comparisons:
+          "*": ignore
+
+    - name: Remove deployed keys
+      when: validator_keys_drifted
+      ansible.builtin.file:
+        path: "{{ item.dest | regex_replace('/+$', '') }}"
+        state: absent
+      loop: "{{ validator_keys_sync_files }}"
+
+    - name: Remove range marker
+      when: validator_keys_drifted
+      ansible.builtin.file:
+        path: "{{ validator_keys_range_marker }}"
+        state: absent
+
+    # Holds every drifted validator client stopped for >= 2 epochs so moved
+    # keys cannot double-sign. Under the linear strategy the task boundary is a
+    # play-wide barrier: no host starts its client again until every host has
+    # finished waiting. Run reshuffles with a linear-strategy play (per-host
+    # waits under a free strategy do not synchronize across hosts).
+    - name: Wait for moved keys to leave their slashing window
+      when: validator_keys_drifted and validator_keys_reshuffle_wait_seconds | int > 0
+      ansible.builtin.wait_for:
+        timeout: "{{ validator_keys_reshuffle_wait_seconds }}"
+
+    - name: Create dest dir
+      when: validator_keys_drifted
+      ansible.builtin.file:
+        path: "{{ item.dest | dirname }}"
+        state: directory
+        recurse: true
+      loop: "{{ validator_keys_sync_files }}"
+
+    - name: Copy reshuffled keys
+      when: validator_keys_drifted
+      ansible.posix.synchronize:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+      loop: "{{ validator_keys_sync_files }}"
+
+    # rsync writes the keys as the ansible user, but validator clients run as
+    # the datadir's owner and need to write inside the key dirs (keystore
+    # lockfiles, slashing DBs). On first provisioning the client role's setup
+    # fixes ownership afterwards; a reshuffle copies into an already-set-up
+    # datadir, so match ownership here.
+    - name: Stat validator datadir
+      when: validator_keys_drifted
+      ansible.builtin.stat:
+        path: "{{ validator_keys_range_marker | dirname }}"
+      register: validator_keys_datadir_stat
+
+    - name: Match reshuffled key ownership to the datadir # noqa: command-instead-of-module
+      when: validator_keys_drifted and validator_keys_datadir_stat.stat.exists
+      ansible.builtin.command:
+        argv:
+          - chown
+          - -R
+          - "{{ validator_keys_datadir_stat.stat.uid }}:{{ validator_keys_datadir_stat.stat.gid }}"
+          - "{{ item.dest | regex_replace('/+$', '') }}"
+      loop: "{{ validator_keys_sync_files }}"
+      changed_when: true
+
+    - name: Write range marker
+      when: validator_keys_drifted
+      ansible.builtin.copy:
+        content: "{{ validator_keys_expected_range }}"
+        dest: "{{ validator_keys_range_marker }}"
+        mode: "0644"
+
+    - name: Start validator container
+      when: validator_keys_drifted and validator_keys_container_info.exists
+      community.docker.docker_container:
+        name: "{{ validator_keys_container_name }}"
+        state: started
+        comparisons:
+          "*": ignore
 
 # - name: Copy change bls key change file
 #   when: not validator_bls_change_file.stat.exists


### PR DESCRIPTION
## Problem

Both halves of the validator key pipeline are create-once, so editing a host's `validator_start`/`validator_end` in the inventory silently does nothing:

- `ethereum_genesis` guards key generation with `creates:` on the per-host output dir — an existing dir is never regenerated.
- `validator_keys` skips the entire sync when the first destination exists (`when: not ...stat.exists`), and `synchronize` runs without `--delete`, so stale keystores would survive even if it ran.

Reassigning ranges (e.g. onboarding new client combos on a live devnet by shrinking existing nodes' ranges) currently requires manual SSH surgery on every affected host, with the slashing hazards that implies.

## Mechanism

**Range markers.** `ethereum_genesis` stamps each generated key dir with `.keyrange` (`"start-end"`) and regenerates the dir when the marker no longer matches the inventory (generation is deterministic from the mnemonic, so this is always safe locally). `validator_keys` seeds a matching `.validator_keyrange` in the validator datadir on first deploy — the marker's default location (parent of the first sync destination) resolves to the datadir for all five client layouts (lighthouse, lodestar, teku, nimbus, prysm).

**Reshuffle mode.** Opt-in via `-e validator_keys_reshuffle=true`. For each host whose deployed marker differs from the inventory (missing marker = drifted):

1. assert the locally generated keys match the new range (refuses to push stale keys if the genesis play was skipped),
2. stop the validator container,
3. remove exactly the `validator_keys_sync_files` destinations,
4. hold **all** drifted hosts stopped for `validator_keys_reshuffle_wait_seconds` (default 800s ≥ 2 epochs) — under the linear strategy the task boundary is a play-wide barrier, so a moved key can never sign on two hosts inside its slashing window,
5. sync the new keys, write the marker, restart the container.

Hosts whose marker matches the inventory are untouched, so fleet-wide runs are safe and idempotent. Normal (non-reshuffle) runs only seed missing markers; they never move keys.

## Safety rails

- **Unknown validator client**: a drifted host with deployed keys but no container named `validator_keys_container_name` hard-fails — wiping keys under an unknown client could leave it signing from memory while another host loads the same keys. Escape hatch: `validator_keys_container_missing_ok=true` for keys that are provably not being served (e.g. staged on a host whose VC was never created).
- **Fresh hosts**: no container + no deployed keys → keys are staged and starting the client is left to the node role.
- **Interrupted run**: marker is removed before the wipe and rewritten only after a successful sync, so a crash mid-flow re-detects drift and self-heals on the next run (offline validators are safe validators).
- **Strategy**: the barrier requires a linear-strategy play. The role avoids `pause`/`run_once` (hard load-time error under free strategies, e.g. `mitogen_free`) and uses a per-host `wait_for` instead. Recommended play (add `any_errors_fatal: true` so an unreachable donor aborts the play before any recipient starts — verified to abort at fact-gathering):

```yaml
- hosts: ethereum_node
  strategy: linear
  any_errors_fatal: true
  become: true
  vars:
    validator_keys_reshuffle: true
  roles:
    - role: ethpandaops.general.validator_keys
      when: ethereum_node_cl_validator_enabled == true
```

- **Slashing DBs**: teku/lodestar/prysm keep theirs (outside the wiped paths); lighthouse/nimbus store them inside `keys/` so they reset — covered by the barrier plus `--init-slashing-protection`.

## Edge cases considered

- Range swap between two hosts in one play: both held through the same barrier — safe.
- Donor and recipient split across separate runs: not detectable from one side (the other host's marker is a remote fact); documented that both sides of a moved range must be in the same play, fleet-wide being the safe default.
- Marker missing on an active host in reshuffle mode: treated as drifted → identical keys resynced with a VC restart; safe, just avoidable downtime (hence seeding on normal runs).
- Zero-key hosts / hosts without `validator_start`: role skipped by the caller's `when`, unchanged.
- `--check` mode: read-only preview; no container or filesystem changes.
- Changed mnemonic since genesis is NOT defended: local regeneration would silently produce different keys (a changed mnemonic is catastrophic for a devnet regardless).

## Testing (live on glamsterdam-devnet-7)

- Local regeneration determinism: regenerated pubkeys byte-match on-chain validators (indices 0 and 2399 spot-checked against the beacon state).
- Marker seeding: fleet-wide normal run seeded 15 hosts, VCs untouched; second run fully idempotent (`changed=0`).
- No-op reshuffle against live hosts with unchanged ranges: `deployed=0-300 expected=0-300 drifted=False`, zero changes.
- Unreachable-host abort: synthetic dead host in the play → `any_errors_fatal` ended the play at fact-gathering, zero role tasks ran on healthy hosts.
- `ansible-lint` passes on the production profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)