### PR TITLE
feat(generate_kubernetes_config): let a devnet nickname survive regeneration

### DIFF
--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -3,8 +3,10 @@ devnet_name: "template" # noqa var-naming[no-role-prefix]
 primary_bootnode: "bootnode-1" # noqa var-naming[no-role-prefix]
 
 gen_kubernetes_config_default_output_dir: ../kubernetes/{{ ethereum_network_name | replace(devnet_name + "-", '') }} # noqa var-naming[no-role-prefix]
-# Name shown to humans: faucet titles, the dora and forkmon network labels.
-# Used verbatim, so write it exactly as it should be displayed.
+# Name shown to humans: faucet titles, the homepage title and chain name, the
+# dora/forkmon/forky network labels. Used verbatim, so write it exactly as it
+# should be displayed. Host names and identifiers keep using
+# ethereum_network_name.
 gen_kubernetes_config_network_display_name: "{{ ethereum_network_name }}" # noqa var-naming[no-role-prefix]
 
 cl_config_path: ../network-configs/{{ ethereum_network_name | replace(devnet_name + "-", '') }}/metadata/config.yaml # noqa var-naming[no-role-prefix]

--- a/roles/generate_kubernetes_config/defaults/main.yaml
+++ b/roles/generate_kubernetes_config/defaults/main.yaml
@@ -3,6 +3,9 @@ devnet_name: "template" # noqa var-naming[no-role-prefix]
 primary_bootnode: "bootnode-1" # noqa var-naming[no-role-prefix]
 
 gen_kubernetes_config_default_output_dir: ../kubernetes/{{ ethereum_network_name | replace(devnet_name + "-", '') }} # noqa var-naming[no-role-prefix]
+# Name shown to humans: faucet titles, the dora and forkmon network labels.
+# Used verbatim, so write it exactly as it should be displayed.
+gen_kubernetes_config_network_display_name: "{{ ethereum_network_name }}" # noqa var-naming[no-role-prefix]
 
 cl_config_path: ../network-configs/{{ ethereum_network_name | replace(devnet_name + "-", '') }}/metadata/config.yaml # noqa var-naming[no-role-prefix]
 

--- a/roles/generate_kubernetes_config/templates/dora.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/dora.yaml.j2
@@ -31,7 +31,7 @@ dora:
           - path: /
             pathType: Prefix
 
-  name: {{ gen_kubernetes_config_network_display_name }}
+  name: "{{ gen_kubernetes_config_network_display_name }}"
   configPath: "https://config.{{ network_subdomain }}/cl/config.yaml"
   validatorNamesInventory: "https://config.{{ network_subdomain }}/api/v1/nodes/validator-ranges"
   buildoorOverviewUrl: "{{ gen_kubernetes_config_dora_buildoor_overview_url }}"

--- a/roles/generate_kubernetes_config/templates/dora.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/dora.yaml.j2
@@ -31,7 +31,7 @@ dora:
           - path: /
             pathType: Prefix
 
-  name: {{ ethereum_network_name }}
+  name: {{ gen_kubernetes_config_network_display_name }}
   configPath: "https://config.{{ network_subdomain }}/cl/config.yaml"
   validatorNamesInventory: "https://config.{{ network_subdomain }}/api/v1/nodes/validator-ranges"
   buildoorOverviewUrl: "{{ gen_kubernetes_config_dora_buildoor_overview_url }}"

--- a/roles/generate_kubernetes_config/templates/forkmon.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/forkmon.yaml.j2
@@ -23,7 +23,7 @@ forkmon:
         paths:
           - path: /
             pathType: Prefix
-  network: {{ ethereum_network_name }}
+  network: {{ gen_kubernetes_config_network_display_name }}
   endpoints:
 {% for host in (groups['ethereum_node'] + groups['bootnode']) | sort %}
   - addr: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@{{ ethereum_node_rpc_prefix }}{{ hostvars[host]['inventory_hostname'] }}.{{ network_server_subdomain }}

--- a/roles/generate_kubernetes_config/templates/forkmon.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/forkmon.yaml.j2
@@ -23,7 +23,7 @@ forkmon:
         paths:
           - path: /
             pathType: Prefix
-  network: {{ gen_kubernetes_config_network_display_name }}
+  network: "{{ gen_kubernetes_config_network_display_name }}"
   endpoints:
 {% for host in (groups['ethereum_node'] + groups['bootnode']) | sort %}
   - addr: https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@{{ ethereum_node_rpc_prefix }}{{ hostvars[host]['inventory_hostname'] }}.{{ network_server_subdomain }}

--- a/roles/generate_kubernetes_config/templates/forky.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/forky.yaml.j2
@@ -75,7 +75,7 @@ forky:
       indexer: {}
       ethereum:
         network:
