### PR TITLE
fix(erpc): add eth_getBlockAccessList to allowMethods allowlist

### DIFF
--- a/roles/generate_kubernetes_config/templates/erpc.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/erpc.yaml.j2
@@ -102,6 +102,7 @@ erpc:
             - "eth_feeHistory"
             - "eth_blobBaseFee"
             - "eth_gasPrice"
+            - "eth_getBlockAccessList"
             - "eth_getBalance"
             - "eth_getBlockByHash"
             - "eth_getBlockByNumber"

--- a/roles/generate_kubernetes_config/templates/erpc.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/erpc.yaml.j2
@@ -103,6 +103,8 @@ erpc:
             - "eth_blobBaseFee"
             - "eth_gasPrice"
             - "eth_getBlockAccessList"
+            - "eth_getBlockAccessListByHash"
+            - "eth_getBlockAccessListByNumber"
             - "eth_getBalance"
             - "eth_getBlockByHash"
             - "eth_getBlockByNumber"


### PR DESCRIPTION
The erpc proxy's `upstreamDefaults.allowMethods` list is missing `eth_getBlockAccessList`, so erpc drops these requests before they ever reach any upstream execution node.

This PR adds `eth_getBlockAccessList` to the allowlist (alphabetically between `eth_gasPrice` and `eth_getBalance`).