### PR TITLE
feat(bootnodoor): optionally upload an IP->name mapping for the web UI

### DIFF
--- a/roles/bootnodoor/defaults/main.yaml
+++ b/roles/bootnodoor/defaults/main.yaml
@@ -28,6 +28,20 @@ bootnodoor_cl_gvr: /data/cl-gvr.txt
 
 bootnodoor_container_stop_timeout: "30"
 bootnodoor_container_networks: []
+
+# Optional IP -> name mapping for the bootnodoor web UI (--ip-names).
+# When enabled, bootnodoor_ip_names_src (a file on the ansible controller,
+# by default the inventory itself) is uploaded to the bootnode and the flag
+# is added to the container command. Bootnodoor auto-detects the format
+# (ansible INI inventory, or a YAML map of IPs/CIDRs to names) and re-reads
+# the file on change, so re-running the role after inventory updates
+# refreshes the names without restarting the container.
+bootnodoor_ip_names_enabled: false
+bootnodoor_ip_names_src: "{{ inventory_file }}"
+bootnodoor_ip_names_host_file: "{{ bootnodoor_datadir }}/inventory.ini"
+bootnodoor_ip_names_container_file: /data/inventory.ini
+bootnodoor_container_command_ip_names_args: >-
+  {{ ['--ip-names=' ~ bootnodoor_ip_names_container_file] if bootnodoor_ip_names_enabled else [] }}
 bootnodoor_container_command_default:
   - --private-key={{ bootnodoor_privkey }}
   - --enr-ip={{ bootnodoor_enr_ip }}
@@ -44,4 +58,4 @@ bootnodoor_container_command_default:
   - --web-port={{ bootnodoor_ui_port }}
 bootnodoor_container_command_extra_args: []
 bootnodoor_container_command: >-
-  {{ bootnodoor_container_command_default + bootnodoor_container_command_extra_args }}
+  {{ bootnodoor_container_command_default + bootnodoor_container_command_ip_names_args + bootnodoor_container_command_extra_args }}

--- a/roles/bootnodoor/tasks/main.yaml
+++ b/roles/bootnodoor/tasks/main.yaml
@@ -1,3 +1,17 @@
+- name: Create dir for IP names file
+  ansible.builtin.file:
+    path: "{{ bootnodoor_ip_names_host_file | dirname }}"
+    state: directory
+    mode: "0755"
+  when: bootnodoor_ip_names_enabled
+
+- name: Upload IP names file for the web UI
+  ansible.builtin.copy:
+    src: "{{ bootnodoor_ip_names_src }}"
+    dest: "{{ bootnodoor_ip_names_host_file }}"
+    mode: "0644"
+  when: bootnodoor_ip_names_enabled
+
 - name: Run bootnodoor container
   community.docker.docker_container:
     name: "{{ bootnodoor_container_name }}"


### PR DESCRIPTION
## Summary

Adds an opt-in step to the `bootnodoor` role that uploads an IP→name mapping file to the bootnode and passes `--ip-names` to the container, so the bootnodoor web UI shows inventory hostnames instead of bare IPs in its node tables.

```yaml
# group_vars — everything else has sensible defaults
bootnodoor_ip_names_enabled: true
```

When enabled, `bootnodoor_ip_names_src` (default: the play's own inventory via `"{{ inventory_file }}"`) is copied to `{{ bootnodoor_datadir }}/inventory.ini` before the container task, and `--ip-names=/data/inventory.ini` is appended to the container command. Bootnodoor parses the `ansible_host=<ip>` entries and uses each host's inventory name as its display name (see ethpandaops/bootnodoor#54); it also accepts a plain YAML map of IPs/CIDRs to names — the format is auto-detected.

Since bootnodoor re-reads the file when it changes, re-running the role after inventory updates refreshes the UI names without restarting the container.

Disabled by default — with `bootnodoor_ip_names_enabled: false` the role behaves exactly as before.

## Dependencies

Requires a bootnodoor image containing ethpandaops/bootnodoor#54 (which is stacked on ethpandaops/bootnodoor#53); on older images the unknown `--ip-names` flag would fail the container, so don't enable the toggle until `ethpandaops/bootnodoor:master` includes it.

## Testing

- `ansible-lint roles/bootnodoor` passes (production profile)
- Jinja command-arg logic verified for both enabled and disabled states