### PR TITLE
faucet-agents: enable the ingress basic-auth lockdown

### DIFF
--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -140,10 +140,10 @@ gen_kubernetes_config_helm_charts: # noqa var-naming[no-role-prefix]
       ipinfoEnabled: false # reached only via the panda proxy; per-IP checks don't apply
       concurrencyByAddrOnly: true # proxy shares one IP; limit concurrency per target address, not per IP
       recurringLimitsByAddrOnly: true # same: per-IP recurring limits would be a global budget behind the proxy
-      # Staged lockdown — set only after the panda proxy ships its faucet
-      # handler (it breaks both access paths before that), pointing at the
-      # htpasswd secret holding the credential the proxy forwards:
-      # ingressAuthSecret: powfaucet-agents-basic-auth
+      # The faucet has no captcha (agents mine via REST), so the ingress is
+      # locked behind basic auth only the panda proxy holds — create the
+      # htpasswd secret with the srv credential in the network's namespace.
+      ingressAuthSecret: powfaucet-agents-basic-auth
   forkmon:
     valuesTemplatePath: templates/forkmon.yaml.j2
     dependencies:


### PR DESCRIPTION
Follow-up to #554: the agent faucet has no captcha (agents mine via the REST API), so its open ingress let anyone claim via the web UI. This flips on the staged `ingressAuthSecret` so regens emit the nginx basic-auth annotations — only the panda proxy holds the credential, so the faucet is reachable solely through it (panda#277 authenticates callers).

Already applied live on glamsterdam-devnet-7 (secret created, ingress annotated, committed in glamsterdam-devnets#55): unauthenticated is 401, the proxy credential gets 200. Networks enabling faucet-agents need the `powfaucet-agents-basic-auth` htpasswd secret in their namespace (or they disable the chart via `gen_kubernetes_config_disabled_services`).