### PR TITLE
fix(generate_kubernetes_config): support SLOT_DURATION_MS

### DIFF
--- a/roles/generate_kubernetes_config/templates/forky.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/forky.yaml.j2
@@ -77,7 +77,8 @@ forky:
         network:
           name: "{{ ethereum_network_name }}"
           spec:
-            seconds_per_slot: {{ (lookup('ansible.builtin.file', cl_config_path) | from_yaml).SECONDS_PER_SLOT }}
+{% set forky_cl_spec = lookup('ansible.builtin.file', cl_config_path) | from_yaml %}
+            seconds_per_slot: {{ (forky_cl_spec.SLOT_DURATION_MS | int // 1000) if forky_cl_spec.SLOT_DURATION_MS is defined else forky_cl_spec.SECONDS_PER_SLOT }}
 {% if (lookup('ansible.builtin.file', cl_config_path) | from_yaml).PRESET_BASE == "mainnet"%}
             slots_per_epoch: 32
 {% else %}

--- a/roles/generate_kubernetes_config/templates/spamoor.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/spamoor.yaml.j2
@@ -32,13 +32,14 @@ spamoor:
             pathType: Prefix
 
 {% set cl_config = lookup('ansible.builtin.file', cl_config_path) | from_yaml %}
+{% set seconds_per_slot = (cl_config.SLOT_DURATION_MS | int // 1000) if cl_config.SLOT_DURATION_MS is defined else seconds_per_slot %}
 {% if cl_config.FULU_FORK_EPOCH != 18446744073709551615 %}
 {% set min_genesis_plus_delay = cl_config.MIN_GENESIS_TIME + cl_config.GENESIS_DELAY %}
   customArgs:
     - --fulu-activation={{
       (cl_config.PRESET_BASE == 'mainnet') | ternary(
-        min_genesis_plus_delay + (32 * cl_config.SECONDS_PER_SLOT * cl_config.FULU_FORK_EPOCH),
-        min_genesis_plus_delay + (8 * cl_config.SECONDS_PER_SLOT * cl_config.FULU_FORK_EPOCH)
+        min_genesis_plus_delay + (32 * seconds_per_slot * cl_config.FULU_FORK_EPOCH),
+        min_genesis_plus_delay + (8 * seconds_per_slot * cl_config.FULU_FORK_EPOCH)
       )
     }}
 {% endif %}


### PR DESCRIPTION
glamsterdam devnet-8's generated `config.yaml` no longer contains `SECONDS_PER_SLOT` — Glamsterdam-era consensus-specs replaced it with `SLOT_DURATION_MS` (12000) as EIP-7782 groundwork — so `gen_kubernetes_config` dies on the forky template with `AnsibleUndefinedVariable: 'dict object' has no attribute 'SECONDS_PER_SLOT'` (and would die on spamoor next).

Both templates now compute slot seconds as `SLOT_DURATION_MS // 1000` when that key exists, falling back to `SECONDS_PER_SLOT` for pre-Glamsterdam configs. Verified both branches render correctly (12000ms → 12; legacy 12 → 12); `ansible-lint --profile production` passes on the role.

Note for the future: when sub-second slots actually happen, forky's `seconds_per_slot` config field itself will need upstream forky work — this keeps the integer-seconds contract intact until then.