### PR TITLE
fix(ethereum_node_fact_discovery): support named ethrex networks

### DIFF
--- a/roles/ethereum_node_fact_discovery/defaults/main.yaml
+++ b/roles/ethereum_node_fact_discovery/defaults/main.yaml
@@ -1,6 +1,27 @@
 ethereum_node_fact_discovery_el: true
 ethereum_node_fact_discovery_cl: true
 
+# ethrex network names
+ethereum_node_fact_discovery_ethrex_network_names:
+  - mainnet
+  - hoodi
+  - sepolia
+
+# ethrex stores node keys under <datadir>/<suffix>/node.key
+# Public networks use the network name; custom networks use chain-<id>
+# See crates/common/config/networks.rs in the ethrex repo for the logic
+# At time of writing, https://github.com/lambdaclass/ethrex/blob/2367dc810d82c2e3c3d098c9d1e10070fbaf63c1/crates/common/config/networks.rs#L126-L139
+ethereum_node_fact_discovery_ethrex_chain_subdir: |-
+  {%- set name = ethereum_network_name | default('') | trim -%}
+  {%- if name in ethereum_node_fact_discovery_ethrex_network_names -%}
+  {{ name }}
+  {%- elif ethereum_network_id is defined and (ethereum_network_id | string | trim | length) > 0 -%}
+  chain-{{ ethereum_network_id | string | trim }}
+  {%- endif -%}
+
+ethereum_node_fact_discovery_ethrex_chain_dir: |-
+  {{ ethrex_datadir | default('/data/ethrex') }}/{{ ethereum_node_fact_discovery_ethrex_chain_subdir }}
+
 # How to find the EL node key on the target system
 ethereum_node_fact_discovery_el_key_cmd:
   besu: cat {{ besu_datadir | default('/data/besu') }}/key | cut -d 'x' -f2
@@ -9,7 +30,7 @@ ethereum_node_fact_discovery_el_key_cmd:
   nethermind: xxd -p -c32 {{ nethermind_datadir | default('/data/nethermind') }}/keystore/node.key.plain
   reth: cat {{ reth_datadir | default('/data/reth') }}/discovery-secret
   nimbusel: cat {{ nimbusel_datadir | default('/data/nimbusel') }}/nodekey | cut -d 'x' -f2
-  ethrex: xxd -p -c32 {{ ethrex_datadir | default('/data/ethrex') }}/chain-{{ ethereum_network_id | trim }}/node.key
+  ethrex: xxd -p -c32 {{ ethereum_node_fact_discovery_ethrex_chain_dir }}/node.key
 
 # How to find the EL enode on the target system
 ethereum_node_fact_discovery_el_enode_cmd:

--- a/roles/ethereum_node_fact_discovery/tasks/execution_layer.yaml
+++ b/roles/ethereum_node_fact_discovery/tasks/execution_layer.yaml
@@ -1,6 +1,16 @@
-- name: Handle Besu, Geth, Erigon, Nethermind enode
+- name: Handle Besu, Geth, Erigon, Nethermind, Reth, NimbusEL, ethrex enode
   when: ethereum_node_el in ["besu", "geth", "erigon", "nethermind", "reth", "nimbusel", "ethrex"]
   block:
+    - name: Assert ethrex network subdirectory is defined
+      when: ethereum_node_el == "ethrex"
+      ansible.builtin.assert:
+        that:
+          - ethereum_node_fact_discovery_ethrex_chain_subdir | length > 0
+        fail_msg: >-
+          ethrex fact discovery requires ethereum_network_name to be one of
+          {{ ethereum_node_fact_discovery_ethrex_network_names | join(', ') }},
+          or ethereum_network_id must be set for other networks
+
     - name: Get EL node key
       ansible.builtin.shell: "{{ ethereum_node_fact_discovery_el_key_cmd[ethereum_node_el] }}" # noqa command-instead-of-shell
       register: ethereum_node_fact_discovery_el_nodekey


### PR DESCRIPTION
ethrex namespaces its datadir by chain id for devnets and with named directories for well-known testnets and mainnet. This fix replicates logic from the ethrex source to determine where to find node.key.

I tested this with a branch dependency in our upstream repository, and with a test playbook that asserted the values of `ethereum_node_fact_discovery_ethrex_chain_subdir`, `ethereum_node_fact_discovery_ethrex_chain_dir`, and `ethereum_node_fact_discovery_el_key_cmd.ethrex` were appropriately populated with either the trimmed network name or the network id