### PR TITLE
feat(generate_kubernetes_config): add slashoor chart template

### DIFF
--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -249,3 +249,9 @@ gen_kubernetes_config_helm_charts: # noqa var-naming[no-role-prefix]
       - name: xatu-relay-monitor
         repository: https://ethpandaops.github.io/ethereum-helm-charts
         version: 0.0.1
+  slashoor:
+    valuesTemplatePath: templates/slashoor.yaml.j2
+    dependencies:
+      - name: slashoor
+        repository: https://ethpandaops.github.io/ethereum-helm-charts
+        version: 0.1.0

--- a/roles/generate_kubernetes_config/templates/slashoor.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/slashoor.yaml.j2
@@ -1,0 +1,49 @@
+# {{ ansible_managed }}
+{% set slashoor_image = default_tooling_images.slashoor | default('ethpandaops/slashoor:latest') %}
+
+slashoor:
+  fullnameOverride: slashoor
+  replicas: 1
+
+  image:
+    repository: {{ slashoor_image.split(':') | first }}
+    tag: {{ slashoor_image.split(':') | last }}
+    pullPolicy: {% if "latest" in (slashoor_image.split(':') | last) %}Always{% else %}IfNotPresent{% endif %}
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+
+  config:
+    beacon:
+      endpoints:
+{% for host in (groups['ethereum_node'] + groups['bootnode']) | sort %}
+        - https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@{{ ethereum_node_beacon_prefix }}{{ hostvars[host]['inventory_hostname'] }}.{{ network_server_subdomain }}
+{% endfor %}
+      timeout: 30s
+
+    indexer:
+      max_epochs_to_keep: 54000
+
+    detector:
+      enabled: true
+
+    submitter:
+      enabled: true
+      dry_run: false
+
+    proposer:
+      enabled: true
+
+    dora:
+      enabled: true
+      url: https://dora.{{ network_subdomain }}
+      scan_on_startup: true
+
+    # Committee resolution for deep history needs archive states; the Dora
+    # scan covers older proposer slashings, so keep the backfill shallow.
+    backfill_slots: 320

--- a/roles/generate_kubernetes_config/templates/slashoor.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/slashoor.yaml.j2
@@ -8,7 +8,7 @@ slashoor:
   image:
     repository: {{ slashoor_image.split(':') | first }}
     tag: {{ slashoor_image.split(':') | last }}
-    pullPolicy: {% if "latest" in (slashoor_image.split(':') | last) %}Always{% else %}IfNotPresent{% endif %}
+    pullPolicy: {% if "latest" in (slashoor_image.split(':') | last) or "master" in (slashoor_image.split(':') | last) %}Always{% else %}IfNotPresent{% endif %}
 
   resources:
     requests:


### PR DESCRIPTION
Adds slashoor (the beacon chain slasher) to the generated per-devnet charts, so every devnet gets an instance by default (opt out via `gen_kubernetes_config_disabled_services`).

- Beacon endpoints enumerated from `ethereum_node` + `bootnode` groups through the authenticated node ingress — same pattern as the checkpointz template
- Dora integration enabled against the devnet's dora instance (`scan_on_startup` covers historical double proposals; the attestation backfill is kept shallow because deep committee resolution needs archive states)
- Live submission (`dry_run: false`) — on devnets, landing the slashing is the point
- Image defaults to `ethpandaops/slashoor:latest`; pin per devnet via `default_tooling_images.slashoor` (v0.1.0 released today with Electra/Gloas support, verified against glamsterdam-devnet-7)

Depends on the chart PR: ethpandaops/ethereum-helm-charts#490