### PR TITLE
feat(generate_kubernetes_config): add mempool-lens chart template

### DIFF
--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -88,6 +88,14 @@ gen_kubernetes_config_powfaucet_authenticatoor_grants: # noqa var-naming[no-role
 gen_kubernetes_config_pandamenu_enabled: true # noqa var-naming[no-role-prefix]
 gen_kubernetes_config_pandamenu_script: '<script src="https://pandamenu.ethpandaops.io/panda-menu-1.0.1.js" integrity="sha384-icGX6g6CzB0tqlhDc6Su4c6IPVbcbUvfM3xjbbFYsYBwuZR79WkmOxDhGEPfmyn2" crossorigin="anonymous"></script>' # noqa var-naming[no-role-prefix] yaml[line-length]
 
+# mempool-lens configuration
+# Inventory hostname of the geth node whose WS API (txtracker/peerstats
+# namespaces) the lens should watch. Empty picks the first geth host.
+gen_kubernetes_config_mempool_lens_node: "" # noqa var-naming[no-role-prefix]
+# Full override for the upstream WebSocket RPC URL; takes precedence over
+# gen_kubernetes_config_mempool_lens_node when set.
+gen_kubernetes_config_mempool_lens_rpc_url: "" # noqa var-naming[no-role-prefix]
+
 gen_kubernetes_config_chat_image: "" # noqa var-naming[no-role-prefix]
 gen_kubernetes_config_chat_llm_model: "claude-sonnet-4-6" # noqa var-naming[no-role-prefix]
 # Cloudflare Access trusted-header SSO.
@@ -253,5 +261,11 @@ gen_kubernetes_config_helm_charts: # noqa var-naming[no-role-prefix]
     valuesTemplatePath: templates/slashoor.yaml.j2
     dependencies:
       - name: slashoor
+        repository: https://ethpandaops.github.io/ethereum-helm-charts
+        version: 0.1.0
+  mempool-lens:
+    valuesTemplatePath: templates/mempool-lens.yaml.j2
+    dependencies:
+      - name: mempool-lens
         repository: https://ethpandaops.github.io/ethereum-helm-charts
         version: 0.1.0

--- a/roles/generate_kubernetes_config/templates/mempool-lens.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/mempool-lens.yaml.j2
@@ -1,0 +1,51 @@
+# {{ ansible_managed }}
+{% set mempool_lens_image = default_tooling_images.mempool_lens | default('bbusa/mempool-lens:latest') %}
+{% if gen_kubernetes_config_mempool_lens_rpc_url | length > 0 %}
+{% set mempool_lens_rpc_url = gen_kubernetes_config_mempool_lens_rpc_url %}
+{% else %}
+{% set mempool_lens_node = gen_kubernetes_config_mempool_lens_node
+   if gen_kubernetes_config_mempool_lens_node | length > 0
+   else (groups['geth'] | sort | first) %}
+{% set mempool_lens_rpc_url = "wss://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets." ~ devnet_name ~ "-devnets.node_ingress.combined}>@" ~ ethereum_node_rpc_prefix ~ mempool_lens_node ~ "." ~ network_server_subdomain %}
+{% endif %}
+
+mempool-lens:
+  fullnameOverride: mempool-lens
+  replicas: 1
+
+  image:
+    repository: {{ mempool_lens_image.split(':') | first }}
+    tag: {{ mempool_lens_image.split(':') | last }}
+    pullPolicy: {% if "latest" in (mempool_lens_image.split(':') | last) or "master" in (mempool_lens_image.split(':') | last) %}Always{% else %}IfNotPresent{% endif %}
+
+  # Upstream geth WS endpoint; needs the txtracker (and ideally
+  # peerstats/admin) namespaces enabled on the WS API. Geth serves WS on the
+  # rpc- ingress when ws.port == http.port.
+  rpcUrl: "{{ mempool_lens_rpc_url }}"
+
+  # Browsers only talk to the lens; it proxies the geth WebSocket via /ws.
+  proxy: true
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+  ingress:
+    enabled: true
+    className: ingress-nginx-public
+{% if gen_kubernetes_config_pandamenu_enabled %}
+    annotations:
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        sub_filter '</head>' '{{ gen_kubernetes_config_pandamenu_script }}</head>';
+        sub_filter_types text/html;
+        sub_filter_once off;
+{% endif %}
+    hosts:
+      - host: mempool-lens.{{ network_subdomain }}
+        paths:
+          - path: /
+            pathType: Prefix


### PR DESCRIPTION
Adds a `mempool-lens` entry to the chart registry plus its values template.

- [mempool-lens](https://github.com/cskiraly/mempool-lens) is a live transaction-lifecycle viewer for geth's `txtracker`/`peerstats` WS namespaces.
- The template targets a geth node's `rpc-` ingress over `wss://` (geth serves WS on the same port as HTTP when `ws.port == http.port`), with basic auth from the usual `node_ingress.combined` secret. Node selection via `gen_kubernetes_config_mempool_lens_node` (defaults to the first geth host), or override the full URL with `gen_kubernetes_config_mempool_lens_rpc_url`.
- Web UI ingress at `mempool-lens.<network_subdomain>` with the standard pandamenu injection.
- Depends on the `mempool-lens` chart from ethpandaops/ethereum-helm-charts#491 being released (version 0.1.0).

`ansible-lint` passes (production profile).

https://claude.ai/code/session_019FXty3nj4rtVjkeSzSysmh