### PR TITLE
feat(generate_kubernetes_config): tracoor execution payload envelope retention

### DIFF
--- a/roles/generate_kubernetes_config/templates/tracoor.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/tracoor.yaml.j2
@@ -82,6 +82,7 @@ tracoor-single:
             beaconStates: 100h
             executionBlockTraces: 100h
             beaconBlocks: 100h
+            executionPayloadEnvelopes: 100h
       ethereum:
         config:
           repository: ethpandaops/{{ devnet_name }}-devnets


### PR DESCRIPTION
Adds executionPayloadEnvelopes: 100h to the tracoor values template, matching the other object retentions. Tracoor archives signed execution payload envelopes on gloas networks (ethpandaops/tracoor#56); without this key the deployment falls back to the 30m default and purges them.

https://claude.ai/code/session_012CnMNMdPisWGmvKhKzj1ii