### PR TITLE
xatu_sentry: assemble the default config from discrete vars

### DIFF
--- a/roles/xatu_sentry/defaults/main.yaml
+++ b/roles/xatu_sentry/defaults/main.yaml
@@ -26,18 +26,54 @@ xatu_sentry_config_server_auth_user: xatu-user
 xatu_sentry_config_server_auth_password: xatu-password
 xatu_sentry_config_network_name_override: ""
 
-xatu_sentry_config: |
-  logging: "info"
-  metricsAddr: ":9090"
-  name: "{{ xatu_sentry_config_name }}"
-  ethereum:
-    beaconNodeAddress: {{ xatu_sentry_config_beacon_uri }}
-    overrideNetworkName: {{ xatu_sentry_config_network_name_override }}
-  outputs:
-  - name: grpc
-    type: xatu
-    config:
-      address: {{ xatu_sentry_config_server_address }}
-      tls: {{ xatu_sentry_config_server_tls_enabled }}
-      headers:
-        authorization: "Basic {{ (xatu_sentry_config_server_auth_user + ":" + xatu_sentry_config_server_auth_password) | b64encode }}"
+# Empty list omits the key so the sentry uses its built-in topic set.
+xatu_sentry_config_beacon_subscriptions: []
+xatu_sentry_config_beacon_committees_enabled: false
+xatu_sentry_config_proposer_duty_enabled: false
+# Omitted from the config when null, leaving the sentry's own defaults.
+xatu_sentry_config_output_max_queue_size: null
+xatu_sentry_config_output_workers: null
+# Deep-merged over the assembled config for anything without a dedicated var.
+xatu_sentry_config_extra: {}
+
+# Assembled from the vars above. Override this with a raw config string only
+# when the structure itself has to change — a full override drops every
+# assembled key, including ones added to this role later.
+xatu_sentry_config_data: >-
+  {{
+    {
+      'logging': 'info',
+      'metricsAddr': ':9090',
+      'name': xatu_sentry_config_name,
+      'ethereum': {
+        'beaconNodeAddress': xatu_sentry_config_beacon_uri,
+        'overrideNetworkName': xatu_sentry_config_network_name_override,
+      } | combine(
+        {'beaconSubscriptions': xatu_sentry_config_beacon_subscriptions}
+        if xatu_sentry_config_beacon_subscriptions else {}
+      ),
+      'beaconCommittees': {'enabled': xatu_sentry_config_beacon_committees_enabled | bool},
+      'proposerDuty': {'enabled': xatu_sentry_config_proposer_duty_enabled | bool},
+      'outputs': [
+        {
+          'name': 'grpc',
+          'type': 'xatu',
+          'config': {
+            'address': xatu_sentry_config_server_address,
+            'tls': xatu_sentry_config_server_tls_enabled | bool,
+            'headers': {
+              'authorization': 'Basic ' + ((xatu_sentry_config_server_auth_user + ':' + xatu_sentry_config_server_auth_password) | b64encode),
+            },
+          } | combine(
+            {'maxQueueSize': xatu_sentry_config_output_max_queue_size}
+            if xatu_sentry_config_output_max_queue_size is not none else {}
+          ) | combine(
+            {'workers': xatu_sentry_config_output_workers}
+            if xatu_sentry_config_output_workers is not none else {}
+          ),
+        },
+      ],
+    } | combine(xatu_sentry_config_extra, recursive=True)
+  }}
+
+xatu_sentry_config: "{{ xatu_sentry_config_data | to_nice_yaml(indent=2) }}"


### PR DESCRIPTION
\`xatu_sentry_config\` was a single opaque Jinja string, so any consumer needing one extra key had to fork the whole config. The forks drift: the devnet fleets forked it to add gloas subscription topics and silently lost \`beaconCommittees\`/\`proposerDuty\`, which left \`beacon_api_eth_v1_beacon_committee\` empty on every devnet and the lab's attestation tables trailing the head by the finalization distance (glamsterdam-devnets#42).

The default config is now assembled from discrete vars:
- \`xatu_sentry_config_beacon_subscriptions\` (empty list = omit, sentry defaults apply)
- \`xatu_sentry_config_beacon_committees_enabled\` / \`xatu_sentry_config_proposer_duty_enabled\`
- \`xatu_sentry_config_output_max_queue_size\` / \`xatu_sentry_config_output_workers\` (null = omit)
- \`xatu_sentry_config_extra\` — deep-merged over the assembled config for anything without a dedicated var

Backwards compatible: overriding \`xatu_sentry_config\` with a raw string still wins. Consumers on role defaults get a one-time config rewrite (same semantics, keys alphabetized by \`to_nice_yaml\`) and a sentry restart on their next apply.

Render-verified for both the bare-default and devnet-shaped var sets; ansible-lint clean.