### PR TITLE
feat(bootstrap): optional docker registry credentials

### DIFF
--- a/roles/bootstrap/defaults/main.yml
+++ b/roles/bootstrap/defaults/main.yml
@@ -71,3 +71,12 @@ bootstrap_hostname_set: true
 bootstrap_harden_sshd_config: true
 bootstrap_rpcbind_disable: false
 bootstrap_swap_disable: true
+
+# Container registry credentials written to /root/.docker/config.json during
+# bootstrap, so image pulls are authenticated from the first docker run —
+# before docker itself is installed. Map of registry host to credentials:
+# bootstrap_docker_registry_auths:
+#   registry-1.docker.io:
+#     username: myuser
+#     password: mytoken
+bootstrap_docker_registry_auths: {}

--- a/roles/bootstrap/tasks/main.yml
+++ b/roles/bootstrap/tasks/main.yml
@@ -174,6 +174,27 @@
     state: present
   when: bootstrap_default_pip_packages | length > 0
 
+# Configure container registry credentials
+- name: Configure docker registry credentials
+  when: bootstrap_docker_registry_auths | length > 0
+  no_log: true
+  block:
+    - name: Create /root/.docker directory
+      ansible.builtin.file:
+        path: /root/.docker
+        state: directory
+        owner: root
+        group: root
+        mode: "0700"
+
+    - name: Write /root/.docker/config.json
+      ansible.builtin.template:
+        src: docker-config.json.j2
+        dest: /root/.docker/config.json
+        owner: root
+        group: root
+        mode: "0600"
+
 # Reboot the machine if required
 - name: Check if reboot required
   ansible.builtin.stat:

--- a/roles/bootstrap/templates/docker-config.json.j2
+++ b/roles/bootstrap/templates/docker-config.json.j2
@@ -1,0 +1,9 @@
+{
+  "auths": {
+{% for registry, cred in bootstrap_docker_registry_auths.items() %}
+    "{{ registry }}": {
+      "auth": "{{ (cred.username ~ ':' ~ cred.password) | b64encode }}"
+    }{{ "," if not loop.last }}
+{% endfor %}
+  }
+}


### PR DESCRIPTION
Adds `bootstrap_docker_registry_auths` (default `{}`, no-op) to the bootstrap role: a map of registry host → username/password that gets templated into `/root/.docker/config.json` with base64 auth entries, `0600`, `no_log`.

Why in bootstrap rather than a docker_login task: bootstrap runs before docker is installed, and `community.docker.docker_login` needs the daemon. Writing the config file directly means the very first image pull on a fresh host is already authenticated — including the init-server-phase pulls (vector, prometheus, etc.) that happen before any later login task could run.

Context: during today's glamsterdam devnet-8 launch we had to do an emergency fleet-wide ad-hoc `docker_login` after the pull-through cache melted down and anonymous Hub pulls over shared DO IPv6 /64s risked rate limits. This makes that setup declarative and survive instance recreation.

Example:
```yaml
bootstrap_docker_registry_auths:
  registry-1.docker.io:
    username: myuser
    password: "{{ secret_dockerhub.token }}"
  https://index.docker.io/v1/:
    username: myuser
    password: "{{ secret_dockerhub.token }}"
```

`ansible-lint --profile production` passes on the role.