-          name: "{{ ethereum_network_name }}"
+          name: "{{ gen_kubernetes_config_network_display_name }}"
           spec:
 {% set forky_cl_spec = lookup('ansible.builtin.file', cl_config_path) | from_yaml %}
             seconds_per_slot: {{ (forky_cl_spec.SLOT_DURATION_MS | int // 1000) if forky_cl_spec.SLOT_DURATION_MS is defined else forky_cl_spec.SECONDS_PER_SLOT }}

--- a/roles/generate_kubernetes_config/templates/powfaucet.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/powfaucet.yaml.j2
@@ -52,7 +52,7 @@ powfaucet:
             pathType: Prefix
   httpProxyCount: 2
 
-  faucetTitle: "{{ ethereum_network_name }} {{ item.value.faucetOverride.titleSuffix | default('PoW Faucet') }}"
+  faucetTitle: "{{ gen_kubernetes_config_network_display_name }} {{ item.value.faucetOverride.titleSuffix | default('PoW Faucet') }}"
   faucetPrivkey: "{{ item.value.faucetOverride.privkeySopsRef | default('<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.' + devnet_name + '-devnets.' + (item.value.faucetOverride.privkeySopsKey | default('faucet_private_key')) + '}>') }}"
   faucetRpcUrl: "https://<path:/secrets/services/services.enc.yaml#ethereum | jsonPath {.testnets.{{ devnet_name }}-devnets.node_ingress.combined}>@{{ ethereum_node_rpc_prefix }}{{ primary_bootnode }}.{{ network_server_subdomain }}"
 {# Multi-RPC endpoint list. If the operator set gen_kubernetes_config_powfaucet_rpc_endpoints, that wins.

--- a/roles/generate_kubernetes_config/templates/testnet-homepage.yaml.j2
+++ b/roles/generate_kubernetes_config/templates/testnet-homepage.yaml.j2
@@ -87,7 +87,7 @@ testnet-homepage:
   config:
     baseURL: https://{{ network_subdomain }}
     languageCode: en-us
-    title: {{ ethereum_network_name }}
+    title: "{{ gen_kubernetes_config_network_display_name }}"
     theme: PaperMod
     markup:
       highlight:
@@ -110,7 +110,7 @@ testnet-homepage:
         blobscanUrl: https://blobscan.com
         blobscanethpandaUrl: https://blobscan.{{ network_subdomain }}
         ethstatsUrl: https://ethstats.{{ network_subdomain }}
-        chainName: "{{ ethereum_network_name }}"
+        chainName: "{{ gen_kubernetes_config_network_display_name }}"
         chainId: "{{ ethereum_genesis_chain_id }}"
         github: https://github.com/ethpandaops/{{ devnet_name }}-devnets/tree/master/network-configs/{{ ethereum_network_name  | replace(devnet_name + "-", '')}}/metadata
         syncoorUrl: https://syncoor.{{ network_subdomain }}


### PR DESCRIPTION
## Problem

A network that goes by a nickname has no way to say so. The faucet titles and the dora/forkmon network labels all render from `ethereum_network_name`, so the only way to show a nickname is to edit the generated values by hand — and the next run of this role reverts them without a word.

`glamsterdam-devnet-8` has exactly that today: "Plataberget" hand-written into four generated files (ethpandaops/glamsterdam-devnets@3502cc6), with nothing in the inventory behind it.

## Change

`gen_kubernetes_config_network_display_name`, defaulting to `ethereum_network_name`, used verbatim at the three display sites (`faucetTitle`, dora `name`, forkmon `network`). Every network that sets nothing renders exactly as it does today.

The identifiers that must stay exact are deliberately untouched and still come from `ethereum_network_name`: dora's `tracoorNetwork` and its validator-names `path`.

## Verification

Regenerated `glamsterdam-devnet-8` with `gen_kubernetes_config_network_display_name: Plataberget` in the inventory:

- `faucet` and `faucet-agents` — byte-identical to what is committed, i.e. the hand-edited titles survive
- `dora` and `forkmon` — identical except the label now reads `Plataberget` rather than the hand-written lowercase `plataberget`, since the value is used as written. Both are free-form labels (the dora chart defaults `name` to `mainnet`, forkmon defaults `network` to `""`, and neither is referenced as an identifier by the chart templates). Happy to lowercase those two sites if the explorer should keep the slug form.
- `ansible-lint` clean on the production profile

## Merge order

Worth landing together with #579: that one fixes the agent faucet's missing auth secret, and applying it means regenerating the devnet repo, which is exactly when the hand-edited titles would otherwise disappear.